### PR TITLE
Nokogiri HTML refactor

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,4 @@ Style/IndentHash:
 
 Style/RegexpLiteral:
   EnforcedStyle: mixed
-  AllowInnerSlashes: true
 
-Style/PerlBackrefs:
-  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,3 +15,7 @@ Style/IndentHash:
 
 Style/RegexpLiteral:
   EnforcedStyle: mixed
+  AllowInnerSlashes: true
+
+Style/PerlBackrefs:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,6 @@ Style/IndentHash:
 Style/RegexpLiteral:
   EnforcedStyle: mixed
 
+Metrics/ModuleLength:
+  CountComments: false
+  Max: 120

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.3.0
+  - 2.3.1
 script:
   - bundle exec rspec spec
   - bundle exec rubocop

--- a/erb_lint.gemspec
+++ b/erb_lint.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir['lib/**/*.rb']
 
+  s.add_dependency 'nokogiri'
+  s.add_dependency 'htmlentities'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'
 end

--- a/lib/erb_lint.rb
+++ b/lib/erb_lint.rb
@@ -2,6 +2,7 @@
 
 require 'erb_lint/linter_registry'
 require 'erb_lint/linter'
+require 'erb_lint/parser'
 require 'erb_lint/runner'
 
 # Load linters

--- a/lib/erb_lint/linter.rb
+++ b/lib/erb_lint/linter.rb
@@ -24,16 +24,9 @@ module ERBLint
       raise NotImplementedError, "must implement ##{__method__}"
     end
 
-    def lint_file(file_content)
-      lines = file_content.scan(/[^\n]*\n|[^\n]+/)
-      lint_lines(lines)
-    end
-
-    protected
-
-    # The lint_lines method that contains the logic for the linter and returns a list of errors.
+    # The lint_file method that contains the logic for the linter and returns a list of errors.
     # Must be implemented by the concrete inheriting class.
-    def lint_lines(_lines)
+    def lint_file(_file_tree)
       raise NotImplementedError, "must implement ##{__method__}"
     end
   end

--- a/lib/erb_lint/linters/deprecated_classes.rb
+++ b/lib/erb_lint/linters/deprecated_classes.rb
@@ -25,10 +25,10 @@ module ERBLint
       def lint_file(file_tree)
         errors = []
 
-        html_elements = Parser.filter_erb_nodes(file_tree)
+        html_elements = Parser.filter_erb_nodes(file_tree.search('*'))
         html_elements.each do |html_element|
           html_element.attribute_nodes.select { |attribute| attribute.name.casecmp('class') == 0 }.each do |class_attr|
-            remove_escaped_erb_tags(class_attr.value).split(' ').each do |class_name|
+            Parser.remove_escaped_erb_tags(class_attr.value).split(' ').each do |class_name|
               errors.push(*generate_errors(html_element, class_name, line_number: class_attr.line))
             end
           end
@@ -37,10 +37,6 @@ module ERBLint
       end
 
       private
-
-      def remove_escaped_erb_tags(string)
-        string.gsub(/_erb_.*?_\/erb_/, '')
-      end
 
       def generate_errors(element, class_name, line_number:)
         violated_rules(class_name).map do |violated_rule|

--- a/lib/erb_lint/linters/deprecated_classes.rb
+++ b/lib/erb_lint/linters/deprecated_classes.rb
@@ -25,10 +25,10 @@ module ERBLint
       def lint_file(file_tree)
         errors = []
 
-        html_elements = file_tree.search('*').select { |element| element.name != 'erb' }
+        html_elements = Parser.filter_erb_nodes(file_tree)
         html_elements.each do |html_element|
           html_element.attribute_nodes.select { |attribute| attribute.name.casecmp('class') == 0 }.each do |class_attr|
-            Parser.remove_escaped_erb_tags(class_attr.value).split(' ').each do |class_name|
+            remove_escaped_erb_tags(class_attr.value).split(' ').each do |class_name|
               errors.push(*generate_errors(html_element, class_name, line_number: class_attr.line))
             end
           end
@@ -37,6 +37,10 @@ module ERBLint
       end
 
       private
+
+      def remove_escaped_erb_tags(string)
+        string.gsub(/_erb_.*?_\/erb_/, '')
+      end
 
       def generate_errors(element, class_name, line_number:)
         violated_rules(class_name).map do |violated_rule|

--- a/lib/erb_lint/linters/deprecated_classes.rb
+++ b/lib/erb_lint/linters/deprecated_classes.rb
@@ -27,7 +27,7 @@ module ERBLint
 
         html_elements = file_tree.search('*').select { |element| element.name != 'erb' }
         html_elements.each do |html_element|
-          html_element.attribute_nodes.select { |attribute| attribute.name.downcase == "class" }.each do |class_attr|
+          html_element.attribute_nodes.select { |attribute| attribute.name.casecmp('class') == 0 }.each do |class_attr|
             Parser.remove_escaped_erb_tags(class_attr.value).split(' ').each do |class_name|
               errors.push(*generate_errors(html_element, class_name, line_number: class_attr.line))
             end
@@ -41,7 +41,8 @@ module ERBLint
       def generate_errors(element, class_name, line_number:)
         violated_rules(class_name).map do |violated_rule|
           suggestion = " #{violated_rule[:suggestion]}".rstrip
