### PR TITLE
Fix O(2^n) runtime hang when trying to parse attributes

### DIFF
--- a/lib/erb_lint/linters/deprecated_classes.rb
+++ b/lib/erb_lint/linters/deprecated_classes.rb
@@ -94,8 +94,10 @@ module ERBLint
       START_TAG_PATTERN = %r{
         <(#{TAG_NAME_PATTERN})         # start of tag with tag name
         (
-          \s+                          # required whitespace between tag name and attributes
-          (#{ATTRIBUTE_PATTERN}\s*)*   # attributes
+          (
+            \s+                        # required whitespace between tag name and first attribute and between attributes
+            #{ATTRIBUTE_PATTERN}       # attributes
+          )*
         )?                             # having an attribute block is optional
         \/?>                           # void or foreign elements can have a slash before tag close
       }x

--- a/spec/erb_lint/linters/deprecated_classes_spec.rb
+++ b/spec/erb_lint/linters/deprecated_classes_spec.rb
@@ -210,5 +210,15 @@ describe ERBLint::Linter::DeprecatedClasses do
         end
       end
     end
+
+    context 'when invalid attributes have really long names' do
+      let(:file) { <<~FILE }
+        <div superlongpotentialattributename"small">
+      FILE
+
+      it 'does not report any errors' do
+        expect(linter_errors).to eq []
+      end
+    end
   end
 end


### PR DESCRIPTION
#### Bug
Fixes a bug where the line
```erb
<div class="color-block__swatch color-block__swatch--<%= color_str %> <%= "color-block__swatch--light-text" if i >= white_text_start_index %>">
```
would cause an "infinite" stall when trying to parse attributes from the start tag.

#### Diagnosis
Notice that there are `"` double quotes in an ERB block within the `class` attribute value.

This causes the `class` attribute to be parsed as `class="color-block__swatch color-block__swatch--<%= color_str %> <%= "`. This is essentially just `class="foo1"` for simplicity.

The rest of the string to be parsed for the remaining attributes is now: `color-block__swatch--light-text" if i >= white_text_start_index %>">`. This is essentially just `areallylongattributename"foo2"`.

This is where the pattern matcher's performance drops drastically as it will try to parse 2^n possible arrangements of empty attributes (attributes with no value like `<button disabled></button>`) with no need for spacing between them.

Illustration: `color-block__swatch--light-text` can be `['c','o','l','o','r','-',...]` or `['co','l','o','r','-',...]` etc.

There are 2^n such arrangements where n is the length of the potential attributes string before an instance of a non-attribute-name char such as `"` or `=`.

In this case, n is `"color-block__swatch--light-text".length = 31` and so the search through over 2 billion (2^31) arrangements caused the hang time to be practically "infinite".

#### Fix

**Require spacing between attributes.**
 - This prevents a potential attribute string with no spaces inside to be searched as multiple potential attribute strings appended together; the entire string will just be checked as 1 potential attribute.
 - This also aligns with the HTML5 spec that attributes require spacing between them. https://www.w3.org/TR/html5/syntax.html#syntax-attributes

I've added a test case for this although it won't be necessary once the parsing logic is delegated to a `Nokogiri::XML` parser instead.

**For review:**
@volmer @dfmcphee 