### PR TITLE
Add default config and handle invalid configs

### DIFF
--- a/lib/erb_lint/linters/deprecated_classes.rb
+++ b/lib/erb_lint/linters/deprecated_classes.rb
@@ -8,17 +8,21 @@ module ERBLint
 
       def initialize(config)
         @deprecated_ruleset = []
-        config['rule_set'].each do |rule|
-          rule['deprecated'].each do |class_expr|
-            @deprecated_ruleset.push(
-              class_expr: class_expr,
-              suggestion: rule['suggestion']
-            )
+        unless config['rule_set'].nil?
+          config['rule_set'].each do |rule|
+            break if rule['deprecated'].nil?
+            suggestion = pad_with_left_space(rule['suggestion'])
+            rule['deprecated'].each do |class_expr|
+              @deprecated_ruleset.push(
+                class_expr: class_expr,
+                suggestion: suggestion
+              )
+            end
           end
         end
         @deprecated_ruleset.freeze
 
-        @addendum = config['addendum']
+        @addendum = pad_with_left_space(config['addendum'])
       end
 
       protected
@@ -43,7 +47,7 @@ module ERBLint
 
       def generate_errors(class_name, line_number)
         violated_rules(class_name).map do |violated_rule|
-          message = "Deprecated class `%s` detected matching the pattern `%s`. %s#{' ' + @addendum if @addendum}"
+          message = "Deprecated class `%s` detected matching the pattern `%s`.%s#{@addendum}"
           {
             line: line_number,
             message: format(message, class_name, violated_rule[:class_expr], violated_rule[:suggestion])
@@ -55,6 +59,10 @@ module ERBLint
         @deprecated_ruleset.select do |deprecated_rule|
           /\A#{deprecated_rule[:class_expr]}\z/.match(class_name)
         end
+      end
+
+      def pad_with_left_space(message)
+        message ? " #{message}" : ''
       end
     end
 

--- a/lib/erb_lint/linters/deprecated_classes.rb
+++ b/lib/erb_lint/linters/deprecated_classes.rb
@@ -61,7 +61,7 @@ module ERBLint
       end
 
       def pad_with_left_space(message)
-        message ? " #{message}" : ''
+        message.empty? ? message : " #{message}"
       end
     end
 

--- a/lib/erb_lint/linters/deprecated_classes.rb
+++ b/lib/erb_lint/linters/deprecated_classes.rb
@@ -8,21 +8,18 @@ module ERBLint
 
       def initialize(config)
         @deprecated_ruleset = []
-        unless config['rule_set'].nil?
-          config['rule_set'].each do |rule|
-            break if rule['deprecated'].nil?
-            suggestion = pad_with_left_space(rule['suggestion'])
-            rule['deprecated'].each do |class_expr|
-              @deprecated_ruleset.push(
-                class_expr: class_expr,
-                suggestion: suggestion
-              )
-            end
+        config.fetch('rule_set', []).each do |rule|
+          suggestion = rule.fetch('suggestion', '')
+          rule.fetch('deprecated', []).each do |class_expr|
+            @deprecated_ruleset.push(
+              class_expr: class_expr,
+              suggestion: suggestion
+            )
           end
         end
         @deprecated_ruleset.freeze
 
-        @addendum = pad_with_left_space(config['addendum'])
+        @addendum = config.fetch('addendum', '')
       end
 
       protected
@@ -47,10 +44,12 @@ module ERBLint
 
       def generate_errors(class_name, line_number)
         violated_rules(class_name).map do |violated_rule|
-          message = "Deprecated class `%s` detected matching the pattern `%s`.%s#{@addendum}"
+          suggestion = pad_with_left_space(violated_rule[:suggestion])
+          addendum = pad_with_left_space(@addendum)
+          message = "Deprecated class `%s` detected matching the pattern `%s`.%s#{addendum}"
           {
             line: line_number,
-            message: format(message, class_name, violated_rule[:class_expr], violated_rule[:suggestion])
+            message: format(message, class_name, violated_rule[:class_expr], suggestion)
           }
         end
       end

--- a/lib/erb_lint/linters/deprecated_classes.rb
+++ b/lib/erb_lint/linters/deprecated_classes.rb
@@ -44,9 +44,8 @@ module ERBLint
 
       def generate_errors(class_name, line_number)
         violated_rules(class_name).map do |violated_rule|
-          suggestion = pad_with_left_space(violated_rule[:suggestion])
-          addendum = pad_with_left_space(@addendum)
-          message = "Deprecated class `%s` detected matching the pattern `%s`.%s#{addendum}"
+          suggestion = " #{violated_rule[:suggestion]}".rstrip
+          message = "Deprecated class `%s` detected matching the pattern `%s`.%s #{@addendum}".strip
           {
             line: line_number,
             message: format(message, class_name, violated_rule[:class_expr], suggestion)
@@ -58,10 +57,6 @@ module ERBLint
         @deprecated_ruleset.select do |deprecated_rule|
           /\A#{deprecated_rule[:class_expr]}\z/.match(class_name)
         end
-      end
-
-      def pad_with_left_space(message)
-        message.empty? ? message : " #{message}"
       end
     end
 

--- a/lib/erb_lint/runner.rb
+++ b/lib/erb_lint/runner.rb
@@ -3,12 +3,8 @@
 module ERBLint
   # Runs all enabled linters against an html.erb file.
   class Runner
-    def initialize(config)
-      @config = if config.nil? || config['linters'].nil?
-                  default_config
-                else
-                  config
-                end
+    def initialize(config = {})
+      @config = default_config.merge(config)
 
       LinterRegistry.load_custom_linters
       @linters = LinterRegistry.linters.select { |linter| linter_enabled?(linter) }

--- a/lib/erb_lint/runner.rb
+++ b/lib/erb_lint/runner.rb
@@ -4,7 +4,12 @@ module ERBLint
   # Runs all enabled linters against an html.erb file.
   class Runner
     def initialize(config)
-      @config = config
+      @config = if config.nil? || config['linters'].nil?
+                  default_config
+                else
+                  config
+                end
+
       LinterRegistry.load_custom_linters
       @linters = LinterRegistry.linters.select { |linter| linter_enabled?(linter) }
       @linters.map! do |linter_class|
@@ -29,6 +34,16 @@ module ERBLint
       linter_class_found = linter_classes[linter_class.simple_name]
       return false if linter_class_found.nil?
       linter_class_found['enabled'] || false
+    end
+
+    def default_config
+      {
+        'linters' => {
+          'FinalNewline' => {
+            'enabled' => true
+          }
+        }
+      }
     end
   end
 end

--- a/lib/erb_lint/runner.rb
+++ b/lib/erb_lint/runner.rb
@@ -4,7 +4,7 @@ module ERBLint
   # Runs all enabled linters against an html.erb file.
   class Runner
     def initialize(config = {})
-      @config = default_config.merge(config)
+      @config = default_config.merge(config || {})
 
       LinterRegistry.load_custom_linters
       @linters = LinterRegistry.linters.select { |linter| linter_enabled?(linter) }

--- a/spec/erb_lint/runner_spec.rb
+++ b/spec/erb_lint/runner_spec.rb
@@ -8,7 +8,8 @@ describe ERBLint::Runner do
   before do
     allow(ERBLint::LinterRegistry).to receive(:linters)
       .and_return([ERBLint::Linter::FakeLinter1,
-                   ERBLint::Linter::FakeLinter2])
+                   ERBLint::Linter::FakeLinter2,
+                   ERBLint::Linter::FinalNewline])
   end
 
   module ERBLint
