### PR TITLE
Add ContentStyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ default_config = {
 
 ## Linters
 
-`erb-lint` comes with 2 linters on-board: `DeprecatedClasses` and `FinalNewline`, each with their own linter-specific options.
+`erb-lint` comes with 3 linters on-board: `DeprecatedClasses`, `ContentStyle`, and `FinalNewline`, each with their own linter-specific options.
 
 ### DeprecatedClasses
 
@@ -137,6 +137,49 @@ Linter-Specific Option | Description
 `rule_set`             | A list of rules, each with a `deprecated` and `suggestion` option.
 `deprecated`           | A list of **regular expressions** which specify the classes deprecated by this rule.
 `suggestion`           | A string to be included in the rule's error message. Make this informative and specific to the rule that it is contained in.
+`addendum`             | A string to be included at the end of every error message of the rule set. (Optional)
+
+### ContentStyle
+
+Based on DeprecatedClasses, ContentStyle will find any words or phrases that
+violate the rule set that you provide.
+
+This `rule_set` is specified as a list of rules, each with a `violation` set and
+a corresponding `suggestion`. Optionally, you can also add a `case_insensitive:
+true` value to make ContentStyle ignore case when searching for violations.
+If your `violation` is a regex pattern, you can add a `regex_description` string
+to replace the pattern in the error message.
+
+```ruby
+'rule_set' => [
+  {
+    'violation' => ['application', 'program'],
+    'suggestion' => 'app'
+    'case_insensitive' => true
+  },
+  {
+    'violation' => 'support page',
+    'suggestion' => 'Lintercorp Help Center'
+  },
+    'violation' => '\d+ ?(—|-) ?\d+'
+    'suggestion' => '— (en dash) in number ranges'
+    'regex_description' => '- (hyphen) or — (em dash) in number ranges'
+  }
+]
+```
+
+You can also specify an addendum to be added to the end of each error message
+using the `addendum` option. The error message format is: `"Don't use
+#{violation}. Do use #{suggestion}"` or `"Don't use #{violation}. Do use
+#{suggestion}. #{addendum}"` if an `addendum` is present.
+
+Linter-Specific Option | Description
+-----------------------|-----------------------------------------------------------------------------------
+`rule_set`             | A list of rules, each with a `violation` and `suggestion` option.
+`violation`            | A list of strings or regex patterns that specify unwanted text content.
+`suggestion`           | A suggested replacement for the unwanted text content defined in `violation`.
+`case_insensitive`     | A Boolean value that determines whether the rule is case sensitive. (Optional, defaults to false if not included)
+`regex_description`    | A string that appears in place of the regex pattern as the violation in the error message. (Optional) 
 `addendum`             | A string to be included at the end of every error message of the rule set. (Optional)
 
 ### FinalNewline

--- a/README.md
+++ b/README.md
@@ -141,13 +141,13 @@ Linter-Specific Option | Description
 
 ### ContentStyle
 
-Based on DeprecatedClasses, ContentStyle will find any words or phrases that
+ContentStyle will find any words or phrases that
 violate the rule set that you provide.
 
 This `rule_set` is specified as a list of rules, each with a `violation` set and
 a corresponding `suggestion`. Optionally, you can also add a `case_insensitive:
 true` value to make ContentStyle ignore case when searching for violations.
-If your `violation` is a regex pattern, you can add a `regex_description` string
+If your `violation` is a regex pattern, you can add a `pattern_description` string
 to replace the pattern in the error message.
 
 ```ruby
@@ -163,15 +163,14 @@ to replace the pattern in the error message.
   },
     'violation' => '\d+ ?(—|-) ?\d+'
     'suggestion' => '— (en dash) in number ranges'
-    'regex_description' => '- (hyphen) or — (em dash) in number ranges'
+    'pattern_description' => '- (hyphen) or — (em dash) in number ranges'
   }
 ]
 ```
 
 You can also specify an addendum to be added to the end of each error message
-using the `addendum` option. The error message format is: `"Don't use
-#{violation}. Do use #{suggestion}"` or `"Don't use #{violation}. Do use
-#{suggestion}. #{addendum}"` if an `addendum` is present.
+using the `addendum` option. The error message format is: `"Don't use #{violation}. Do use #{suggestion}"` 
+or `"Don't use #{violation}. Do use #{suggestion}. #{addendum}"` if an `addendum` is present.
 
 Linter-Specific Option | Description
 -----------------------|-----------------------------------------------------------------------------------
@@ -179,7 +178,7 @@ Linter-Specific Option | Description
 `violation`            | A list of strings or regex patterns that specify unwanted text content.
 `suggestion`           | A suggested replacement for the unwanted text content defined in `violation`.
 `case_insensitive`     | A Boolean value that determines whether the rule is case sensitive. (Optional, defaults to false if not included)
-`regex_description`    | A string that appears in place of the regex pattern as the violation in the error message. (Optional) 
+`pattern_description`    | A string that appears in place of the regex pattern as the violation in the error message. (Optional) 
 `addendum`             | A string to be included at the end of every error message of the rule set. (Optional)
 
 ### FinalNewline

--- a/lib/erb_lint/linters/content_style.rb
+++ b/lib/erb_lint/linters/content_style.rb
@@ -12,8 +12,9 @@ module ERBLint
           suggestion = rule.fetch('suggestion', '')
           pattern_description = rule.fetch('pattern_description', '')
           case_insensitive = rule.fetch('case_insensitive', false)
-          violation = rule.fetch('violation', [])
-          (violation.is_a?(String) ? [violation] : violation).each do |violating_pattern|
+          violation_string_or_array = rule.fetch('violation', [])
+          violation_array = [violation_string_or_array].flatten
+          violation_array.each do |violating_pattern|
             @content_ruleset.push(
               violating_pattern: violating_pattern,
               suggestion: suggestion,

--- a/lib/erb_lint/linters/content_style.rb
+++ b/lib/erb_lint/linters/content_style.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+module ERBLint
+  class Linter
+    # Checks for content style guide violations in the text nodes of HTML files.
+    class ContentStyle < Linter
+      include LinterRegistry
+
+      def initialize(config)
+        @content_ruleset = []
+        config.fetch('rule_set', []).each do |rule|
+          suggestion = rule.fetch('suggestion', '')
+          regex_description = rule.fetch('regex_description', '')
+          case_insensitive = rule.fetch('case_insensitive', false)
+          violation = rule.fetch('violation', [])
+          (violation.is_a?(String) ? [violation] : violation).each do |violating_pattern|
+            @content_ruleset.push(
+              violating_pattern: violating_pattern,
+              suggestion: suggestion,
+              case_insensitive: case_insensitive,
+              regex_description: regex_description
+            )
+          end
+        end
+        @content_ruleset.freeze
+        @addendum = config.fetch('addendum', '')
+      end
+
+      def lint_file(file_tree)
+        errors = []
+        @prior_violations = []
+        inner_text = select_text_children(html_elements(file_tree))
+        outer_text = select_text_children(file_tree)
+        all_text = (outer_text + inner_text)
+        # Assumes the immediate parent is on the same line. Nokogiri bug
+        # prevents retrieving line number from text node:
+        # https://github.com/sparklemotion/nokogiri/issues/1493
+        all_text.each do |text_node|
+          # Skips nodes that contain only a newline
+          next if text_node.text == '\n'
+          line_number = calculate_line_number(text_node)
+          errors.push(*generate_errors(strip_next_lines(text_node.text), line_number))
+        end
+        errors
+      end
+
+      private
+
+      def calculate_line_number(text_node)
+        unless text_node.parent.nil?
+          s = StringScanner.new(text_node.text)
+          # Scan until character that's not newline or space
+          newlines = s.scan_until(/[^\\n\s]/) || ''
+          @newline_count = newlines.scan(/\n/).size || 0
+          text_node.parent.line + @newline_count
+        end
+      end
+
+      # To avoid errors showing the wrong line number in Policial
+      def strip_next_lines(text)
+        if text =~ /\n/
+          if text[0] == '\n'
+            # Strips out content after any newlines following the
+            # newline_count number of newlines.
+            text.match(/\A.*\n{#{@newline_count}}.*/).to_s
+          else
+            # Strips out the content after any newlines.
+            text.match(/(.+?)(?=\n)/).to_s
+          end
+        else
+          text
+        end
+      end
+
+      def select_text_children(source)
+        source.children.select(&:text?) || []
+      end
+
+      def html_elements(file_tree)
+        Nokogiri::XML::NodeSet.new(file_tree.document, file_tree.search('*'))
+      end
+
+      def generate_errors(text, line_number)
+        violated_rules(text).map do |violated_rule|
+          suggestion = violated_rule[:suggestion]
+          regex_description = violated_rule[:regex_description]
+          violation = if !regex_description.empty?
+                        regex_description
+                      else
+                        violated_rule[:violating_pattern]
+                      end
+          {
+            line: line_number,
+            message: "Don't use `#{violation}`. Do use `#{suggestion}`. #{@addendum}".strip
+          }
+        end
+      end
+
+      def violated_rules(text)
+        @content_ruleset.select do |content_rule|
+          violation = content_rule[:violating_pattern]
+          suggestion = content_rule[:suggestion]
+          rule_case_insensitive = content_rule[:case_insensitive] == true
+          # Next if this violation is contained within another one that has occurred earlier
+          # in the list, e.g. "Store's admin" violates "store's admin" and "Store"
+          next if @prior_violations.to_s.include?(violation)
+          if rule_case_insensitive
+            # case-insensitive_match
+            match_violation(/(#{violation})\b/i, text)
+          elsif !rule_case_insensitive && suggestion_lowercase(suggestion, violation)
+            # case-sensitive match that ignores case violations that start a sentence
+            match_violation(/\w (#{violation})\b/, text)
+          else
+            # case-sensitive match
+            match_violation(/(#{violation})\b/, text)
+          end
+        end
+      end
+
+      def match_violation(regex, text)
+        regex.match(text) && record_prior_violation(regex, text)
+      end
+
+      def suggestion_lowercase(suggestion, violation)
+        # Check if the suggestion starts with a lowercase letter and the
+        # violation starts with an uppercase letter, in which case the match
+        # needs to ignore cases where the violation starts a sentence.
+        suggestion.match(/\p{Lower}/) && !violation.match(/\p{Lower}/)
+      end
+
+      def record_prior_violation(regex, text)
+        @prior_violations.push(regex.match(text).captures)
+      end
+    end
+  end
+end

--- a/lib/erb_lint/linters/content_style.rb
+++ b/lib/erb_lint/linters/content_style.rb
@@ -34,7 +34,7 @@ module ERBLint
           next unless text_node.text =~ /[^\n\s]/
           content_lines = split_lines(text_node)
           content_lines.each do |line|
-            errors.push(*generate_errors(line[:text], line[:number]))
+            errors.concat(generate_errors(line[:text], line[:number]))
           end
         end
         errors
@@ -48,7 +48,7 @@ module ERBLint
         unless text_node.parent.nil?
           s = StringScanner.new(text_node.text)
           if s.check_until(/\n/)
-            while line_content = s.scan_until(/\n/)
+            while (line_content = s.scan_until(/\n/))
               lines.push(text: line_content, number: current_line_number)
               current_line_number += 1
             end

--- a/lib/erb_lint/linters/content_style.rb
+++ b/lib/erb_lint/linters/content_style.rb
@@ -28,7 +28,6 @@ module ERBLint
 
       def lint_file(file_tree)
         errors = []
-        @prior_violations = []
         text_nodes = Parser.get_text_nodes(file_tree)
         text_nodes.each do |text_node|
           # Next if node doesn't contain content

--- a/lib/erb_lint/runner.rb
+++ b/lib/erb_lint/runner.rb
@@ -15,7 +15,20 @@ module ERBLint
     end
 
     def run(filename, file_content)
-      file_tree = Parser.parse(file_content)
+      file_tree = begin
+
+        Parser.parse(file_content)
+      rescue Parser::ParseError
+        return [
+          { linter_name: 'HTMLValidity', errors: [
+            { line: 1,
+              message: 'File is not HTML valid and could not be successfully parsed.
+              Ensure all tags are properly closed.' }
+          ] }
+        ]
+      end
+      return unless file_tree
+
       linters_for_file = @linters.select { |linter| !linter_excludes_file?(linter, filename) }
       linters_for_file.map do |linter|
         {

--- a/spec/erb_lint/linters/content_style_spec.rb
+++ b/spec/erb_lint/linters/content_style_spec.rb
@@ -393,7 +393,6 @@ describe ERBLint::Linter::ContentStyle do
     end
 
     context '- text node has multiple lines' do
-      # This test will only handle following lines once we build in multiline functionality
       violation_set_1 = 'App'
       suggestion_1 = 'app'
       violation_set_2 = 'Apps'
@@ -419,21 +418,23 @@ describe ERBLint::Linter::ContentStyle do
         </p>
       FILE
 
-      it 'strips the content after the first line and reports only 1 error' do
-        expect(linter_errors.size).to eq 1
+      it 'reports 2 errors' do
+        expect(linter_errors.size).to eq 2
       end
 
       it 'reports an error for `App` and suggests `app`' do
         expect(linter_errors[0][:message]).to include 'Don\'t use `App`'
         expect(linter_errors[0][:message]).to include 'Do use `app`'
+        expect(linter_errors[1][:message]).to include 'Don\'t use `Apps`'
+        expect(linter_errors[1][:message]).to include 'Do use `apps`'
       end
-      it 'calculates a correct first line number' do
+      it 'calculates correct line numbers' do
         expect(linter_errors[0][:line]).to eq(3)
+        expect(linter_errors[1][:line]).to eq(4)
       end
     end
 
     context '- text node starts on same line as parent but has multiple lines' do
-      # This test will only handle following lines once we build in multiline functionality
       violation_set_1 = 'App'
       suggestion_1 = 'app'
       violation_set_2 = 'Apps'
@@ -457,16 +458,19 @@ describe ERBLint::Linter::ContentStyle do
         </p>
       FILE
 
-      it 'strips the content after the first line and reports only 1 error' do
-        expect(linter_errors.size).to eq 1
+      it 'reports 2 errors' do
+        expect(linter_errors.size).to eq 2
       end
 
-      it 'reports an error for `App` and suggests `app`' do
+      it 'reports errors for `App` and `Apps` and suggests `app` and `apps`' do
         expect(linter_errors[0][:message]).to include 'Don\'t use `App`'
         expect(linter_errors[0][:message]).to include 'Do use `app`'
+        expect(linter_errors[1][:message]).to include 'Don\'t use `Apps`'
+        expect(linter_errors[1][:message]).to include 'Do use `apps`'
       end
-      it 'calculates a correct first line number' do
+      it 'calculates correct line numbers' do
         expect(linter_errors[0][:line]).to eq(1)
+        expect(linter_errors[1][:line]).to eq(2)
       end
     end
 

--- a/spec/erb_lint/linters/content_style_spec.rb
+++ b/spec/erb_lint/linters/content_style_spec.rb
@@ -14,10 +14,10 @@ describe ERBLint::Linter::ContentStyle do
 
   subject(:linter_errors) { linter.lint_file(ERBLint::Parser.parse(file)) }
 
-  context 'when the rule set is empty' do
+  context 'when rule set is empty' do
     let(:rule_set) { [] }
 
-    context 'when the file is empty' do
+    context 'when file is empty' do
       let(:file) { '' }
 
       it 'does not report any errors' do
@@ -26,11 +26,8 @@ describe ERBLint::Linter::ContentStyle do
     end
   end
 
-  context 'when the rule set contains violations' do
-    context '- rule is case-insensitive
-    - file contains violation with different case from suggestion (`Drop down`)
-    - file contains violation with same case as suggestion (`dropdown`)
-    - file contains suggestion (`drop-down`)' do
+  context 'when rule set and file contain violations' do
+    context 'when rule is case-insensitive and file contains violations in different cases' do
       violation_set_1 = ['dropdown', 'drop down']
       suggestion_1 = 'drop-down'
       case_insensitive_1 = true
@@ -62,9 +59,7 @@ describe ERBLint::Linter::ContentStyle do
       end
     end
 
-    context '- suggestion is prefix + violation (`Lintercorp Help Center`)
-    - file contains suggestion (`Lintercorp Help Center`)
-    - file contains violation (`Help Center`)' do
+    context 'when suggestion is prefix + violation' do
       violation_set_1 = ['Help Center', 'help center']
       suggestion_1 = 'Lintercorp Help Center'
 
@@ -92,11 +87,7 @@ describe ERBLint::Linter::ContentStyle do
       end
     end
 
-    context '- violation starts with uppercase character (`Apps`)
-    - suggestion starts with lowercase character (`apps`)
-    - file contains violation (`Big Apps`)
-    - file contains two potential false positives (the string and a sentence within the string both start
-      with `Apps`)' do
+    context 'when violation starts with uppercase and suggestion starts with lowercase' do
       violation_set_1 = 'Apps'
       suggestion_1 = 'apps'
 
@@ -122,13 +113,7 @@ describe ERBLint::Linter::ContentStyle do
       end
     end
 
-    context '- violation starts with uppercase character (`App`)
-    - suggestion starts with lowercase character (`app`)
-    - violation (`App`) contained in another violation (`Apps`)
-    - file contains a violation (`Five hundred App`)
-    - file contains four potential false positives
-      (the string and a sentence within the string both start with `App`, and
-      `App` is preceded by a comma and then a space, and an em dash and no space)' do
+    context 'when violation is contained in another violation in rule list' do
       violation_set_1 = 'App'
       suggestion_1 = 'app'
       violation_set_2 = 'Apps'
@@ -160,8 +145,7 @@ describe ERBLint::Linter::ContentStyle do
       end
     end
 
-    context '- violation has multiple words starting with uppercase characters (`Payment Gateways`)
-    - suggestion contains only lowercase characters (`payment gateways`)' do
+    context 'when violation is compound word starting with uppercase and suggestion starts with lowercase' do
       violation_set_1 = 'Payment Gateways'
       suggestion_1 = 'payment gateways'
 
@@ -187,9 +171,7 @@ describe ERBLint::Linter::ContentStyle do
       end
     end
 
-    context '- violation has multiple words and first word of violation starts with uppercase character (`Lintercorp
-      partner`)
-    - suggestion has multiple words, both starting with uppercase characters (`Lintercorp Partner`)' do
+    context 'when violation and suggestion are compound words starting with uppercase' do
       violation_set_1 = 'Lintercorp partner'
       suggestion_1 = 'Lintercorp Partner'
 
@@ -215,7 +197,7 @@ describe ERBLint::Linter::ContentStyle do
       end
     end
 
-    context '- file contains violation with a dumb single quote (`Store\'s dashboard`)' do
+    context 'when violation contains single dumb quote' do
       violation_set_1 = 'store\'s dashboard'
       suggestion_1 = 'Lintercorp dashboard'
       case_insensitive_1 = true
@@ -243,8 +225,7 @@ describe ERBLint::Linter::ContentStyle do
       end
     end
 
-    context '- violation has a smart single quote (`Store’s dashboard`)
-    - violation contained in prior violation' do
+    context 'when violation contains single smart quote' do
       violation_set_1 = 'store’s dashboard'
       suggestion_1 = 'Lintercorp dashboard'
       case_insensitive_1 = true
@@ -272,7 +253,7 @@ describe ERBLint::Linter::ContentStyle do
       end
     end
 
-    context '- file has a dumb double quote (`"backend store dashboard`)' do
+    context 'when file contains double dumb quote' do
       violation_set_1 = 'backend store dashboard'
       suggestion_1 = 'Lintercorp dashboard'
       case_insensitive_1 = true
@@ -300,7 +281,7 @@ describe ERBLint::Linter::ContentStyle do
       end
     end
 
-    context '- text node starts on line after parent' do
+    context 'when text node starts on line after parent' do
       violation_set_1 = 'Lintercorp Plus client'
       suggestion_1 = 'Lintercorp Plus merchant'
       case_insensitive_1 = true
@@ -341,7 +322,7 @@ describe ERBLint::Linter::ContentStyle do
       end
     end
 
-    context '- text node has multiple lines' do
+    context 'when text node has multiple lines' do
       violation_set_1 = 'App'
       suggestion_1 = 'app'
       violation_set_2 = 'Apps'
@@ -371,19 +352,13 @@ describe ERBLint::Linter::ContentStyle do
         expect(linter_errors.size).to eq 2
       end
 
-      it 'reports an error for `App` and suggests `app`' do
-        expect(linter_errors[0][:message]).to include 'Don\'t use `App`'
-        expect(linter_errors[0][:message]).to include 'Do use `app`'
-        expect(linter_errors[1][:message]).to include 'Don\'t use `Apps`'
-        expect(linter_errors[1][:message]).to include 'Do use `apps`'
-      end
       it 'calculates correct line numbers' do
         expect(linter_errors[0][:line]).to eq(3)
         expect(linter_errors[1][:line]).to eq(4)
       end
     end
 
-    context '- text node starts on same line as parent but has multiple lines' do
+    context 'when text node starts on same line as parent and has multiple lines' do
       violation_set_1 = 'App'
       suggestion_1 = 'app'
       violation_set_2 = 'Apps'
@@ -411,19 +386,13 @@ describe ERBLint::Linter::ContentStyle do
         expect(linter_errors.size).to eq 2
       end
 
-      it 'reports errors for `App` and `Apps` and suggests `app` and `apps`' do
-        expect(linter_errors[0][:message]).to include 'Don\'t use `App`'
-        expect(linter_errors[0][:message]).to include 'Do use `app`'
-        expect(linter_errors[1][:message]).to include 'Don\'t use `Apps`'
-        expect(linter_errors[1][:message]).to include 'Do use `apps`'
-      end
       it 'calculates correct line numbers' do
         expect(linter_errors[0][:line]).to eq(1)
         expect(linter_errors[1][:line]).to eq(2)
       end
     end
 
-    context '- an extra line is present above parent node' do
+    context 'when an extra line is present above parent node' do
       violation_set_1 = 'App'
       suggestion_1 = 'app'
 
@@ -451,7 +420,7 @@ describe ERBLint::Linter::ContentStyle do
       end
     end
 
-    context '- dumb single quote is violation and file has dumb single quote' do
+    context 'when violation is dumb single quote' do
       violation_set_1 = '\''
       suggestion_1 = '’'
 
@@ -477,7 +446,7 @@ describe ERBLint::Linter::ContentStyle do
       end
     end
 
-    context '- violation is regex' do
+    context 'when violation is regex' do
       violation_set_1 = '\D+(-|–|—)\$?\d+'
       suggestion_1 = '– (minus sign) to denote negative numbers'
       pattern_description_1 = '— (em dash), – (en dash), or - (hyphen) to denote negative numbers'
@@ -505,7 +474,7 @@ describe ERBLint::Linter::ContentStyle do
       end
     end
 
-    context 'when an addendum is present' do
+    context 'when addendum is present' do
       violation_set_1 = 'App'
       suggestion_1 = 'app'
       violation_set_2 = 'Apps'
@@ -532,7 +501,7 @@ describe ERBLint::Linter::ContentStyle do
       end
       let(:addendum) { 'Addendum!' }
 
-      context 'when the file is empty' do
+      context 'when file is empty' do
         let(:file) { '' }
 
         it 'does not report any errors' do
@@ -540,7 +509,7 @@ describe ERBLint::Linter::ContentStyle do
         end
       end
 
-      context 'when the file contains a violation' do
+      context 'when file contains violation' do
         let(:file) { <<~FILE }
           <p>All about that App</p>
         FILE
@@ -555,7 +524,7 @@ describe ERBLint::Linter::ContentStyle do
       end
     end
 
-    context 'when an addendum is absent' do
+    context 'when addendum is absent' do
       violation_set_1 = 'App'
       suggestion_1 = 'app'
       violation_set_2 = 'Apps'
@@ -574,7 +543,7 @@ describe ERBLint::Linter::ContentStyle do
         ]
       end
 
-      context 'when the file is empty' do
+      context 'when file is empty' do
         violation_set_1 = 'App'
         suggestion_1 = 'app'
         violation_set_2 = 'Apps'

--- a/spec/erb_lint/linters/content_style_spec.rb
+++ b/spec/erb_lint/linters/content_style_spec.rb
@@ -1,0 +1,625 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ERBLint::Linter::ContentStyle do
+  let(:linter_config) do
+    {
+      'rule_set' => rule_set,
+      'addendum' => 'Questions? Contact Lintercorp Product Content at product-content@lintercorp.com.'
+    }
+  end
+
+  let(:linter) { described_class.new(linter_config) }
+
+  subject(:linter_errors) { linter.lint_file(ERBLint::Parser.parse(file)) }
+
+  context 'when the rule set is empty' do
+    let(:rule_set) { [] }
+
+    context 'when the file is empty' do
+      let(:file) { '' }
+
+      it 'does not report any errors' do
+        expect(linter_errors).to eq []
+      end
+    end
+  end
+
+  context 'when the rule set contains violations' do
+    context '- rule is case-insensitive
+    - file contains violation with different case from suggestion (`Drop down`)
+    - file contains violation with same case as suggestion (`dropdown`)
+    - file contains suggestion (`drop-down`)' do
+      violation_set_1 = ['dropdown', 'drop down']
+      suggestion_1 = 'drop-down'
+      case_insensitive_1 = true
+
+      let(:rule_set) do
+        [
+          {
+            'violation' => violation_set_1,
+            'suggestion' => suggestion_1,
+            'case_insensitive' => case_insensitive_1
+          }
+        ]
+      end
+
+      let(:file) { <<~FILE }
+        <p>Tune in, turn on, and drop-down out! And check out the Drop down and dropdown menu too.</p>
+
+      FILE
+
+      it 'reports 2 errors' do
+        expect(linter_errors.size).to eq 2
+      end
+
+      it 'reports errors for `Drop down` and `dropdown` and suggests `drop-down`' do
+        expect(linter_errors[0][:message]).to include 'Don\'t use `dropdown`'
+        expect(linter_errors[0][:message]).to include 'Do use `drop-down`'
+        expect(linter_errors[1][:message]).to include 'Don\'t use `drop down`'
+        expect(linter_errors[1][:message]).to include 'Do use `drop-down`'
+      end
+    end
+
+    context '- suggestion is prefix + violation (`Lintercorp Help Center`)
+    - file contains suggestion (`Lintercorp Help Center`)
+    - file contains violation (`Help Center`)' do
+      violation_set_1 = ['Help Center', 'help center']
+      suggestion_1 = 'Lintercorp Help Center'
+
+      let(:rule_set) do
+        [
+          {
+            'violation' => violation_set_1,
+            'suggestion' => suggestion_1
+          }
+        ]
+      end
+
+      let(:file) { <<~FILE }
+        <p>Help! I need a Lintercorp Help Center. Not just any Help Center. Help!</p>
+
+      FILE
+
+      it 'reports 1 errors' do
+        expect(linter_errors.size).to eq 1
+      end
+
+      it 'reports error for `Help Center` and suggests `Lintercorp Help Center`' do
+        expect(linter_errors[0][:message]).to include 'Don\'t use `Help Center`'
+        expect(linter_errors[0][:message]).to include 'Do use `Lintercorp Help Center`'
+      end
+    end
+
+    context '- suggestion is prefix + violation (`Lintercorp theme store`)
+    - file contains violation (`theme store`)
+    - file contains violation (`Theme Store`)
+    - violation contains other violations (`Theme Store` contains `Theme` and `Store`)' do
+      # Note that this test will fail if the violations contained within another
+      # violation appear earlier in the rule list than the containing violation.
+      violation_set_1 = ['theme store', 'Theme Store']
+      suggestion_1 = 'Lintercorp theme store'
+      violation_set_2 = 'Theme'
+      suggestion_2 = 'theme'
+      violation_set_3 = 'Themes'
+      suggestion_3 = 'themes'
+      violation_set_4 = 'Store'
+      suggestion_4 = 'store'
+
+      let(:rule_set) do
+        [
+          {
+            'violation' => violation_set_1,
+            'suggestion' => suggestion_1
+          },
+          {
+            'violation' => violation_set_2,
+            'suggestion' => suggestion_2
+          },
+          {
+            'violation' => violation_set_3,
+            'suggestion' => suggestion_3
+          },
+          {
+            'violation' => violation_set_4,
+            'suggestion' => suggestion_4
+          }
+        ]
+      end
+      let(:file) { <<~FILE }
+        <p>The theme store called. They are out of themes at the Theme Store.</p>
+
+      FILE
+
+      it 'reports 2 errors' do
+        expect(linter_errors.size).to eq 2
+      end
+
+      it 'reports errors for `theme store` and `Theme Store` and suggests `Lintercorp theme store`' do
+        expect(linter_errors[0][:message]).to include 'Don\'t use `theme store`'
+        expect(linter_errors[0][:message]).to include 'Do use `Lintercorp theme store`'
+        expect(linter_errors[1][:message]).to include 'Don\'t use `Theme Store`'
+        expect(linter_errors[1][:message]).to include 'Do use `Lintercorp theme store`'
+      end
+    end
+
+    context '- violation starts with uppercase character (`Apps`)
+    - suggestion starts with lowercase character (`apps`)
+    - file contains violation (`Big Apps`)
+    - file contains two potential false positives (the string and a sentence within the string both start
+      with `Apps`)' do
+      violation_set_1 = 'Apps'
+      suggestion_1 = 'apps'
+
+      let(:rule_set) do
+        [
+          {
+            'violation' => violation_set_1,
+            'suggestion' => suggestion_1
+          }
+        ]
+      end
+      let(:file) { <<~FILE }
+        <p>Apps, apps, and away. Big Apps and salutations. Did Britney sing apps, I did it again? Apps a daisy.</p>
+      FILE
+
+      it 'reports 1 errors' do
+        expect(linter_errors.size).to eq 1
+      end
+
+      it 'reports errors for `Apps` and suggests `apps`' do
+        expect(linter_errors[0][:message]).to include 'Don\'t use `Apps`'
+        expect(linter_errors[0][:message]).to include 'Do use `apps`'
+      end
+    end
+
+    context '- violation starts with uppercase character (`App`)
+    - suggestion starts with lowercase character (`app`)
+    - violation (`App`) contained in another violation (`Apps`)
+    - file contains a violation (`Five hundred App`)
+    - file contains two potential false positives
+      (the string and a sentence within the string both start with `App`)' do
+      violation_set_1 = 'App'
+      suggestion_1 = 'app'
+      violation_set_2 = 'Apps'
+      suggestion_2 = 'apps'
+
+      let(:rule_set) do
+        [
+          {
+            'violation' => violation_set_1,
+            'suggestion' => suggestion_1
+          },
+          {
+            'violation' => violation_set_2,
+            'suggestion' => suggestion_2
+          }
+        ]
+      end
+      let(:file) { <<~FILE }
+        <p>App Apply. Five hundred App. App now, time is running out.</p>
+      FILE
+
+      it 'reports 1 errors' do
+        expect(linter_errors.size).to eq 1
+      end
+
+      it 'reports errors for `App` and suggests `app`' do
+        expect(linter_errors[0][:message]).to include 'Don\'t use `App`'
+        expect(linter_errors[0][:message]).to include 'Do use `app`'
+      end
+    end
+
+    context '- violation has multiple words starting with uppercase characters (`Payment Gateways`)
+    - suggestion contains only lowercase characters (`payment gateways`)' do
+      violation_set_1 = 'Payment Gateways'
+      suggestion_1 = 'payment gateways'
+
+      let(:rule_set) do
+        [
+          {
+            'violation' => violation_set_1,
+            'suggestion' => suggestion_1
+          }
+        ]
+      end
+      let(:file) { <<~FILE }
+        <p>Payment Gateways are a gateway drug.</p>
+      FILE
+
+      it 'reports 1 errors' do
+        expect(linter_errors.size).to eq 1
+      end
+
+      it 'reports errors for `Payment Gateways` and suggests `payment gateways`' do
+        expect(linter_errors[0][:message]).to include 'Don\'t use `Payment Gateways`'
+        expect(linter_errors[0][:message]).to include 'Do use `payment gateways`'
+      end
+    end
+
+    context '- violation has multiple words and first word of violation starts with uppercase character (`Lintercorp
+      partner`)
+    - suggestion has multiple words, both starting with uppercase characters (`Lintercorp Partner`)' do
+      violation_set_1 = 'Lintercorp partner'
+      suggestion_1 = 'Lintercorp Partner'
+
+      let(:rule_set) do
+        [
+          {
+            'violation' => violation_set_1,
+            'suggestion' => suggestion_1
+          }
+        ]
+      end
+      let(:file) { <<~FILE }
+        <p>Are you a Lintercorp partner, partner?</p>
+      FILE
+
+      it 'reports 1 errors' do
+        expect(linter_errors.size).to eq 1
+      end
+
+      it 'reports errors for `Lintercorp partner` and suggests `Lintercorp Partner`' do
+        expect(linter_errors[0][:message]).to include 'Don\'t use `Lintercorp partner`'
+        expect(linter_errors[0][:message]).to include 'Do use `Lintercorp Partner`'
+      end
+    end
+
+    context '- file contains violation with a dumb single quote (`Store\'s dashboard`)' do
+      violation_set_1 = 'store\'s dashboard'
+      suggestion_1 = 'Lintercorp dashboard'
+      case_insensitive_1 = true
+
+      let(:rule_set) do
+        [
+          {
+            'violation' => violation_set_1,
+            'suggestion' => suggestion_1,
+            'case_insensitive' => case_insensitive_1
+          }
+        ]
+      end
+      let(:file) { <<~FILE }
+        <p>Welcome to the Store's dashboard.</p>
+      FILE
+
+      it 'reports 1 errors' do
+        expect(linter_errors.size).to eq 1
+      end
+
+      it 'reports errors for `store\'s dashboard` and suggests `Lintercorp dashboard`' do
+        expect(linter_errors[0][:message]).to include 'Don\'t use `store\'s dashboard`'
+        expect(linter_errors[0][:message]).to include 'Do use `Lintercorp dashboard`'
+      end
+    end
+
+    context '- violation has a smart single quote (`Store’s dashboard`)
+    - violation contained in prior violation' do
+      violation_set_1 = 'store’s dashboard'
+      suggestion_1 = 'Lintercorp dashboard'
+      case_insensitive_1 = true
+
+      let(:rule_set) do
+        [
+          {
+            'violation' => violation_set_1,
+            'suggestion' => suggestion_1,
+            'case_insensitive' => case_insensitive_1
+          }
+        ]
+      end
+      let(:file) { <<~FILE }
+        <p>Welcome to the Store’s dashboard.</p>
+      FILE
+
+      it 'reports 1 errors' do
+        expect(linter_errors.size).to eq 1
+      end
+
+      it 'reports errors for `store’s dashboard` and suggests `Lintercorp dashboard`' do
+        expect(linter_errors[0][:message]).to include 'Don\'t use `store’s dashboard`'
+        expect(linter_errors[0][:message]).to include 'Do use `Lintercorp dashboard`'
+      end
+    end
+
+    context '- file has a dumb double quote (`"backend store dashboard`)' do
+      violation_set_1 = 'backend store dashboard'
+      suggestion_1 = 'Lintercorp dashboard'
+      case_insensitive_1 = true
+
+      let(:rule_set) do
+        [
+          {
+            'violation' => violation_set_1,
+            'suggestion' => suggestion_1,
+            'case_insensitive' => case_insensitive_1
+          }
+        ]
+      end
+      let(:file) { <<~FILE }
+        <p>The "backend store dashboard is not what it seems.</p>
+      FILE
+
+      it 'reports 1 errors' do
+        expect(linter_errors.size).to eq 1
+      end
+
+      it 'reports errors for `backend store dashboard` and suggests `Lintercorp dashboard`' do
+        expect(linter_errors[0][:message]).to include 'Don\'t use `backend store dashboard`'
+        expect(linter_errors[0][:message]).to include 'Do use `Lintercorp dashboard`'
+      end
+    end
+
+    context '- text node starts on line after parent' do
+      violation_set_1 = 'Lintercorp Plus client'
+      suggestion_1 = 'Lintercorp Plus merchant'
+      case_insensitive_1 = true
+      violation_set_2 = 'Lintercorp plus'
+      suggestion_2 = 'Lintercorp Plus'
+      case_insensitive_2 = false
+
+      let(:rule_set) do
+        [
+          {
+            'violation' => violation_set_1,
+            'suggestion' => suggestion_1,
+            'case_insensitive' => case_insensitive_1
+          },
+          {
+            'violation' => violation_set_2,
+            'suggestion' => suggestion_2,
+            'case_insensitive' => case_insensitive_2
+          }
+        ]
+      end
+      let(:file) { <<~FILE }
+        <p>
+        The Lintercorp Plus client is upset.
+        </p>
+      FILE
+
+      it 'reports 1 errors' do
+        expect(linter_errors.size).to eq 1
+      end
+
+      it 'reports errors for `Lintercorp Plus client` and suggests `Lintercorp Plus merchant`' do
+        expect(linter_errors[0][:message]).to include 'Don\'t use `Lintercorp Plus client`'
+        expect(linter_errors[0][:message]).to include 'Do use `Lintercorp Plus merchant`'
+      end
+      it 'calculates the correct line number' do
+        expect(linter_errors[0][:line]).to eq(2)
+      end
+    end
+
+    context '- text node has multiple lines' do
+      # This test will only handle following lines once we build in multiline functionality
+      violation_set_1 = 'App'
+      suggestion_1 = 'app'
+      violation_set_2 = 'Apps'
+      suggestion_2 = 'apps'
+
+      let(:rule_set) do
+        [
+          {
+            'violation' => violation_set_1,
+            'suggestion' => suggestion_1
+          },
+          {
+            'violation' => violation_set_2,
+            'suggestion' => suggestion_2
+          }
+        ]
+      end
+      let(:file) { <<~FILE }
+        <p>
+
+        The App is not what it seems.
+        The Apps are not what they seem.
+        </p>
+      FILE
+
+      it 'strips the content after the first line and reports only 1 error' do
+        expect(linter_errors.size).to eq 1
+      end
+
+      it 'reports an error for `App` and suggests `app`' do
+        expect(linter_errors[0][:message]).to include 'Don\'t use `App`'
+        expect(linter_errors[0][:message]).to include 'Do use `app`'
+      end
+      it 'calculates a correct first line number' do
+        expect(linter_errors[0][:line]).to eq(3)
+      end
+    end
+
+    context '- text node starts on same line as parent but has multiple lines' do
+      # This test will only handle following lines once we build in multiline functionality
+      violation_set_1 = 'App'
+      suggestion_1 = 'app'
+      violation_set_2 = 'Apps'
+      suggestion_2 = 'apps'
+
+      let(:rule_set) do
+        [
+          {
+            'violation' => violation_set_1,
+            'suggestion' => suggestion_1
+          },
+          {
+            'violation' => violation_set_2,
+            'suggestion' => suggestion_2
+          }
+        ]
+      end
+      let(:file) { <<~FILE }
+        <p>The App is not what it seems.
+        The Apps are not what they seem.
+        </p>
+      FILE
+
+      it 'strips the content after the first line and reports only 1 error' do
+        expect(linter_errors.size).to eq 1
+      end
+
+      it 'reports an error for `App` and suggests `app`' do
+        expect(linter_errors[0][:message]).to include 'Don\'t use `App`'
+        expect(linter_errors[0][:message]).to include 'Do use `app`'
+      end
+      it 'calculates a correct first line number' do
+        expect(linter_errors[0][:line]).to eq(1)
+      end
+    end
+
+    context '- dumb single quote is violation and file has dumb single quote' do
+      violation_set_1 = '\''
+      suggestion_1 = '’'
+
+      let(:rule_set) do
+        [
+          {
+            'violation' => violation_set_1,
+            'suggestion' => suggestion_1
+          }
+        ]
+      end
+      let(:file) { <<~FILE }
+      The 'App' is not what it seems.
+      FILE
+
+      it 'reports 1 error' do
+        expect(linter_errors.size).to eq 1
+      end
+
+      it 'reports an error for `\'` and suggests `’`' do
+        expect(linter_errors[0][:message]).to include 'Don\'t use `\'`'
+        expect(linter_errors[0][:message]).to include 'Do use `’`'
+      end
+    end
+
+    context '- violation is regex' do
+      violation_set_1 = '\D+(-|–|—)\$?\d+'
+      suggestion_1 = '– (minus sign) to denote negative numbers'
+      regex_description_1 = '— (em dash), – (en dash), or - (hyphen) to denote negative numbers'
+
+      let(:rule_set) do
+        [
+          {
+            'violation' => violation_set_1,
+            'suggestion' => suggestion_1,
+            'regex_description' => regex_description_1
+          }
+        ]
+      end
+      let(:file) { <<~FILE }
+      The -65 and the –$65
+      FILE
+
+      it 'reports 1 error' do
+        expect(linter_errors.size).to eq 1
+      end
+
+      it 'reports an error for `– (en dash) or - (hyphen)` and suggests `– (minus sign)`' do
+        expect(linter_errors[0][:message]).to include 'Don\'t use `— (em dash), – (en dash), or - (hyphen)'
+        expect(linter_errors[0][:message]).to include 'Do use `– (minus sign) to denote negative numbers`'
+      end
+    end
+
+    context 'when an addendum is present' do
+      violation_set_1 = 'App'
+      suggestion_1 = 'app'
+      violation_set_2 = 'Apps'
+      suggestion_2 = 'apps'
+
+      let(:linter_config) do
+        {
+          'rule_set' => rule_set,
+          'addendum' => addendum
+        }
+      end
+
+      let(:rule_set) do
+        [
+          {
+            'violation' => violation_set_1,
+            'suggestion' => suggestion_1
+          },
+          {
+            'violation' => violation_set_2,
+            'suggestion' => suggestion_2
+          }
+        ]
+      end
+      let(:addendum) { 'Addendum!' }
+
+      context 'when the file is empty' do
+        let(:file) { '' }
+
+        it 'does not report any errors' do
+          expect(linter_errors).to eq []
+        end
+      end
+
+      context 'when the file contains a violation' do
+        let(:file) { <<~FILE }
+          <p>All about that App</p>
+        FILE
+
+        it 'reports 1 error' do
+          expect(linter_errors.size).to eq 1
+        end
+
+        it 'reports an error with its message ending with the addendum' do
+          expect(linter_errors.first[:message]).to end_with addendum
+        end
+      end
+    end
+
+    context 'when an addendum is absent' do
+      violation_set_1 = 'App'
+      suggestion_1 = 'app'
+      violation_set_2 = 'Apps'
+      suggestion_2 = 'apps'
+
+      let(:rule_set) do
+        [
+          {
+            'violation' => violation_set_1,
+            'suggestion' => suggestion_1
+          },
+          {
+            'violation' => violation_set_2,
+            'suggestion' => suggestion_2
+          }
+        ]
+      end
+
+      context 'when the file is empty' do
+        violation_set_1 = 'App'
+        suggestion_1 = 'app'
+        violation_set_2 = 'Apps'
+        suggestion_2 = 'apps'
+        let(:linter_config) do
+          {
+            'rule_set' => rule_set
+          }
+        end
+        let(:rule_set) do
+          [
+            {
+              'violation' => violation_set_1,
+              'suggestion' => suggestion_1
+            },
+            {
+              'violation' => violation_set_2,
+              'suggestion' => suggestion_2
+            }
+          ]
+        end
+        let(:file) { '' }
+        it 'does not report any errors' do
+          expect(linter_errors).to eq []
+        end
+      end
+    end
+  end
+end

--- a/spec/erb_lint/linters/content_style_spec.rb
+++ b/spec/erb_lint/linters/content_style_spec.rb
@@ -28,23 +28,22 @@ describe ERBLint::Linter::ContentStyle do
 
   context 'when rule set and file contain violations' do
     context 'when rule is case-insensitive and file contains violations in different cases' do
-      violation_set_1 = ['dropdown', 'drop down']
-      suggestion_1 = 'drop-down'
-      case_insensitive_1 = true
+      violation_set = ['dropdown', 'drop down']
+      suggestion = 'drop-down'
+      case_insensitive = true
 
       let(:rule_set) do
         [
           {
-            'violation' => violation_set_1,
-            'suggestion' => suggestion_1,
-            'case_insensitive' => case_insensitive_1
+            'violation' => violation_set,
+            'suggestion' => suggestion,
+            'case_insensitive' => case_insensitive
           }
         ]
       end
 
       let(:file) { <<~FILE }
         <p>Tune in, turn on, and drop-down out! And check out the Drop down and dropdown menu too.</p>
-
       FILE
 
       it 'reports 2 errors' do
@@ -60,21 +59,20 @@ describe ERBLint::Linter::ContentStyle do
     end
 
     context 'when suggestion is prefix + violation' do
-      violation_set_1 = ['Help Center', 'help center']
-      suggestion_1 = 'Lintercorp Help Center'
+      violation_set = ['Help Center', 'help center']
+      suggestion = 'Lintercorp Help Center'
 
       let(:rule_set) do
         [
           {
-            'violation' => violation_set_1,
-            'suggestion' => suggestion_1
+            'violation' => violation_set,
+            'suggestion' => suggestion
           }
         ]
       end
 
       let(:file) { <<~FILE }
         <p>Help! I need a Lintercorp Help Center. Not just any Help Center. Help!</p>
-
       FILE
 
       it 'reports 1 errors' do
@@ -88,14 +86,14 @@ describe ERBLint::Linter::ContentStyle do
     end
 
     context 'when violation starts with uppercase and suggestion starts with lowercase' do
-      violation_set_1 = 'Apps'
-      suggestion_1 = 'apps'
+      violation_set = 'Apps'
+      suggestion = 'apps'
 
       let(:rule_set) do
         [
           {
-            'violation' => violation_set_1,
-            'suggestion' => suggestion_1
+            'violation' => violation_set,
+            'suggestion' => suggestion
           }
         ]
       end
@@ -146,14 +144,14 @@ describe ERBLint::Linter::ContentStyle do
     end
 
     context 'when violation is compound word starting with uppercase and suggestion starts with lowercase' do
-      violation_set_1 = 'Payment Gateways'
-      suggestion_1 = 'payment gateways'
+      violation_set = 'Payment Gateways'
+      suggestion = 'payment gateways'
 
       let(:rule_set) do
         [
           {
-            'violation' => violation_set_1,
-            'suggestion' => suggestion_1
+            'violation' => violation_set,
+            'suggestion' => suggestion
           }
         ]
       end
@@ -172,14 +170,14 @@ describe ERBLint::Linter::ContentStyle do
     end
 
     context 'when violation and suggestion are compound words starting with uppercase' do
-      violation_set_1 = 'Lintercorp partner'
-      suggestion_1 = 'Lintercorp Partner'
+      violation_set = 'Lintercorp partner'
+      suggestion = 'Lintercorp Partner'
 
       let(:rule_set) do
         [
           {
-            'violation' => violation_set_1,
-            'suggestion' => suggestion_1
+            'violation' => violation_set,
+            'suggestion' => suggestion
           }
         ]
       end
@@ -197,17 +195,17 @@ describe ERBLint::Linter::ContentStyle do
       end
     end
 
-    context 'when violation contains single dumb quote' do
-      violation_set_1 = 'store\'s dashboard'
-      suggestion_1 = 'Lintercorp dashboard'
-      case_insensitive_1 = true
+    context 'when violation contains single quote' do
+      violation_set = 'store\'s dashboard'
+      suggestion = 'Lintercorp dashboard'
+      case_insensitive = true
 
       let(:rule_set) do
         [
           {
-            'violation' => violation_set_1,
-            'suggestion' => suggestion_1,
-            'case_insensitive' => case_insensitive_1
+            'violation' => violation_set,
+            'suggestion' => suggestion,
+            'case_insensitive' => case_insensitive
           }
         ]
       end
@@ -226,16 +224,16 @@ describe ERBLint::Linter::ContentStyle do
     end
 
     context 'when violation contains single smart quote' do
-      violation_set_1 = 'store’s dashboard'
-      suggestion_1 = 'Lintercorp dashboard'
-      case_insensitive_1 = true
+      violation_set = 'store’s dashboard'
+      suggestion = 'Lintercorp dashboard'
+      case_insensitive = true
 
       let(:rule_set) do
         [
           {
-            'violation' => violation_set_1,
-            'suggestion' => suggestion_1,
-            'case_insensitive' => case_insensitive_1
+            'violation' => violation_set,
+            'suggestion' => suggestion,
+            'case_insensitive' => case_insensitive
           }
         ]
       end
@@ -253,17 +251,17 @@ describe ERBLint::Linter::ContentStyle do
       end
     end
 
-    context 'when file contains double dumb quote' do
-      violation_set_1 = 'backend store dashboard'
-      suggestion_1 = 'Lintercorp dashboard'
-      case_insensitive_1 = true
+    context 'when file contains double quote' do
+      violation_set = 'backend store dashboard'
+      suggestion = 'Lintercorp dashboard'
+      case_insensitive = true
 
       let(:rule_set) do
         [
           {
-            'violation' => violation_set_1,
-            'suggestion' => suggestion_1,
-            'case_insensitive' => case_insensitive_1
+            'violation' => violation_set,
+            'suggestion' => suggestion,
+            'case_insensitive' => case_insensitive
           }
         ]
       end
@@ -393,14 +391,14 @@ describe ERBLint::Linter::ContentStyle do
     end
 
     context 'when an extra line is present above parent node' do
-      violation_set_1 = 'App'
-      suggestion_1 = 'app'
+      violation_set = 'App'
+      suggestion = 'app'
 
       let(:rule_set) do
         [
           {
-            'violation' => violation_set_1,
-            'suggestion' => suggestion_1
+            'violation' => violation_set,
+            'suggestion' => suggestion
           }
         ]
       end
@@ -420,15 +418,15 @@ describe ERBLint::Linter::ContentStyle do
       end
     end
 
-    context 'when violation is dumb single quote' do
-      violation_set_1 = '\''
-      suggestion_1 = '’'
+    context 'when violation is single quote' do
+      violation_set = '\''
+      suggestion = '’'
 
       let(:rule_set) do
         [
           {
-            'violation' => violation_set_1,
-            'suggestion' => suggestion_1
+            'violation' => violation_set,
+            'suggestion' => suggestion
           }
         ]
       end
@@ -447,16 +445,16 @@ describe ERBLint::Linter::ContentStyle do
     end
 
     context 'when violation is regex' do
-      violation_set_1 = '\D+(-|–|—)\$?\d+'
-      suggestion_1 = '– (minus sign) to denote negative numbers'
-      pattern_description_1 = '— (em dash), – (en dash), or - (hyphen) to denote negative numbers'
+      violation_set = '\D+(-|–|—)\$?\d+'
+      suggestion = '– (minus sign) to denote negative numbers'
+      pattern_description = '— (em dash), – (en dash), or - (hyphen) to denote negative numbers'
 
       let(:rule_set) do
         [
           {
-            'violation' => violation_set_1,
-            'suggestion' => suggestion_1,
-            'pattern_description' => pattern_description_1
+            'violation' => violation_set,
+            'suggestion' => suggestion,
+            'pattern_description' => pattern_description
           }
         ]
       end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Check .html.erb files for content style guide violations in a manner that can integrate with [Policial](https://github.com/volmer/policial).


**How?**

Add a new linter, ContentStyle, to erb-lint that checks the text content between HTML tags against a ruleset. The ruleset comes from the same .yml config file already used by erb-lint.

**What could go wrong? (if anything)**

Policial could slow down or hang.

**Rollback steps**

- [x] It is safe to simply rollback this change.

@justinthec
