### PR TITLE
Add excluded files config option for linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ gem 'erb_lint'
 
   ```ruby
   file = File.read('file.html.erb')
-  violations = runner.run(file)
+  violations = runner.run('file.html.erb', file)
   ```
   
   The runner returns a violation list containing each linter that was run and its corresponding list of errors.
@@ -73,6 +73,7 @@ config = {
   'linters' => {
     'Linter1' => {
       'enabled' => true,
+      'exclude' => ['**/exclude_this_directory/**', 'app/views/and_this_one/**.html.erb']
       'linter_specific_option' => 'value',
       ...
     },
@@ -86,10 +87,14 @@ config = {
 }
 ```
 
-All linters have an `enabled` option which can be `true` or `false`, which
-controls whether the linter is run, along with linter-specific options.
+All linters have an `enabled` option which can be `true` or `false`, and controls whether the linter is run.
 
-The default configuration is:
+In addition, linters have an optional `exclude` option which specifies a list of paths that this linter should ignore.
+The format for specifying path patterns follows the [Ruby glob pattern](http://ruby-doc.org/core-2.3.0/File.html#method-c-fnmatch).
+
+Lastly, linters have a set of options that are specific to that linter's functionality and are defined down below for each linter.
+
+By default, ERBLint will enable `FinalNewLine`, even if the `Runner` has no config passed in:
 
 ```ruby
 default_config = {
@@ -100,8 +105,6 @@ default_config = {
   }
 }
 ```
-
-which gets used when you create a `Runner` with no config.
 
 ## Linters
 

--- a/lib/erb_lint/runner.rb
+++ b/lib/erb_lint/runner.rb
@@ -35,9 +35,7 @@ module ERBLint
     def linter_excludes_file?(linter, filename)
       excluded_filepaths = @config.dig('linters', linter.class.simple_name, 'exclude') || []
       excluded_filepaths.each do |path|
-        if File.fnmatch?(path, filename)
-          return true
-        end
+        return true if File.fnmatch?(path, filename)
       end
       false
     end

--- a/lib/erb_lint/runner.rb
+++ b/lib/erb_lint/runner.rb
@@ -7,18 +7,19 @@ module ERBLint
       @config = default_config.merge(config || {})
 
       LinterRegistry.load_custom_linters
-      @linters = LinterRegistry.linters.select { |linter| linter_enabled?(linter) }
+      @linters = LinterRegistry.linters.select { |linter_class| linter_enabled?(linter_class) }
       @linters.map! do |linter_class|
         linter_config = @config['linters'][linter_class.simple_name]
         linter_class.new(linter_config)
       end
     end
 
-    def run(file)
-      @linters.map do |linter|
+    def run(filename, file_content)
+      linters_for_file = @linters.select { |linter| !linter_excludes_file?(linter, filename) }
+      linters_for_file.map do |linter|
         {
           linter_name: linter.class.simple_name,
-          errors: linter.lint_file(file)
+          errors: linter.lint_file(file_content)
         }
       end
     end
@@ -30,6 +31,16 @@ module ERBLint
       linter_class_found = linter_classes[linter_class.simple_name]
       return false if linter_class_found.nil?
       linter_class_found['enabled'] || false
+    end
+
+    def linter_excludes_file?(linter, filename)
+      excluded_filepaths = linter['exclude'] || []
+      excluded_filepaths.each do |path|
+        if File.fnmatch?(path, filename)
+          return true
+        end
+      end
+      false
     end
 
     def default_config

--- a/lib/erb_lint/runner.rb
+++ b/lib/erb_lint/runner.rb
@@ -9,7 +9,7 @@ module ERBLint
       LinterRegistry.load_custom_linters
       @linters = LinterRegistry.linters.select { |linter_class| linter_enabled?(linter_class) }
       @linters.map! do |linter_class|
-        linter_config = @config['linters'][linter_class.simple_name]
+        linter_config = @config.dig('linters', linter_class.simple_name)
         linter_class.new(linter_config)
       end
     end
@@ -27,14 +27,13 @@ module ERBLint
     private
 
     def linter_enabled?(linter_class)
-      linter_classes = @config['linters']
-      linter_class_found = linter_classes[linter_class.simple_name]
-      return false if linter_class_found.nil?
-      linter_class_found['enabled'] || false
+      linter_config = @config.dig('linters', linter_class.simple_name)
+      return false if linter_config.nil?
+      linter_config['enabled'] || false
     end
 
     def linter_excludes_file?(linter, filename)
-      excluded_filepaths = linter['exclude'] || []
+      excluded_filepaths = @config.dig('linters', linter.class.simple_name, 'exclude') || []
       excluded_filepaths.each do |path|
         if File.fnmatch?(path, filename)
           return true

--- a/spec/erb_lint/runner_spec.rb
+++ b/spec/erb_lint/runner_spec.rb
@@ -25,7 +25,8 @@ describe ERBLint::Runner do
 
   describe '#run' do
     let(:file) { 'DummyFileContent' }
-    subject { runner.run(file) }
+    let(:filename) { 'somefolder/otherfolder/dummyfile.html.erb' }
+    subject { runner.run(filename, file) }
 
     fake_linter_1_errors = ['FakeLinter1DummyErrors']
     fake_linter_2_errors = ['FakeLinter2DummyErrors']
@@ -90,6 +91,21 @@ describe ERBLint::Runner do
           'linters' => {
             'FakeLinter1' => { 'enabled' => false },
             'FakeLinter2' => { 'enabled' => false }
+          }
+        }
+      end
+
+      it 'returns no linters' do
+        expect(subject).to be_empty
+      end
+    end
+
+    context 'when all linters exclude the file' do
+      let(:config) do
+        {
+          'linters' => {
+            'FakeLinter1' => { 'enabled' => true, 'exclude' => ['**/otherfolder/**'] },
+            'FakeLinter2' => { 'enabled' => true, 'exclude' => ['somefolder/**.html.erb'] }
           }
         }
       end


### PR DESCRIPTION
Adds functionality to exclude a path of files for any linter.

Adds a test and documentation to the README.

For Ruby Review:
@arthurgouveia @volmer 