@@ -28,12 +29,15 @@ describe ERBLint::Runner do
 
     fake_linter_1_errors = ['FakeLinter1DummyErrors']
     fake_linter_2_errors = ['FakeLinter2DummyErrors']
+    fake_final_newline_errors = ['FakeFinalNewlineDummyErrors']
 
     before do
       allow_any_instance_of(ERBLint::Linter::FakeLinter1).to receive(:lint_file)
         .with(file).and_return fake_linter_1_errors
       allow_any_instance_of(ERBLint::Linter::FakeLinter2).to receive(:lint_file)
         .with(file).and_return fake_linter_2_errors
+      allow_any_instance_of(ERBLint::Linter::FinalNewline).to receive(:lint_file)
+        .with(file).and_return fake_final_newline_errors
     end
 
     context 'when all linters are enabled' do
@@ -92,6 +96,32 @@ describe ERBLint::Runner do
 
       it 'returns no linters' do
         expect(subject).to be_empty
+      end
+    end
+
+    context 'when the config has no linters' do
+      let(:config) { {} }
+
+      it 'returns default linters with their errors' do
+        expect(subject).to eq [
+          {
+            linter_name: 'FinalNewline',
+            errors: fake_final_newline_errors
+          }
+        ]
+      end
+    end
+
+    context 'when the config is nil' do
+      let(:config) { nil }
+
+      it 'returns default linters with their errors' do
+        expect(subject).to eq [
+          {
+            linter_name: 'FinalNewline',
+            errors: fake_final_newline_errors
+          }
+        ]
       end
     end
   end


### PR DESCRIPTION
This PR prevents the `Runner` from 💥  when the config hash is `nil` or doesn't contain `linters`.
 - The runner will now default to a `default_config` which enables `FinalNewline`.
 - `DeprecatedClasses` has also been improved to gracefully run with no `rule_set`, `deprecated` array, and `suggestion` message.

@volmer 