### PR TITLE
pluralize Linter

### DIFF
--- a/lib/erb_lint/linter.rb
+++ b/lib/erb_lint/linter.rb
@@ -8,10 +8,10 @@ module ERBLint
 
       # When defining a Linter class, define its simple name as well. This
       # assumes that the module hierarchy of every linter starts with
-      # `ERBLint::Linter::`, and removes this part of the class name.
+      # `ERBLint::Linters::`, and removes this part of the class name.
       #
-      # `ERBLint::Linter::Foo.simple_name`          #=> "Foo"
-      # `ERBLint::Linter::Compass::Bar.simple_name` #=> "Compass::Bar"
+      # `ERBLint::Linters::Foo.simple_name`          #=> "Foo"
+      # `ERBLint::Linters::Compass::Bar.simple_name` #=> "Compass::Bar"
       def inherited(linter)
         name_parts = linter.name.split('::')
         name = name_parts.length < 3 ? '' : name_parts[2..-1].join('::')

--- a/lib/erb_lint/linters/deprecated_classes.rb
+++ b/lib/erb_lint/linters/deprecated_classes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ERBLint
-  class Linter
+  module Linters
     # Checks for deprecated classes in the start tags of HTML elements.
     class DeprecatedClasses < Linter
       include LinterRegistry

--- a/lib/erb_lint/linters/final_newline.rb
+++ b/lib/erb_lint/linters/final_newline.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ERBLint
-  class Linter
+  module Linters
     # Checks for final newlines at the end of a file.
     class FinalNewline < Linter
       include LinterRegistry

--- a/spec/erb_lint/fixtures/custom_linter.rb
+++ b/spec/erb_lint/fixtures/custom_linter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ERBLint
-  class Linter
+  module Linters
     class CustomLinter < Linter
       include LinterRegistry
     end

--- a/spec/erb_lint/linter_spec.rb
+++ b/spec/erb_lint/linter_spec.rb
@@ -5,10 +5,10 @@ require 'spec_helper'
 describe ERBLint::Linter do
   context 'when inheriting from the Linter class' do
     let(:linter_config) { {} }
-    subject             { ERBLint::Linter::Fake.new(linter_config) }
+    subject             { ERBLint::Linters::Fake.new(linter_config) }
 
     module ERBLint
-      class Linter
+      module Linters
         class Fake < ERBLint::Linter
           def initialize(_config)
           end

--- a/spec/erb_lint/linters/deprecated_classes_spec.rb
+++ b/spec/erb_lint/linters/deprecated_classes_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe ERBLint::Linter::DeprecatedClasses do
+describe ERBLint::Linters::DeprecatedClasses do
   let(:linter_config) do
     {
       'rule_set' => rule_set

--- a/spec/erb_lint/linters/final_newline_spec.rb
+++ b/spec/erb_lint/linters/final_newline_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe ERBLint::Linter::FinalNewline do
+describe ERBLint::Linters::FinalNewline do
   let(:linter_config) { { 'present' => present } }
 
   let(:linter) { described_class.new(linter_config) }

--- a/spec/erb_lint/runner_spec.rb
+++ b/spec/erb_lint/runner_spec.rb
@@ -7,13 +7,13 @@ describe ERBLint::Runner do
 
   before do
     allow(ERBLint::LinterRegistry).to receive(:linters)
-      .and_return([ERBLint::Linter::FakeLinter1,
-                   ERBLint::Linter::FakeLinter2,
-                   ERBLint::Linter::FinalNewline])
+      .and_return([ERBLint::Linters::FakeLinter1,
+                   ERBLint::Linters::FakeLinter2,
+                   ERBLint::Linters::FinalNewline])
   end
 
   module ERBLint
-    class Linter
+    module Linters
       class FakeLinter1 < Linter
         def initialize(_config) end
       end
@@ -33,11 +33,11 @@ describe ERBLint::Runner do
     fake_final_newline_errors = ['FakeFinalNewlineDummyErrors']
 
     before do
-      allow_any_instance_of(ERBLint::Linter::FakeLinter1).to receive(:lint_file)
+      allow_any_instance_of(ERBLint::Linters::FakeLinter1).to receive(:lint_file)
         .with(file).and_return fake_linter_1_errors
-      allow_any_instance_of(ERBLint::Linter::FakeLinter2).to receive(:lint_file)
+      allow_any_instance_of(ERBLint::Linters::FakeLinter2).to receive(:lint_file)
         .with(file).and_return fake_linter_2_errors
-      allow_any_instance_of(ERBLint::Linter::FinalNewline).to receive(:lint_file)
+      allow_any_instance_of(ERBLint::Linters::FinalNewline).to receive(:lint_file)
         .with(file).and_return fake_final_newline_errors
     end
 


### PR DESCRIPTION
Right now all linters are nested in the `ERBLint::Linter::` namespace but also inherit from the class `ERBLint::Linter`. This makes linters inherit from `ERBLint::Linters` (pluralized) and makes that a module instead.

@jeremyhansonfinger @nwtn 