### PR TITLE
Suppress invalid html errors

### DIFF
--- a/lib/erb_lint/parser.rb
+++ b/lib/erb_lint/parser.rb
@@ -148,10 +148,9 @@ module ERBLint
         # in the future we would ideally parse out the erb tags into real nodes and assign line numbers
       end
 
-      def ensure_valid_tree(file_tree)
-        if file_tree.children.empty? || file_tree.children.last.name != END_MARKER_NAME
-          raise ParseError, 'File could not be successfully parsed. Ensure all tags are properly closed.'
-        end
+      # Temporarily suppressing invalid HTML errors because nokogiri is raising lots of false positives
+      def ensure_valid_tree(_file_tree)
+        true
       end
     end
 

--- a/spec/erb_lint/parser_spec.rb
+++ b/spec/erb_lint/parser_spec.rb
@@ -216,19 +216,6 @@ describe ERBLint::Parser do
         end
       end
     end
-
-    context 'when tags are not properly closed' do
-      let(:file) { <<~FILE.chomp }
-        <div>
-      FILE
-
-      it 'raises a general parsing error' do
-        expect { described_class.parse(file) }.to raise_error(
-          described_class::ParseError,
-          'File could not be successfully parsed. Ensure all tags are properly closed.'
-        )
-      end
-    end
   end
 
   describe '#file_is_empty?' do


### PR DESCRIPTION
Nokogiri is raising false invalid HTML errors. Temporarily suppressing HTML errors so we can continue to test the content linting.

@justinthec @nwtn @stariqmi 