-          message = "Deprecated class `%s` detected matching the pattern `%s` on the surrounding `%s` element.%s #{@addendum}".strip
+          message = 'Deprecated class `%s` detected matching the pattern `%s` on the surrounding `%s` element.'\
+            "%s #{@addendum}".strip
           {
             line: line_number,
             message: format(message, class_name, violated_rule[:class_expr], element.name, suggestion)

--- a/lib/erb_lint/linters/deprecated_classes.rb
+++ b/lib/erb_lint/linters/deprecated_classes.rb
@@ -22,18 +22,14 @@ module ERBLint
         @addendum = config.fetch('addendum', '')
       end
 
-      protected
-
-      def lint_lines(lines)
+      def lint_file(file_tree)
         errors = []
 
-        lines.each_with_index do |line, index|
-          start_tags = StartTagHelper.start_tags(line)
-          start_tags.each do |start_tag|
-            start_tag.attributes.select(&:class?).each do |class_attr|
-              class_attr.value.split(' ').each do |class_name|
-                errors.push(*generate_errors(class_name, index + 1))
-              end
+        html_elements = file_tree.search('*').select { |element| element.name != 'erb' }
+        html_elements.each do |html_element|
+          html_element.attribute_nodes.select { |attribute| attribute.name.downcase == "class" }.each do |class_attr|
+            Parser.remove_escaped_erb_tags(class_attr.value).split(' ').each do |class_name|
+              errors.push(*generate_errors(html_element, class_name, line_number: class_attr.line))
             end
           end
         end
@@ -42,13 +38,13 @@ module ERBLint
 
       private
 
-      def generate_errors(class_name, line_number)
+      def generate_errors(element, class_name, line_number:)
         violated_rules(class_name).map do |violated_rule|
           suggestion = " #{violated_rule[:suggestion]}".rstrip
-          message = "Deprecated class `%s` detected matching the pattern `%s`.%s #{@addendum}".strip
+          message = "Deprecated class `%s` detected matching the pattern `%s` on the surrounding `%s` element.%s #{@addendum}".strip
           {
             line: line_number,
-            message: format(message, class_name, violated_rule[:class_expr], suggestion)
+            message: format(message, class_name, violated_rule[:class_expr], element.name, suggestion)
           }
         end
       end
@@ -56,110 +52,6 @@ module ERBLint
       def violated_rules(class_name)
         @deprecated_ruleset.select do |deprecated_rule|
           /\A#{deprecated_rule[:class_expr]}\z/.match(class_name)
-        end
-      end
-    end
-
-    # Provides methods and classes for finding HTML start tags and their attributes.
-    module StartTagHelper
-      # These patterns cover a superset of the W3 HTML5 specification.
-      # Additional cases not included in the spec include those that are still rendered by some browsers.
-
-      # Attribute Patterns
-      # https://www.w3.org/TR/html5/syntax.html#syntax-attributes
-
-      # attribute names must be non empty and can't contain a certain set of special characters
-      ATTRIBUTE_NAME_PATTERN = %r{[^\s"'>\/=]+}
-
-      ATTRIBUTE_VALUE_PATTERN = %r{
-        "([^"]*)" |           # double-quoted value
-        '([^']*)' |           # single-quoted value
-        ([^\s"'=<>`]+)        # unquoted non-empty value without special characters
-      }x
-
-      # attributes can be empty or have an attribute value
-      ATTRIBUTE_PATTERN = %r{
-        #{ATTRIBUTE_NAME_PATTERN}        # attribute name
-        (
-          \s*=\s*                        # any whitespace around equals sign
-          (#{ATTRIBUTE_VALUE_PATTERN})   # attribute value
-        )?                               # attributes can be empty or have an assignemnt.
-      }x
-
-      # Start tag Patterns
-      # https://www.w3.org/TR/html5/syntax.html#syntax-start-tag
-
-      TAG_NAME_PATTERN = /[A-Za-z0-9]+/ # maybe add _ < ? etc later since it gets interpreted by some browsers
-
-      START_TAG_PATTERN = %r{
-        <(#{TAG_NAME_PATTERN})         # start of tag with tag name
-        (
-          (
-            \s+                        # required whitespace between tag name and first attribute and between attributes
-            #{ATTRIBUTE_PATTERN}       # attributes
-          )*
-        )?                             # having an attribute block is optional
-        \/?>                           # void or foreign elements can have a slash before tag close
-      }x
-
-      # Represents and provides an interface for a start tag found in the HTML.
-      class StartTag
-        attr_accessor :tag_name, :attributes
-
-        def initialize(tag_name, attributes)
-          @tag_name = tag_name
-          @attributes = attributes
-        end
-      end
-
-      # Represents and provides an interface for an attribute found in a start tag in the HTML.
-      class Attribute
-        ATTR_NAME_CLASS_PATTERN = /\Aclass\z/i # attribute names are case-insensitive
-        attr_accessor :attribute_name, :value
-
-        def initialize(attribute_name, value)
-          @attribute_name = attribute_name
-          @value = value
-        end
-
-        def class?
-          ATTR_NAME_CLASS_PATTERN.match(@attribute_name)
-        end
-      end
-
-      class << self
-        def start_tags(line)
-          # TODO: Implement String Scanner to track quotes before the start tag begins to ensure that it is
-          #       not enclosed inside of a string. Alternatively this problem would be solved by using
-          #       a 3rd party parser like Nokogiri::XML
-
-          start_tag_matching_groups = line.scan(/(#{START_TAG_PATTERN})/)
-          start_tag_matching_groups.map do |start_tag_matching_group|
-            tag_name = start_tag_matching_group[1]
-
-            # attributes_string can be nil if there is no space after the tag name (and therefore no attributes).
-            attributes_string = start_tag_matching_group[2] || ''
-
-            attribute_list = attributes(attributes_string)
-
-            StartTag.new(tag_name, attribute_list)
-          end
-        end
-
-        private
-
-        def attributes(attributes_string)
-          attributes_string.scan(/(#{ATTRIBUTE_PATTERN})/).map do |attribute_matching_group|
-            entire_string = attribute_matching_group[0]
-            value_with_equal_sign = attribute_matching_group[1] || '' # This can be nil if attribute is empty
-            name = entire_string.sub(value_with_equal_sign, '')
-
-            # The 3 captures [3..5] are the possibilities specified in ATTRIBUTE_VALUE_PATTERN
-            possible_value_formats = attribute_matching_group[3..5]
-            value = possible_value_formats.reduce { |a, e| a.nil? ? e : a }
-
-            Attribute.new(name, value)
-          end
         end
       end
     end

--- a/lib/erb_lint/linters/final_newline.rb
+++ b/lib/erb_lint/linters/final_newline.rb
@@ -10,22 +10,22 @@ module ERBLint
         @new_lines_should_be_present = config['present'].nil? ? true : config['present']
       end
 
-      protected
-
-      def lint_lines(lines)
+      def lint_file(file_tree)
         errors = []
-        return errors if lines.empty?
+        return errors if file_tree.children.size == 1
 
-        ends_with_newline = lines.last.chars[-1] == "\n"
+        end_marker = file_tree.search(Parser::END_MARKER_NAME).first
+        last_child = end_marker.previous_sibling
+        ends_with_newline = last_child.text? && last_child.text.chars[-1] == "\n"
 
         if @new_lines_should_be_present && !ends_with_newline
           errors.push(
-            line: lines.length,
+            line: end_marker.line,
             message: 'Missing a trailing newline at the end of the file.'
           )
         elsif !@new_lines_should_be_present && ends_with_newline
           errors.push(
-            line: lines.length,
+            line: end_marker.line - 1,
             message: 'Remove the trailing newline at the end of the file.'
           )
         end

--- a/lib/erb_lint/parser.rb
+++ b/lib/erb_lint/parser.rb
@@ -72,8 +72,8 @@ module ERBLint
       end
 
       def escape_erb_tag_literals(file_content)
-        file_content.gsub(/(<%%|%%>)/) do |_match|
-          HTMLEntities.new.encode($1)
+        file_content.gsub(/(<%%|%%>)/) do |tag_literal|
+          HTMLEntities.new.encode(tag_literal)
         end
       end
 

--- a/lib/erb_lint/parser.rb
+++ b/lib/erb_lint/parser.rb
@@ -5,7 +5,6 @@ require 'securerandom'
 
 module ERBLint
   # Contains the logic for generating the file tree structure used by linters.
-  # rubocop:disable Metrics/ModuleLength
   module Parser
     END_MARKER_NAME = 'erb_lint_end_marker'
 
@@ -48,7 +47,6 @@ module ERBLint
 
       private
 
-      # rubocop:disable Metrics/AbcSize
       def escape_erb_tags(file_content, seed)
         scanner = StringScanner.new(file_content)
 
@@ -73,12 +71,13 @@ module ERBLint
           scanner = StringScanner.new(file_content)
           scanner.pos = new_scanner_pos
         end
+        file_content_encoded_erb_tag_literals(file_content)
+      end
 
+      def file_content_encoded_erb_tag_literals(file_content)
         file_content = encode_erb_tag_literals(file_content)
-
         file_content
       end
-      # rubocop:enable Metrics/AbcSize
 
       def find_end_tag_index(file:, scanner:)
         end_tag_not_found = true
@@ -108,9 +107,8 @@ module ERBLint
         )
 
         new_end_index = start_index + escaped_tag.length
-        # rubocop:disable Style/RedundantReturn
-        return file, new_end_index
-        # rubocop:enable Style/RedundantReturn
+
+        [file, new_end_index]
       end
 
       def replace_tag_in_file(file:, start_index:, end_index:, content:)
@@ -160,5 +158,4 @@ module ERBLint
     class ParseError < StandardError
     end
   end
-  # rubocop:enable Metrics/ModuleLength
 end

--- a/lib/erb_lint/parser.rb
+++ b/lib/erb_lint/parser.rb
@@ -10,10 +10,12 @@ module ERBLint
         require 'nokogiri'
         require 'htmlentities'
 
-        file_content = file_content + "<#{END_MARKER_NAME}>This is used to calculate the line number of the last line</#{END_MARKER_NAME}>"
+        file_content += "<#{END_MARKER_NAME}>"\
+          'This is used to calculate the line number of the last line'\
+          "</#{END_MARKER_NAME}>"
 
-        file_content_with_erb_tags = file_content.gsub(/<%(.+?)%>/m) do |_match| 
-          "<erb>#{ HTMLEntities.new.encode($1) }</erb>"
+        file_content_with_erb_tags = file_content.gsub(/<%(.+?)%>/m) do |_match|
+          "<erb>#{HTMLEntities.new.encode($1)}</erb>"
         end
 
         file_content_with_erb_tags = escape_erb_tags_in_strings(file_content_with_erb_tags)
@@ -50,7 +52,6 @@ module ERBLint
               '_erb_'
             when '</erb>'
               '_/erb_'
-            else
             end
           end
 
@@ -61,7 +62,7 @@ module ERBLint
       end
 
       def validate_tree(file_tree)
-        if file_tree.children.size == 0 || file_tree.children.last.name != END_MARKER_NAME
+        if file_tree.children.empty? || file_tree.children.last.name != END_MARKER_NAME
           raise ParsingError, 'File could not be successfully parsed. Ensure all tags are properly closed.'
         end
       end

--- a/lib/erb_lint/parser.rb
+++ b/lib/erb_lint/parser.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module ERBLint
+  # Contains the logic for generating the file tree structure used by linters.
+  module Parser
+    END_MARKER_NAME = 'erb_lint_end_marker'
+
+    class << self
+      def parse(file_content)
+        require 'nokogiri'
+        require 'htmlentities'
+
+        file_content = file_content + "<#{END_MARKER_NAME}>This is used to calculate the line number of the last line</#{END_MARKER_NAME}>"
+
+        file_content_with_erb_tags = file_content.gsub(/<%(.+?)%>/m) do |_match| 
+          "<erb>#{ HTMLEntities.new.encode($1) }</erb>"
+        end
+
+        file_content_with_erb_tags = escape_erb_tags_in_strings(file_content_with_erb_tags)
+
+        file_tree = Nokogiri::XML.fragment(file_content_with_erb_tags)
+        validate_tree(file_tree)
+
+        file_tree
+      end
+
+      def remove_escaped_erb_tags(string)
+        string.gsub(/_erb_.*?_\/erb_/, '')
+      end
+
+      private
+
+      def escape_erb_tags_in_strings(file_content)
+        scanner = StringScanner.new(file_content)
+
+        while scanner.skip_until(/'|"/)
+          open_string_type = scanner.matched
+
+          string_start = scanner.pos - 1
+          if scanner.skip_until(/#{open_string_type}/).nil?
+            raise ParsingError, 'Unclosed string found.'
+          end
+          string_end = scanner.pos - 1
+
+          string_content = file_content.byteslice(string_start..string_end)
+
+          string_content_with_erb_tags_escaped = string_content.gsub(/(<erb>|<\/erb>)/m) do |_match|
+            case $1
+            when '<erb>'
+              '_erb_'
+            when '</erb>'
+              '_/erb_'
+            else
+            end
+          end
+
+          file_content[string_start..string_end] = string_content_with_erb_tags_escaped
+        end
+
+        file_content
+      end
+
+      def validate_tree(file_tree)
+        if file_tree.children.size == 0 || file_tree.children.last.name != END_MARKER_NAME
+          raise ParsingError, 'File could not be successfully parsed. Ensure all tags are properly closed.'
+        end
+      end
+    end
+
+    class ParsingError < StandardError
+    end
+  end
+end

--- a/lib/erb_lint/parser.rb
+++ b/lib/erb_lint/parser.rb
@@ -26,10 +26,14 @@ module ERBLint
         file_tree
       end
 
-      def filter_erb_nodes(node)
-        node.search('*').select do |element|
+      def filter_erb_nodes(node_list)
+        node_list.select do |element|
           element.name != 'erb' && element.name != END_MARKER_NAME
         end
+      end
+
+      def remove_escaped_erb_tags(string)
+        string.gsub(/_erb_.*?_\/erb_/, '')
       end
 
       private
@@ -37,11 +41,11 @@ module ERBLint
       def escape_erb_tags_in_strings(file_content)
         scanner = StringScanner.new(file_content)
 
-        while scanner.skip_until(/'|"/)
-          open_string_type = scanner.matched
+        while scanner.skip_until(/([^\\]|\A)('|")/)
+          open_string_type = scanner.matched[-1]
 
           string_start = scanner.pos - 1
-          if scanner.skip_until(/#{open_string_type}/).nil?
+          if scanner.skip_until(/([^\\]|\A)#{open_string_type}/).nil?
             raise ParsingError, 'Unclosed string found.'
           end
           string_end = scanner.pos - 1

--- a/lib/erb_lint/parser.rb
+++ b/lib/erb_lint/parser.rb
@@ -11,9 +11,9 @@ module ERBLint
       def parse(file_content)
         clean_file_content = strip_erb_tags(file_content)
 
-        xml_ready_file_content = add_end_marker(clean_file_content)
+        html_ready_file_content = add_end_marker(clean_file_content)
 
-        file_tree = Nokogiri::XML.fragment(xml_ready_file_content)
+        file_tree = Nokogiri::HTML.fragment(html_ready_file_content)
 
         ensure_valid_tree(file_tree)
 

--- a/lib/erb_lint/parser.rb
+++ b/lib/erb_lint/parser.rb
@@ -26,8 +26,10 @@ module ERBLint
         file_tree
       end
 
-      def remove_escaped_erb_tags(string)
-        string.gsub(/_erb_.*?_\/erb_/, '')
+      def filter_erb_nodes(node)
+        node.search('*').select do |element|
+          element.name != 'erb' && element.name != END_MARKER_NAME
+        end
       end
 
       private

--- a/lib/erb_lint/parser.rb
+++ b/lib/erb_lint/parser.rb
@@ -5,6 +5,7 @@ require 'securerandom'
 
 module ERBLint
   # Contains the logic for generating the file tree structure used by linters.
+  # rubocop:disable Metrics/ModuleLength
   module Parser
     END_MARKER_NAME = 'erb_lint_end_marker'
 
@@ -47,6 +48,7 @@ module ERBLint
 
       private
 
+      # rubocop:disable Metrics/AbcSize
       def escape_erb_tags(file_content, seed)
         scanner = StringScanner.new(file_content)
 
@@ -76,6 +78,7 @@ module ERBLint
 
         file_content
       end
+      # rubocop:enable Metrics/AbcSize
 
       def find_end_tag_index(file:, scanner:)
         end_tag_not_found = true
@@ -93,8 +96,8 @@ module ERBLint
         bare_erb_tag = file.byteslice(start_index..end_index)
 
         escaped_tag = bare_erb_tag
-          .gsub(/<%/, "_erb#{escape_seed}start_")
-          .gsub(/%>/, "_erb#{escape_seed}end_")
+                      .gsub(/<%/, "_erb#{escape_seed}start_")
+                      .gsub(/%>/, "_erb#{escape_seed}end_")
         escaped_encoded_tag = HTMLEntities.new.encode(escaped_tag)
 
         file = replace_tag_in_file(
@@ -105,13 +108,14 @@ module ERBLint
         )
 
         new_end_index = start_index + escaped_tag.length
-
+        # rubocop:disable Style/RedundantReturn
         return file, new_end_index
+        # rubocop:enable Style/RedundantReturn
       end
 
       def replace_tag_in_file(file:, start_index:, end_index:, content:)
         left_boundary = start_index - 1
-        preceding_content = left_boundary < 0 ? '' : file[0..left_boundary]
+        preceding_content = left_boundary.negative? ? '' : file[0..left_boundary]
 
         right_boundary = end_index + 1
         following_content = right_boundary > file.length - 1 ? '' : file[right_boundary..-1]
@@ -138,8 +142,8 @@ module ERBLint
         text_containers = get_text_nodes(file_tree) + get_attributes(file_tree)
         text_containers.each do |text_container|
           erb_tag_restored_content = text_container.content
-            .gsub(/_erb#{seed}start_/, "<%")
-            .gsub(/_erb#{seed}end_/, "%>")
+                                                   .gsub(/_erb#{seed}start_/, '<%')
+                                                   .gsub(/_erb#{seed}end_/, '%>')
           text_container.content = erb_tag_restored_content
         end
 
@@ -156,4 +160,5 @@ module ERBLint
     class ParseError < StandardError
     end
   end
+  # rubocop:enable Metrics/ModuleLength
 end

--- a/lib/erb_lint/parser.rb
+++ b/lib/erb_lint/parser.rb
@@ -110,11 +110,11 @@ module ERBLint
       end
 
       def replace_tag_in_file(file:, start_index:, end_index:, content:)
-        left_boundary = [0, start_index - 1].max
-        preceding_content = left_boundary == 0 ? '' : file[0..left_boundary]
+        left_boundary = start_index - 1
+        preceding_content = left_boundary < 0 ? '' : file[0..left_boundary]
 
-        right_boundary = [end_index + 1, file.length - 1].min
-        following_content = right_boundary == file.length - 1 ? '' : file[right_boundary..-1]
+        right_boundary = end_index + 1
+        following_content = right_boundary > file.length - 1 ? '' : file[right_boundary..-1]
 
         preceding_content + content + following_content
       end

--- a/lib/erb_lint/runner.rb
+++ b/lib/erb_lint/runner.rb
@@ -15,11 +15,12 @@ module ERBLint
     end
 
     def run(filename, file_content)
+      file_tree = Parser.parse(file)
       linters_for_file = @linters.select { |linter| !linter_excludes_file?(linter, filename) }
       linters_for_file.map do |linter|
         {
           linter_name: linter.class.simple_name,
-          errors: linter.lint_file(file_content)
+          errors: linter.lint_file(file_tree)
         }
       end
     end

--- a/lib/erb_lint/runner.rb
+++ b/lib/erb_lint/runner.rb
@@ -15,7 +15,7 @@ module ERBLint
     end
 
     def run(filename, file_content)
-      file_tree = Parser.parse(file)
+      file_tree = Parser.parse(file_content)
       linters_for_file = @linters.select { |linter| !linter_excludes_file?(linter, filename) }
       linters_for_file.map do |linter|
         {

--- a/spec/erb_lint/linter_spec.rb
+++ b/spec/erb_lint/linter_spec.rb
@@ -13,56 +13,8 @@ describe ERBLint::Linter do
           def initialize(_config)
           end
 
-          protected
-
-          def lint_lines(_lines)
+          def lint_file(_file_tree)
           end
-        end
-      end
-    end
-
-    describe '#lint_file' do
-      after do
-        subject.lint_file(file)
-      end
-
-      context 'when the file is empty' do
-        let(:file) { '' }
-
-        it 'calls lint_lines with an empty list' do
-          expect(subject).to receive(:lint_lines).with([])
-        end
-      end
-
-      context 'when the file does not end with a newline' do
-        let(:file) { <<~FILE.chomp }
-          Line1
-          Line2
-          Line3
-        FILE
-
-        it 'calls lint_lines with the list of lines' do
-          expect(subject).to receive(:lint_lines).with(%W(
-            Line1\n
-            Line2\n
-            Line3
-          ))
-        end
-      end
-
-      context 'when the file ends with a newline' do
-        let(:file) { <<~FILE }
-          Line1
-          Line2
-          Line3
-        FILE
-
-        it 'calls lint_lines with the list of lines' do
-          expect(subject).to receive(:lint_lines).with(%W(
-            Line1\n
-            Line2\n
-            Line3\n
-          ))
         end
       end
     end

--- a/spec/erb_lint/linters/deprecated_classes_spec.rb
+++ b/spec/erb_lint/linters/deprecated_classes_spec.rb
@@ -66,7 +66,7 @@ describe ERBLint::Linter::DeprecatedClasses do
 
     context 'when the file contains no classes from either set' do
       let(:file) { <<~FILE }
-        <div class="unkown">
+        <div class="unknown">
           Content
         </div>
       FILE
@@ -255,17 +255,13 @@ describe ERBLint::Linter::DeprecatedClasses do
 
       context 'when the file contains a class from a deprecated set' do
         let(:file) { <<~FILE }
-          <div cLaSs="#{deprecated_set_1.first}">
+          <div ClAsS="#{deprecated_set_1.first}">
             Content
           </div>
         FILE
 
-        it 'reports 1 error' do
-          expect(linter_errors.size).to eq 1
-        end
-
-        it 'reports an error with its message ending with the suggestion' do
-          expect(linter_errors.first[:message]).to end_with suggestion_1
+        it 'does not report any errors' do
+          expect(linter_errors).to eq []
         end
       end
     end

--- a/spec/erb_lint/linters/deprecated_classes_spec.rb
+++ b/spec/erb_lint/linters/deprecated_classes_spec.rb
@@ -213,7 +213,7 @@ describe ERBLint::Linter::DeprecatedClasses do
 
     context 'when invalid attributes have really long names' do
       let(:file) { <<~FILE }
-        <div superlongpotentialattributename"small">
+        <div superlongpotentialattributename"small"></div>
       FILE
 
       it 'does not report any errors' do
@@ -260,8 +260,12 @@ describe ERBLint::Linter::DeprecatedClasses do
           </div>
         FILE
 
-        it 'does not report any errors' do
-          expect(linter_errors).to eq []
+        it 'reports 1 error' do
+          expect(linter_errors.size).to eq 1
+        end
+
+        it 'reports an error with its message ending with the suggestion' do
+          expect(linter_errors.first[:message]).to end_with suggestion_1
         end
       end
     end

--- a/spec/erb_lint/linters/final_newline_spec.rb
+++ b/spec/erb_lint/linters/final_newline_spec.rb
@@ -7,7 +7,7 @@ describe ERBLint::Linter::FinalNewline do
 
   let(:linter) { described_class.new(linter_config) }
 
-  subject(:linter_errors) { linter.lint_file(file) }
+  subject(:linter_errors) { linter.lint_file(ERBLint::Parser.parse(file)) }
 
   context 'when trailing newline is preferred' do
     let(:present) { true }

--- a/spec/erb_lint/parser_spec.rb
+++ b/spec/erb_lint/parser_spec.rb
@@ -8,7 +8,7 @@ describe ERBLint::Parser do
       let(:file) { '' }
 
       it 'returns a document fragment with only the end marker as a child' do
-        expect(described_class.parse(file).class).to eq Nokogiri::XML::DocumentFragment
+        expect(described_class.parse(file).class).to eq Nokogiri::HTML::DocumentFragment
         expect(described_class.parse(file).children.size).to eq 1
         expect(described_class.parse(file).child.name).to eq ERBLint::Parser::END_MARKER_NAME
       end

--- a/spec/erb_lint/parser_spec.rb
+++ b/spec/erb_lint/parser_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ERBLint::Parser do
+  describe '#remove_escaped_erb_tags' do
+    # Test cases
+    # _erb_ ... _/erb_
+  end
+
+  describe '#parse' do
+    # Test cases
+    # <% %>
+    # <%= %>
+    # <% -%>
+    # <%# %>
+    # '<% %>'
+    # "<% %>"
+    # <% ' ' %>
+    # <% " " %>
+    # " "
+    # " ' "
+    # " ' ' "
+    # " ' ' ' "
+    # ' '
+    # ' " '
+    # ' " " '
+    # ' " " " '
+    # " " "
+    # ' ' '
+    # <div>
+
+    context 'when the file is empty' do
+      let(:file) { '' }
+
+      it 'returns a document fragment with only the end marker as a child' do
+        expect(described_class.parse(file).children.size).to eq 1
+        expect(described_class.parse(file).child.name).to eq ERBLint::Parser::END_MARKER_NAME
+      end
+    end
+
+    context 'when the file is full of edge cases' do
+      let(:file) { <<~'FILE' }
+        <div class='a <%= something if " adwiawd "%> a-b--c'
+             name="foo">
+          <h1>Fleeb</h1>
+        </div>
+        <h3 class="d-e__f__g"><%= section %></h3>
+        <ul class="h-i j-k--<%= color %>">
+          <div class="l-m__n o-p__q--<%= color_str %> <%= "r-s__t--u-v" if i >= something %>">
+          </div>
+        </ul>
+      FILE
+
+      it 'returns a valid tree structure representing the file' do
+        expect(described_class.parse(file).class).to eq Nokogiri::XML::DocumentFragment
+      end
+    end
+  end
+end

--- a/spec/erb_lint/parser_spec.rb
+++ b/spec/erb_lint/parser_spec.rb
@@ -9,33 +9,242 @@ describe ERBLint::Parser do
   end
 
   describe '#parse' do
-    # Test cases
-    # <% %>
-    # <%= %>
-    # <% -%>
-    # <%# %>
-    # '<% %>'
-    # "<% %>"
-    # <% ' ' %>
-    # <% " " %>
-    # " "
-    # " ' "
-    # " ' ' "
-    # " ' ' ' "
-    # ' '
-    # ' " '
-    # ' " " '
-    # ' " " " '
-    # " " "
-    # ' ' '
-    # <div>
-
     context 'when the file is empty' do
       let(:file) { '' }
 
       it 'returns a document fragment with only the end marker as a child' do
         expect(described_class.parse(file).children.size).to eq 1
         expect(described_class.parse(file).child.name).to eq ERBLint::Parser::END_MARKER_NAME
+      end
+    end
+
+    context 'when the file has erb tags' do
+      context 'when the erb tags are code execution tags' do
+        let(:file) { '<% %>' }
+
+        it 'returns a document fragment with an empty erb tag' do
+          expect(described_class.parse(file).children.size).to eq 2
+          expect(described_class.parse(file).child.name).to eq 'erb'
+          expect(described_class.parse(file).child.text).to start_with ' '
+        end
+      end
+
+      context 'when the erb tags are code evaluation tags' do
+        let(:file) { '<%= %>' }
+
+        it 'returns a document fragment with an erb tag beginning with =' do
+          expect(described_class.parse(file).children.size).to eq 2
+          expect(described_class.parse(file).child.name).to eq 'erb'
+          expect(described_class.parse(file).child.text).to start_with '='
+        end
+      end
+
+      context 'when the erb tags trim the following line break' do
+        let(:file) { '<% -%>' }
+
+        it 'returns a document fragment with an erb tag ending with -' do
+          expect(described_class.parse(file).children.size).to eq 2
+          expect(described_class.parse(file).child.name).to eq 'erb'
+          expect(described_class.parse(file).child.text).to end_with '-'
+        end
+      end
+
+      context 'when the erb tags are comment tags' do
+        let(:file) { '<%# %>' }
+
+        it 'returns a document fragment with an erb tag beginning with #' do
+          expect(described_class.parse(file).children.size).to eq 2
+          expect(described_class.parse(file).child.name).to eq 'erb'
+          expect(described_class.parse(file).child.text).to start_with '#'
+        end
+      end
+
+      context 'when the erb tags are inside double quotes' do
+        let(:file) { '"<% %>"' }
+
+        it 'returns a document fragment with escaped erb tags inside a text node' do
+          expect(described_class.parse(file).children.size).to eq 2
+          expect(described_class.parse(file).child.name).to eq 'text'
+          expect(described_class.parse(file).child.text).to eq '"_erb_ _/erb_"'
+        end
+      end
+
+      context 'when the erb tags are inside single quotes' do
+        let(:file) { "'<% %>'" }
+
+        it 'returns a document fragment with escaped erb tags inside a text node' do
+          expect(described_class.parse(file).children.size).to eq 2
+          expect(described_class.parse(file).child.name).to eq 'text'
+          expect(described_class.parse(file).child.text).to eq "'_erb_ _/erb_'"
+        end
+      end
+
+      context 'when the erb tags contain an invalid string with double quotes' do
+        let(:file) { '<% " %>' }
+
+        it 'does not raise an error' do
+          expect{described_class.parse(file)}.to_not raise_error
+        end
+
+        it 'returns a document fragment with the double quote inside the erb tag' do
+          expect(described_class.parse(file).children.size).to eq 2
+          expect(described_class.parse(file).child.name).to eq 'erb'
+          expect(described_class.parse(file).child.text).to eq ' " '
+        end
+      end
+
+      context 'when the erb tags contain an invalid string with single quotes' do
+        let(:file) { "<% ' %>" }
+
+        it 'does not raise an error' do
+          expect{described_class.parse(file)}.to_not raise_error
+        end
+
+        it 'returns a document fragment with the single quote inside the erb tag' do
+          expect(described_class.parse(file).children.size).to eq 2
+          expect(described_class.parse(file).child.name).to eq 'erb'
+          expect(described_class.parse(file).child.text).to eq " ' "
+        end
+      end
+    end
+
+    context 'when the file contains quotes' do
+      context 'when the file has two double quotes' do
+        let(:file) { <<~'FILE' }
+          " "
+        FILE
+
+        it 'does not raise an error' do
+          expect{described_class.parse(file)}.to_not raise_error
+        end
+      end
+
+      context 'when the file has three double quotes' do
+        let(:file) { <<~'FILE' }
+          " " "
+        FILE
+
+        it 'raises an unclosed string error' do
+          expect{described_class.parse(file)}.to raise_error(described_class::ParsingError, 'Unclosed string found.')
+        end
+      end
+
+      context 'when the file has an escaped double quote within double quotes' do
+        let(:file) { <<~'FILE' }
+          " \" "
+        FILE
+
+        it 'does not raise an error' do
+          expect{described_class.parse(file)}.to_not raise_error
+        end
+      end
+
+      context 'when the file has one single quote within double quotes' do
+        let(:file) { <<~'FILE' }
+          " ' "
+        FILE
+
+        it 'does not raise an error' do
+          expect{described_class.parse(file)}.to_not raise_error
+        end
+      end
+
+      context 'when the file has two single quotes within double quotes' do
+        let(:file) { <<~'FILE' }
+          " ' ' "
+        FILE
+
+        it 'does not raise an error' do
+          expect{described_class.parse(file)}.to_not raise_error
+        end
+      end
+
+      context 'when the file has three single quotes within double quotes' do
+        let(:file) { <<~'FILE' }
+          " ' ' ' "
+        FILE
+
+        it 'does not raise an error' do
+          expect{described_class.parse(file)}.to_not raise_error
+        end
+      end
+
+      context 'when the file has two single quotes' do
+        let(:file) { <<~'FILE' }
+          ' '
+        FILE
+
+        it 'does not raise an error' do
+          expect{described_class.parse(file)}.to_not raise_error
+        end
+      end
+
+      context 'when the file has three single quotes' do
+        let(:file) { <<~'FILE' }
+          ' ' '
+        FILE
+
+        it 'raises an unclosed string error' do
+          expect{described_class.parse(file)}.to raise_error(described_class::ParsingError, 'Unclosed string found.')
+        end
+      end
+
+      context 'when the file has an escaped single quote within single quotes' do
+        let(:file) { <<~'FILE' }
+          ' \' '
+        FILE
+
+        it 'does not raise an error' do
+          expect{described_class.parse(file)}.to_not raise_error
+        end
+      end
+
+      context 'when the file has one double quote within single quotes' do
+        let(:file) { <<~'FILE' }
+          ' " '
+        FILE
+
+        it 'does not raise an error' do
+          expect{described_class.parse(file)}.to_not raise_error
+        end
+      end
+
+      context 'when the file has two double quotes within single quotes' do
+        let(:file) { <<~'FILE' }
+          ' " " '
+        FILE
+
+        it 'does not raise an error' do
+          expect{described_class.parse(file)}.to_not raise_error
+        end
+      end
+
+      context 'when the file has three double quotes within single quotes' do
+        let(:file) { <<~'FILE' }
+          ' " " " '
+        FILE
+
+        it 'does not raise an error' do
+          expect{described_class.parse(file)}.to_not raise_error
+        end
+      end
+
+      context 'when the file has overlapping quotes' do
+        let(:file) { <<~'FILE' }
+          " ' " '
+        FILE
+
+        it 'raises an unclosed string error' do
+          expect{described_class.parse(file)}.to raise_error(described_class::ParsingError, 'Unclosed string found.')
+        end
+
+        let(:file) { <<~'FILE' }
+          ' " ' "
+        FILE
+
+        it 'raises an unclosed string error' do
+          expect{described_class.parse(file)}.to raise_error(described_class::ParsingError, 'Unclosed string found.')
+        end
       end
     end
 

--- a/spec/erb_lint/parser_spec.rb
+++ b/spec/erb_lint/parser_spec.rb
@@ -81,10 +81,10 @@ describe ERBLint::Parser do
         context 'when the erb tags contain content on one line' do
           let(:file) { '<% this is some content %>' }
 
-          it 'returns a text node consisting only of whitespace' do
+          it 'returns a text node consisting of the erb tag containing the single line of content' do
             expect(described_class.parse(file).children.size).to eq 2
             expect(described_class.parse(file).child.text?).to be_truthy
-            expect(described_class.parse(file).child.text.strip).to eq ''
+            expect(described_class.parse(file).child.text).to eq '<% this is some content %>'
             expect(described_class.parse(file).child.text.scan(/\n/).size).to eq 0
           end
         end
@@ -92,10 +92,10 @@ describe ERBLint::Parser do
         context 'when the erb tags contain multiple lines' do
           let(:file) { "<% \n \n \n %>" }
 
-          it 'returns a text node consiting only of whitespace and three newlines' do
+          it 'returns a text node consiting of the erb tag containing the whitespace and three newlines' do
             expect(described_class.parse(file).children.size).to eq 2
             expect(described_class.parse(file).child.text?).to be_truthy
-            expect(described_class.parse(file).child.text.strip).to eq ''
+            expect(described_class.parse(file).child.text).to eq "<% \n \n \n %>"
             expect(described_class.parse(file).child.text.scan(/\n/).size).to eq 3
           end
         end
@@ -103,16 +103,16 @@ describe ERBLint::Parser do
         context 'when the erb tags contain content on multiple lines' do
           let(:file) { <<~FILE.chomp }
             <%
-              line1
-              line2
-              line3
+            line1
+            line2
+            line3
             %>
           FILE
 
-          it 'returns a text node consiting only of whitespace and four newlines' do
+          it 'returns a text node consiting of the erb tag containing the lines of content and four newlines' do
             expect(described_class.parse(file).children.size).to eq 2
             expect(described_class.parse(file).child.text?).to be_truthy
-            expect(described_class.parse(file).child.text.strip).to eq ''
+            expect(described_class.parse(file).child.text).to eq "<%\nline1\nline2\nline3\n%>"
             expect(described_class.parse(file).child.text.scan(/\n/).size).to eq 4
           end
         end
@@ -120,60 +120,60 @@ describe ERBLint::Parser do
         context 'when the erb tags contain an erb start tag' do
           let(:file) { '<% <% %>' }
 
-          it 'returns a text node consisting only of whitespace' do
+          it 'returns a text node consisting of the erb tag containing the erb start tag' do
             expect(described_class.parse(file).children.size).to eq 2
             expect(described_class.parse(file).child.text?).to be_truthy
-            expect(described_class.parse(file).child.text.strip).to eq ''
+            expect(described_class.parse(file).child.text).to eq '<% <% %>'
           end
         end
 
         context 'when the erb tags appear after an erb start tag literal' do
-          let(:file) { '<%% <% has literal %>' }
+          let(:file) { '<%% <% after literal %>' }
 
-          it 'returns a text node consisting only of an erb start tag literal and whitespace' do
+          it 'returns a text node consisting of the erb start tag literal and erb tag' do
             expect(described_class.parse(file).children.size).to eq 2
             expect(described_class.parse(file).child.text?).to be_truthy
-            expect(described_class.parse(file).child.text.strip).to eq '<%%'
+            expect(described_class.parse(file).child.text.strip).to eq '<%% <% after literal %>'
           end
         end
 
         context 'when the erb tags contain an erb end tag literal' do
           let(:file) { '<% has literal %%> %>' }
 
-          it 'returns a text node consisting only of whitespace' do
+          it 'returns a text node consisting of the erb tag containing the erb end tag literal' do
             expect(described_class.parse(file).children.size).to eq 2
             expect(described_class.parse(file).child.text?).to be_truthy
-            expect(described_class.parse(file).child.text.strip).to eq ''
+            expect(described_class.parse(file).child.text.strip).to eq '<% has literal %%> %>'
           end
         end
 
         context 'when the erb tags are separated in strings' do
           let(:file) { "'<%=' + within_string + '%>'" }
 
-          it 'returns a text node consisting of single quotes containing 26 spaces' do
+          it 'returns a text node consisting of the string separated erb tags' do
             expect(described_class.parse(file).children.size).to eq 2
             expect(described_class.parse(file).child.text?).to be_truthy
-            expect(described_class.parse(file).child.text.strip).to eq "'                          '"
+            expect(described_class.parse(file).child.text.strip).to eq "'<%=' + within_string + '%>'"
           end
         end
 
         context 'when the erb tags contain an invalid string with double quotes' do
           let(:file) { '<% " %>' }
 
-          it 'returns a text node consisting only of whitespace' do
+          it 'returns a text node consisting of the erb tag containing the double quote' do
             expect(described_class.parse(file).children.size).to eq 2
             expect(described_class.parse(file).child.text?).to be_truthy
-            expect(described_class.parse(file).child.text.strip).to eq ''
+            expect(described_class.parse(file).child.text.strip).to eq '<% " %>'
           end
         end
 
         context 'when the erb tags contain an invalid string with single quotes' do
           let(:file) { "<% ' %>" }
 
-          it 'returns a text node consisting only of whitespace' do
+          it 'returns a text node consisting of the erb tag containing the single quote' do
             expect(described_class.parse(file).children.size).to eq 2
             expect(described_class.parse(file).child.text?).to be_truthy
-            expect(described_class.parse(file).child.text.strip).to eq ''
+            expect(described_class.parse(file).child.text.strip).to eq "<% ' %>"
           end
         end
       end
@@ -186,12 +186,12 @@ describe ERBLint::Parser do
             </div>
           FILE
 
-          it 'returns a div node with a text node consisting only of whitespace as its child' do
+          it 'returns a div node with a text node consisting of the erb tag' do
             expect(described_class.parse(file).children.size).to eq 2
             expect(described_class.parse(file).child.name).to eq 'div'
             expect(described_class.parse(file).child.children.size).to eq 1
             expect(described_class.parse(file).child.child.text?).to be_truthy
-            expect(described_class.parse(file).child.child.text.strip).to eq ''
+            expect(described_class.parse(file).child.child.text.strip).to eq '<% within element content %>'
           end
         end
 
@@ -200,23 +200,10 @@ describe ERBLint::Parser do
             <div class="<% within element attribute %>"></div>
           FILE
 
-          it 'returns a div node with a class atribute value consisting only of whitespace' do
+          it 'returns a div node with a class attribute value consisting of the erb tag' do
             expect(described_class.parse(file).children.size).to eq 2
             expect(described_class.parse(file).child.name).to eq 'div'
-            expect(described_class.parse(file).child['class'].strip).to eq ''
-          end
-        end
-
-        context 'when the erb tags are within the attribute list of the element' do
-          let(:file) { <<~FILE.chomp }
-            <div <% within element attribute list %>></div>
-          FILE
-
-          it 'returns a div node with no attributes or children' do
-            expect(described_class.parse(file).children.size).to eq 2
-            expect(described_class.parse(file).child.name).to eq 'div'
-            expect(described_class.parse(file).child.attributes.size).to eq 0
-            expect(described_class.parse(file).child.children.size).to eq 0
+            expect(described_class.parse(file).child['class'].strip).to eq '<% within element attribute %>'
           end
         end
       end

--- a/spec/erb_lint/parser_spec.rb
+++ b/spec/erb_lint/parser_spec.rb
@@ -19,60 +19,60 @@ describe ERBLint::Parser do
         context 'when the erb tags are code execution tags' do
           let(:file) { '<% %>' }
 
-          it 'returns a text node consisting only of whitespace' do
+          it 'returns a text node consisting of the execution tag' do
             expect(described_class.parse(file).children.size).to eq 2
             expect(described_class.parse(file).child.text?).to be_truthy
-            expect(described_class.parse(file).child.text.strip).to eq ''
+            expect(described_class.parse(file).child.text).to eq '<% %>'
           end
         end
 
         context 'when the erb tags are code evaluation tags' do
           let(:file) { '<%= %>' }
 
-          it 'returns a text node consisting only of whitespace' do
+          it 'returns a text node consisting of the evaluation tag' do
             expect(described_class.parse(file).children.size).to eq 2
             expect(described_class.parse(file).child.text?).to be_truthy
-            expect(described_class.parse(file).child.text.strip).to eq ''
+            expect(described_class.parse(file).child.text).to eq '<%= %>'
           end
         end
 
         context 'when the erb tags trim the following line break' do
           let(:file) { '<% -%>' }
 
-          it 'returns a text node consisting only of whitespace' do
+          it 'returns a text node consisting of the trim tag' do
             expect(described_class.parse(file).children.size).to eq 2
             expect(described_class.parse(file).child.text?).to be_truthy
-            expect(described_class.parse(file).child.text.strip).to eq ''
+            expect(described_class.parse(file).child.text).to eq '<% -%>'
           end
         end
 
         context 'when the erb tags are comment tags' do
           let(:file) { '<%# %>' }
 
-          it 'returns a text node consisting only of whitespace' do
+          it 'returns a text node consisting of the comment tag' do
             expect(described_class.parse(file).children.size).to eq 2
             expect(described_class.parse(file).child.text?).to be_truthy
-            expect(described_class.parse(file).child.text.strip).to eq ''
+            expect(described_class.parse(file).child.text).to eq '<%# %>'
           end
         end
 
         context 'when the erb tags are inside double quotes' do
           let(:file) { '"<% %>"' }
 
-          it 'returns a text node consisting of double quotes containing 5 spaces' do
+          it 'returns a text node consisting of double quotes containing the erb tag' do
             expect(described_class.parse(file).children.size).to eq 2
             expect(described_class.parse(file).child.text?).to be_truthy
-            expect(described_class.parse(file).child.text.strip).to eq '"     "'
+            expect(described_class.parse(file).child.text).to eq '"<% %>"'
           end
         end
 
         context 'when the erb tags are inside single quotes' do
           let(:file) { "'<% %>'" }
 
-          it 'returns a text node consisting of single quotes containing 5 spaces' do
+          it 'returns a text node consisting of single quotes containing the erb tag' do
             expect(described_class.parse(file).children.size).to eq 2
             expect(described_class.parse(file).child.text?).to be_truthy
-            expect(described_class.parse(file).child.text.strip).to eq "'     '"
+            expect(described_class.parse(file).child.text).to eq "'<% %>'"
           end
         end
       end

--- a/spec/erb_lint/parser_spec.rb
+++ b/spec/erb_lint/parser_spec.rb
@@ -3,266 +3,271 @@
 require 'spec_helper'
 
 describe ERBLint::Parser do
-  describe '#remove_escaped_erb_tags' do
-    # Test cases
-    # _erb_ ... _/erb_
-  end
-
   describe '#parse' do
     context 'when the file is empty' do
       let(:file) { '' }
 
       it 'returns a document fragment with only the end marker as a child' do
+        expect(described_class.parse(file).class).to eq Nokogiri::XML::DocumentFragment
         expect(described_class.parse(file).children.size).to eq 1
         expect(described_class.parse(file).child.name).to eq ERBLint::Parser::END_MARKER_NAME
       end
     end
 
     context 'when the file has erb tags' do
-      context 'when the erb tags are code execution tags' do
-        let(:file) { '<% %>' }
+      context 'when the erb tags only contain whitespace' do
+        context 'when the erb tags are code execution tags' do
+          let(:file) { '<% %>' }
 
-        it 'returns a document fragment with an empty erb tag' do
-          expect(described_class.parse(file).children.size).to eq 2
-          expect(described_class.parse(file).child.name).to eq 'erb'
-          expect(described_class.parse(file).child.text).to start_with ' '
+          it 'returns a text node consisting only of whitespace' do
+            expect(described_class.parse(file).children.size).to eq 2
+            expect(described_class.parse(file).child.text?).to be_truthy
+            expect(described_class.parse(file).child.text.strip).to eq ''
+          end
+        end
+
+        context 'when the erb tags are code evaluation tags' do
+          let(:file) { '<%= %>' }
+
+          it 'returns a text node consisting only of whitespace' do
+            expect(described_class.parse(file).children.size).to eq 2
+            expect(described_class.parse(file).child.text?).to be_truthy
+            expect(described_class.parse(file).child.text.strip).to eq ''
+          end
+        end
+
+        context 'when the erb tags trim the following line break' do
+          let(:file) { '<% -%>' }
+
+          it 'returns a text node consisting only of whitespace' do
+            expect(described_class.parse(file).children.size).to eq 2
+            expect(described_class.parse(file).child.text?).to be_truthy
+            expect(described_class.parse(file).child.text.strip).to eq ''
+          end
+        end
+
+        context 'when the erb tags are comment tags' do
+          let(:file) { '<%# %>' }
+
+          it 'returns a text node consisting only of whitespace' do
+            expect(described_class.parse(file).children.size).to eq 2
+            expect(described_class.parse(file).child.text?).to be_truthy
+            expect(described_class.parse(file).child.text.strip).to eq ''
+          end
+        end
+
+        context 'when the erb tags are inside double quotes' do
+          let(:file) { '"<% %>"' }
+
+          it 'returns a text node consisting of double quotes containing 5 spaces' do
+            expect(described_class.parse(file).children.size).to eq 2
+            expect(described_class.parse(file).child.text?).to be_truthy
+            expect(described_class.parse(file).child.text.strip).to eq '"     "'
+          end
+        end
+
+        context 'when the erb tags are inside single quotes' do
+          let(:file) { "'<% %>'" }
+
+          it 'returns a text node consisting of single quotes containing 5 spaces' do
+            expect(described_class.parse(file).children.size).to eq 2
+            expect(described_class.parse(file).child.text?).to be_truthy
+            expect(described_class.parse(file).child.text.strip).to eq "'     '"
+          end
         end
       end
 
-      context 'when the erb tags are code evaluation tags' do
-        let(:file) { '<%= %>' }
+      context 'when the erb tags contain content' do
+        context 'when the erb tags contain content on one line' do
+          let(:file) { '<% this is some content %>' }
 
-        it 'returns a document fragment with an erb tag beginning with =' do
-          expect(described_class.parse(file).children.size).to eq 2
-          expect(described_class.parse(file).child.name).to eq 'erb'
-          expect(described_class.parse(file).child.text).to start_with '='
+          it 'returns a text node consisting only of whitespace' do
+            expect(described_class.parse(file).children.size).to eq 2
+            expect(described_class.parse(file).child.text?).to be_truthy
+            expect(described_class.parse(file).child.text.strip).to eq ''
+            expect(described_class.parse(file).child.text.scan(/\n/).size).to eq 0
+          end
+        end
+
+        context 'when the erb tags contain multiple lines' do
+          let(:file) { "<% \n \n \n %>" }
+
+          it 'returns a text node consiting only of whitespace and three newlines' do
+            expect(described_class.parse(file).children.size).to eq 2
+            expect(described_class.parse(file).child.text?).to be_truthy
+            expect(described_class.parse(file).child.text.strip).to eq ''
+            expect(described_class.parse(file).child.text.scan(/\n/).size).to eq 3
+          end
+        end
+
+        context 'when the erb tags contain content on multiple lines' do
+          let(:file) { <<~FILE.chomp }
+            <%
+              line1
+              line2
+              line3
+            %>
+          FILE
+
+          it 'returns a text node consiting only of whitespace and four newlines' do
+            expect(described_class.parse(file).children.size).to eq 2
+            expect(described_class.parse(file).child.text?).to be_truthy
+            expect(described_class.parse(file).child.text.strip).to eq ''
+            expect(described_class.parse(file).child.text.scan(/\n/).size).to eq 4
+          end
+        end
+
+        context 'when the erb tags contain an erb start tag' do
+          let(:file) { '<% <% %>' }
+
+          it 'returns a text node consisting only of whitespace' do
+            expect(described_class.parse(file).children.size).to eq 2
+            expect(described_class.parse(file).child.text?).to be_truthy
+            expect(described_class.parse(file).child.text.strip).to eq ''
+          end
+        end
+
+        context 'when the erb tags appear after an erb start tag literal' do
+          let(:file) { '<%% <% has literal %>' }
+
+          it 'returns a text node consisting only of an erb start tag literal and whitespace' do
+            expect(described_class.parse(file).children.size).to eq 2
+            expect(described_class.parse(file).child.text?).to be_truthy
+            expect(described_class.parse(file).child.text.strip).to eq '<%%'
+          end
+        end
+
+        context 'when the erb tags contain an erb end tag literal' do
+          let(:file) { '<% has literal %%> %>' }
+
+          it 'returns a text node consisting only of whitespace' do
+            expect(described_class.parse(file).children.size).to eq 2
+            expect(described_class.parse(file).child.text?).to be_truthy
+            expect(described_class.parse(file).child.text.strip).to eq ''
+          end
+        end
+
+        context 'when the erb tags are separated in strings' do
+          let(:file) { "'<%=' + within_string + '%>'" }
+
+          it 'returns a text node consisting of single quotes containing 26 spaces' do
+            expect(described_class.parse(file).children.size).to eq 2
+            expect(described_class.parse(file).child.text?).to be_truthy
+            expect(described_class.parse(file).child.text.strip).to eq "'                          '"
+          end
+        end
+
+        context 'when the erb tags contain an invalid string with double quotes' do
+          let(:file) { '<% " %>' }
+
+          it 'returns a text node consisting only of whitespace' do
+            expect(described_class.parse(file).children.size).to eq 2
+            expect(described_class.parse(file).child.text?).to be_truthy
+            expect(described_class.parse(file).child.text.strip).to eq ''
+          end
+        end
+
+        context 'when the erb tags contain an invalid string with single quotes' do
+          let(:file) { "<% ' %>" }
+
+          it 'returns a text node consisting only of whitespace' do
+            expect(described_class.parse(file).children.size).to eq 2
+            expect(described_class.parse(file).child.text?).to be_truthy
+            expect(described_class.parse(file).child.text.strip).to eq ''
+          end
         end
       end
 
-      context 'when the erb tags trim the following line break' do
-        let(:file) { '<% -%>' }
+      context 'when the erb tags are inside of another element' do
+        context 'when the erb tags represent a child of the element' do
+          let(:file) { <<~FILE.chomp }
+            <div>
+              <% within element content %>
+            </div>
+          FILE
 
-        it 'returns a document fragment with an erb tag ending with -' do
-          expect(described_class.parse(file).children.size).to eq 2
-          expect(described_class.parse(file).child.name).to eq 'erb'
-          expect(described_class.parse(file).child.text).to end_with '-'
+          it 'returns a div node with a text node consisting only of whitespace as its child' do
+            expect(described_class.parse(file).children.size).to eq 2
+            expect(described_class.parse(file).child.name).to eq 'div'
+            expect(described_class.parse(file).child.children.size).to eq 1
+            expect(described_class.parse(file).child.child.text?).to be_truthy
+            expect(described_class.parse(file).child.child.text.strip).to eq ''
+          end
+        end
+
+        context 'when the erb tags are within an attribute of the element' do
+          let(:file) { <<~FILE.chomp }
+            <div class="<% within element attribute %>"></div>
+          FILE
+
+          it 'returns a div node with a class atribute value consisting only of whitespace' do
+            expect(described_class.parse(file).children.size).to eq 2
+            expect(described_class.parse(file).child.name).to eq 'div'
+            expect(described_class.parse(file).child['class'].strip).to eq ''
+          end
+        end
+
+        context 'when the erb tags are within the attribute list of the element' do
+          let(:file) { <<~FILE.chomp }
+            <div <% within element attribute list %>></div>
+          FILE
+
+          it 'returns a div node with no attributes or children' do
+            expect(described_class.parse(file).children.size).to eq 2
+            expect(described_class.parse(file).child.name).to eq 'div'
+            expect(described_class.parse(file).child.attributes.size).to eq 0
+            expect(described_class.parse(file).child.children.size).to eq 0
+          end
         end
       end
 
-      context 'when the erb tags are comment tags' do
-        let(:file) { '<%# %>' }
+      context 'when the erb tags are not closed properly' do
+        let(:file) { '<% unclosed ' }
 
-        it 'returns a document fragment with an erb tag beginning with #' do
-          expect(described_class.parse(file).children.size).to eq 2
-          expect(described_class.parse(file).child.name).to eq 'erb'
-          expect(described_class.parse(file).child.text).to start_with '#'
-        end
-      end
-
-      context 'when the erb tags are inside double quotes' do
-        let(:file) { '"<% %>"' }
-
-        it 'returns a document fragment with escaped erb tags inside a text node' do
-          expect(described_class.parse(file).children.size).to eq 2
-          expect(described_class.parse(file).child.name).to eq 'text'
-          expect(described_class.parse(file).child.text).to eq '"_erb_ _/erb_"'
-        end
-      end
-
-      context 'when the erb tags are inside single quotes' do
-        let(:file) { "'<% %>'" }
-
-        it 'returns a document fragment with escaped erb tags inside a text node' do
-          expect(described_class.parse(file).children.size).to eq 2
-          expect(described_class.parse(file).child.name).to eq 'text'
-          expect(described_class.parse(file).child.text).to eq "'_erb_ _/erb_'"
-        end
-      end
-
-      context 'when the erb tags contain an invalid string with double quotes' do
-        let(:file) { '<% " %>' }
-
-        it 'does not raise an error' do
-          expect{described_class.parse(file)}.to_not raise_error
-        end
-
-        it 'returns a document fragment with the double quote inside the erb tag' do
-          expect(described_class.parse(file).children.size).to eq 2
-          expect(described_class.parse(file).child.name).to eq 'erb'
-          expect(described_class.parse(file).child.text).to eq ' " '
-        end
-      end
-
-      context 'when the erb tags contain an invalid string with single quotes' do
-        let(:file) { "<% ' %>" }
-
-        it 'does not raise an error' do
-          expect{described_class.parse(file)}.to_not raise_error
-        end
-
-        it 'returns a document fragment with the single quote inside the erb tag' do
-          expect(described_class.parse(file).children.size).to eq 2
-          expect(described_class.parse(file).child.name).to eq 'erb'
-          expect(described_class.parse(file).child.text).to eq " ' "
-        end
-      end
-    end
-
-    context 'when the file contains quotes' do
-      context 'when the file has two double quotes' do
-        let(:file) { <<~'FILE' }
-          " "
-        FILE
-
-        it 'does not raise an error' do
-          expect{described_class.parse(file)}.to_not raise_error
-        end
-      end
-
-      context 'when the file has three double quotes' do
-        let(:file) { <<~'FILE' }
-          " " "
-        FILE
-
-        it 'raises an unclosed string error' do
-          expect{described_class.parse(file)}.to raise_error(described_class::ParsingError, 'Unclosed string found.')
-        end
-      end
-
-      context 'when the file has an escaped double quote within double quotes' do
-        let(:file) { <<~'FILE' }
-          " \" "
-        FILE
-
-        it 'does not raise an error' do
-          expect{described_class.parse(file)}.to_not raise_error
-        end
-      end
-
-      context 'when the file has one single quote within double quotes' do
-        let(:file) { <<~'FILE' }
-          " ' "
-        FILE
-
-        it 'does not raise an error' do
-          expect{described_class.parse(file)}.to_not raise_error
-        end
-      end
-
-      context 'when the file has two single quotes within double quotes' do
-        let(:file) { <<~'FILE' }
-          " ' ' "
-        FILE
-
-        it 'does not raise an error' do
-          expect{described_class.parse(file)}.to_not raise_error
-        end
-      end
-
-      context 'when the file has three single quotes within double quotes' do
-        let(:file) { <<~'FILE' }
-          " ' ' ' "
-        FILE
-
-        it 'does not raise an error' do
-          expect{described_class.parse(file)}.to_not raise_error
-        end
-      end
-
-      context 'when the file has two single quotes' do
-        let(:file) { <<~'FILE' }
-          ' '
-        FILE
-
-        it 'does not raise an error' do
-          expect{described_class.parse(file)}.to_not raise_error
-        end
-      end
-
-      context 'when the file has three single quotes' do
-        let(:file) { <<~'FILE' }
-          ' ' '
-        FILE
-
-        it 'raises an unclosed string error' do
-          expect{described_class.parse(file)}.to raise_error(described_class::ParsingError, 'Unclosed string found.')
-        end
-      end
-
-      context 'when the file has an escaped single quote within single quotes' do
-        let(:file) { <<~'FILE' }
-          ' \' '
-        FILE
-
-        it 'does not raise an error' do
-          expect{described_class.parse(file)}.to_not raise_error
-        end
-      end
-
-      context 'when the file has one double quote within single quotes' do
-        let(:file) { <<~'FILE' }
-          ' " '
-        FILE
-
-        it 'does not raise an error' do
-          expect{described_class.parse(file)}.to_not raise_error
-        end
-      end
-
-      context 'when the file has two double quotes within single quotes' do
-        let(:file) { <<~'FILE' }
-          ' " " '
-        FILE
-
-        it 'does not raise an error' do
-          expect{described_class.parse(file)}.to_not raise_error
-        end
-      end
-
-      context 'when the file has three double quotes within single quotes' do
-        let(:file) { <<~'FILE' }
-          ' " " " '
-        FILE
-
-        it 'does not raise an error' do
-          expect{described_class.parse(file)}.to_not raise_error
-        end
-      end
-
-      context 'when the file has overlapping quotes' do
-        let(:file) { <<~'FILE' }
-          " ' " '
-        FILE
-
-        it 'raises an unclosed string error' do
-          expect{described_class.parse(file)}.to raise_error(described_class::ParsingError, 'Unclosed string found.')
-        end
-
-        let(:file) { <<~'FILE' }
-          ' " ' "
-        FILE
-
-        it 'raises an unclosed string error' do
-          expect{described_class.parse(file)}.to raise_error(described_class::ParsingError, 'Unclosed string found.')
+        it 'raises an unclosed erb tag error' do
+          expect { described_class.parse(file) }.to raise_error(described_class::ParseError, 'Unclosed ERB tag found.')
         end
       end
     end
 
-    context 'when the file is full of edge cases' do
-      let(:file) { <<~'FILE' }
-        <div class='a <%= something if " adwiawd "%> a-b--c'
-             name="foo">
-          <h1>Fleeb</h1>
-        </div>
-        <h3 class="d-e__f__g"><%= section %></h3>
-        <ul class="h-i j-k--<%= color %>">
-          <div class="l-m__n o-p__q--<%= color_str %> <%= "r-s__t--u-v" if i >= something %>">
-          </div>
-        </ul>
+    context 'when tags are not properly closed' do
+      let(:file) { <<~FILE.chomp }
+        <div>
       FILE
 
-      it 'returns a valid tree structure representing the file' do
-        expect(described_class.parse(file).class).to eq Nokogiri::XML::DocumentFragment
+      it 'raises a general parsing error' do
+        expect { described_class.parse(file) }.to raise_error(
+          described_class::ParseError,
+          'File could not be successfully parsed. Ensure all tags are properly closed.'
+        )
+      end
+    end
+  end
+
+  describe '#file_is_empty?' do
+    let(:file_tree) { described_class.parse(file) }
+
+    context 'when the file is empty' do
+      let(:file) { '' }
+
+      it 'returns true' do
+        expect(described_class.file_is_empty?(file_tree)).to be_truthy
+      end
+    end
+
+    context 'when the file has content' do
+      let(:file) { 'content' }
+
+      it 'returns false' do
+        expect(described_class.file_is_empty?(file_tree)).to be_falsy
+      end
+    end
+
+    context 'when the file contains only a newline' do
+      let(:file) { "\n" }
+
+      it 'returns false' do
+        expect(described_class.file_is_empty?(file_tree)).to be_falsy
       end
     end
   end

--- a/spec/erb_lint/runner_spec.rb
+++ b/spec/erb_lint/runner_spec.rb
@@ -26,6 +26,7 @@ describe ERBLint::Runner do
   describe '#run' do
     let(:file) { 'DummyFileContent' }
     let(:filename) { 'somefolder/otherfolder/dummyfile.html.erb' }
+    let(:file_tree) { 'DummyFileTree' }
     subject { runner.run(filename, file) }
 
     fake_linter_1_errors = ['FakeLinter1DummyErrors']
@@ -33,12 +34,14 @@ describe ERBLint::Runner do
     fake_final_newline_errors = ['FakeFinalNewlineDummyErrors']
 
     before do
+      allow(ERBLint::Parser).to receive(:parse)
+        .with(file).and_return file_tree
       allow_any_instance_of(ERBLint::Linter::FakeLinter1).to receive(:lint_file)
-        .with(file).and_return fake_linter_1_errors
+        .with(file_tree).and_return fake_linter_1_errors
       allow_any_instance_of(ERBLint::Linter::FakeLinter2).to receive(:lint_file)
-        .with(file).and_return fake_linter_2_errors
+        .with(file_tree).and_return fake_linter_2_errors
       allow_any_instance_of(ERBLint::Linter::FinalNewline).to receive(:lint_file)
-        .with(file).and_return fake_final_newline_errors
+        .with(file_tree).and_return fake_final_newline_errors
     end
 
     context 'when all linters are enabled' do


### PR DESCRIPTION
#### Why?
The current use of the `StartTagHelper` module in `DeprecatedClasses` for analyzing HTML start tags is not robust (as demonstrated by https://github.com/Shopify/erb-lint/pull/5), difficult to maintain due to excessive use of regular expressions, and limited in functionality (no multiline start tags, catches tags within quotes, etc).

Refactoring `ERBLint` to use a proper parser, supported by over [100 contributors](https://github.com/sparklemotion/nokogiri/graphs/contributors) will solve all the problems of the current solution and make it easier for other developers to contribute linters to the gem.

#### What?
This PR changes the interface that linters use to analyze the file from `file_content`/`lines` to a `file_tree`.

This `file_tree` is a `Nokogiri::HTML::Fragment` which can be traversed and examined just like any other `Nokogiri::HTML::Node`.

3 small modifications are being made during the transformation from the bare text `file_content` to the `file_tree` HTML fragment.
* All ERB tags (`<%..%>`, `<%=..%>`, `<%..-%>`, `<%#..%>`, etc) have been ~~replaced by `<erb>...</erb>`~~ removed from the file content and replaced with corresponding whitespace and newlines.
  * Example: `<% apples \n %>` --> `__________\n___`
* All ERB tag literals (`<%%`, `%%>`) have been escaped via `htmlentities` entity encoding.
  * Example: `<%%` --> `&lt;%%`
* An `erb_lint_end_marker` tag has been appended to the end of the document fragment for calculating end-of-file line numbers. **This is a workaround for this [Nokogiri line number bug](https://github.com/sparklemotion/nokogiri/issues/1493).**
* ~~All content within ERB tags has had all of its contained entities encoded (special character escaping using `htmlentities`)~~
* ~~All ERB tags (now `<erb>...</erb>`) within strings (`"..."` or `'...'`) have been replaced by `_erb_..._/erb_` to prevent them from being parsed as tags by `Nokogiri::HTML`.~~

#### How?
* The `StartTagHelper` has been removed.
* `ERBLint::Parser` has been added, exposing a `parse` method to generate the valid `Nokogiri::HTML::Fragment` from a `file_content` string.
* The `ERBLint::Runner` parses the file using the `parse` method before passing the resulting `file_tree` to each linter's `lint_file` method.
* `ERBLint::Linter#lint_lines` has been removed.

#### Todo
- [x] Finish adding test cases to `parser_spec.rb`

**For review:**
@edward @volmer @lemonmade 