### PR TITLE
Use better-html gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,7 @@ source 'https://rubygems.org'
 
 gem 'rubocop', '~> 0.40.0', require: false
 
+gem 'better_html'
+gem 'html_tokenizer'
+
 gemspec

--- a/erb_lint.gemspec
+++ b/erb_lint.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'html_tokenizer'
   s.add_dependency 'better_html'
+  s.add_dependency 'activesupport', '~> 5.1'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'
-  s.add_development_dependency 'activesupport', '~> 5.1'
 end

--- a/erb_lint.gemspec
+++ b/erb_lint.gemspec
@@ -12,6 +12,10 @@ Gem::Specification.new do |s|
 
   s.files = Dir['lib/**/*.rb']
 
+  s.add_dependency 'html_tokenizer'
+  s.add_dependency 'better_html'
+
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'activesupport', '~> 5.1'
 end

--- a/erb_lint.gemspec
+++ b/erb_lint.gemspec
@@ -13,8 +13,7 @@ Gem::Specification.new do |s|
   s.files = Dir['lib/**/*.rb']
 
   s.add_dependency 'html_tokenizer'
-  s.add_dependency 'better_html'
-  s.add_dependency 'activesupport', '~> 5.1'
+  s.add_dependency 'better_html', '~> 0.0.5'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'

--- a/lib/erb_lint/linters/deprecated_classes.rb
+++ b/lib/erb_lint/linters/deprecated_classes.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-require 'active_support'
-require 'active_support/core_ext/module/delegation'
-require 'active_support/core_ext/class/attribute_accessors'
-require 'better_html/node_iterator'
+require 'better_html'
 
 module ERBLint
   module Linters

--- a/lib/erb_lint/linters/deprecated_classes.rb
+++ b/lib/erb_lint/linters/deprecated_classes.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support'
 require 'active_support/core_ext/module/delegation'
 require 'active_support/core_ext/class/attribute_accessors'
 require 'better_html/node_iterator'

--- a/lib/erb_lint/linters/deprecated_classes.rb
+++ b/lib/erb_lint/linters/deprecated_classes.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'active_support/core_ext/module/delegation'
+require 'active_support/core_ext/class/attribute_accessors'
+require 'better_html/node_iterator'
+
 module ERBLint
   module Linters
     # Checks for deprecated classes in the start tags of HTML elements.
@@ -22,25 +26,32 @@ module ERBLint
         @addendum = config.fetch('addendum', '')
       end
 
-      protected
-
-      def lint_lines(lines)
+      def lint_file(file_content)
         errors = []
-
-        lines.each_with_index do |line, index|
-          start_tags = StartTagHelper.start_tags(line)
-          start_tags.each do |start_tag|
-            start_tag.attributes.select(&:class?).each do |class_attr|
-              class_attr.value.split(' ').each do |class_name|
-                errors.push(*generate_errors(class_name, index + 1))
-              end
-            end
-          end
+        iterator = BetterHtml::NodeIterator.new(file_content, template_language: :html)
+        each_class_name(iterator) do |class_name, line|
+          errors.push(*generate_errors(class_name, line))
         end
         errors
       end
 
       private
+
+      def each_class_name(iterator)
+        each_element(iterator) do |element|
+          klass = element.find_attr('class')
+          next unless klass
+          klass.value_without_quotes.split(' ').each do |class_name|
+            yield class_name, klass.name_parts.first.location.line
+          end
+        end
+      end
+
+      def each_element(iterator)
+        iterator.nodes.each do |node|
+          yield node if node.element?
+        end
+      end
 
       def generate_errors(class_name, line_number)
         violated_rules(class_name).map do |violated_rule|
@@ -56,110 +67,6 @@ module ERBLint
       def violated_rules(class_name)
         @deprecated_ruleset.select do |deprecated_rule|
           /\A#{deprecated_rule[:class_expr]}\z/.match(class_name)
-        end
-      end
-    end
-
-    # Provides methods and classes for finding HTML start tags and their attributes.
-    module StartTagHelper
-      # These patterns cover a superset of the W3 HTML5 specification.
-      # Additional cases not included in the spec include those that are still rendered by some browsers.
-
-      # Attribute Patterns
-      # https://www.w3.org/TR/html5/syntax.html#syntax-attributes
-
-      # attribute names must be non empty and can't contain a certain set of special characters
-      ATTRIBUTE_NAME_PATTERN = %r{[^\s"'>\/=]+}
-
-      ATTRIBUTE_VALUE_PATTERN = %r{
-        "([^"]*)" |           # double-quoted value
-        '([^']*)' |           # single-quoted value
-        ([^\s"'=<>`]+)        # unquoted non-empty value without special characters
-      }x
-
-      # attributes can be empty or have an attribute value
-      ATTRIBUTE_PATTERN = %r{
-        #{ATTRIBUTE_NAME_PATTERN}        # attribute name
-        (
-          \s*=\s*                        # any whitespace around equals sign
-          (#{ATTRIBUTE_VALUE_PATTERN})   # attribute value
-        )?                               # attributes can be empty or have an assignemnt.
-      }x
-
-      # Start tag Patterns
-      # https://www.w3.org/TR/html5/syntax.html#syntax-start-tag
-
-      TAG_NAME_PATTERN = /[A-Za-z0-9]+/ # maybe add _ < ? etc later since it gets interpreted by some browsers
-
-      START_TAG_PATTERN = %r{
-        <(#{TAG_NAME_PATTERN})         # start of tag with tag name
-        (
-          (
-            \s+                        # required whitespace between tag name and first attribute and between attributes
-            #{ATTRIBUTE_PATTERN}       # attributes
-          )*
-        )?                             # having an attribute block is optional
-        \/?>                           # void or foreign elements can have a slash before tag close
-      }x
-
-      # Represents and provides an interface for a start tag found in the HTML.
-      class StartTag
-        attr_accessor :tag_name, :attributes
-
-        def initialize(tag_name, attributes)
-          @tag_name = tag_name
-          @attributes = attributes
-        end
-      end
-
-      # Represents and provides an interface for an attribute found in a start tag in the HTML.
-      class Attribute
-        ATTR_NAME_CLASS_PATTERN = /\Aclass\z/i # attribute names are case-insensitive
-        attr_accessor :attribute_name, :value
-
-        def initialize(attribute_name, value)
-          @attribute_name = attribute_name
-          @value = value
-        end
-
-        def class?
-          ATTR_NAME_CLASS_PATTERN.match(@attribute_name)
-        end
-      end
-
-      class << self
-        def start_tags(line)
-          # TODO: Implement String Scanner to track quotes before the start tag begins to ensure that it is
-          #       not enclosed inside of a string. Alternatively this problem would be solved by using
-          #       a 3rd party parser like Nokogiri::XML
-
-          start_tag_matching_groups = line.scan(/(#{START_TAG_PATTERN})/)
-          start_tag_matching_groups.map do |start_tag_matching_group|
-            tag_name = start_tag_matching_group[1]
-
-            # attributes_string can be nil if there is no space after the tag name (and therefore no attributes).
-            attributes_string = start_tag_matching_group[2] || ''
-
-            attribute_list = attributes(attributes_string)
-
-            StartTag.new(tag_name, attribute_list)
-          end
-        end
-
-        private
-
-        def attributes(attributes_string)
-          attributes_string.scan(/(#{ATTRIBUTE_PATTERN})/).map do |attribute_matching_group|
-            entire_string = attribute_matching_group[0]
-            value_with_equal_sign = attribute_matching_group[1] || '' # This can be nil if attribute is empty
-            name = entire_string.sub(value_with_equal_sign, '')
-
-            # The 3 captures [3..5] are the possibilities specified in ATTRIBUTE_VALUE_PATTERN
-            possible_value_formats = attribute_matching_group[3..5]
-            value = possible_value_formats.reduce { |a, e| a.nil? ? e : a }
-
-            Attribute.new(name, value)
-          end
         end
       end
     end

--- a/lib/erb_lint/linters/deprecated_classes.rb
+++ b/lib/erb_lint/linters/deprecated_classes.rb
@@ -46,7 +46,7 @@ module ERBLint
       end
 
       def each_class_name_with_line(iterator)
-        each_element_with_index(iterator) do |element, index|
+        each_element_with_index(iterator) do |element, _index|
           klass = element.find_attr('class')
           next unless klass
           klass.value_without_quotes.split(' ').each do |class_name|
@@ -67,9 +67,8 @@ module ERBLint
           next unless type
           next unless 'text/html' == type.value_without_quotes
           next_node = iterator.nodes[index + 1]
-          if next_node&.text?
-            yield next_node
-          end
+
+          yield next_node if next_node&.text?
         end
       end
 

--- a/spec/erb_lint/linters/deprecated_classes_spec.rb
+++ b/spec/erb_lint/linters/deprecated_classes_spec.rb
@@ -92,6 +92,24 @@ describe ERBLint::Linters::DeprecatedClasses do
       end
     end
 
+    context 'when the file contains nested html content' do
+      let(:file) { <<~FILE }
+        <script type="text/html">
+          <div class="#{deprecated_set_1.first}">
+            Content
+          </div>
+        </script>
+      FILE
+
+      it 'reports 1 error' do
+        expect(linter_errors.size).to eq 1
+      end
+
+      it 'reports an error with message containing suggestion 1' do
+        expect(linter_errors.first[:message]).to include suggestion_1
+      end
+    end
+
     context 'when the file contains both classes from set 1' do
       context 'when both classes are on the same tag' do
         let(:file) { <<~FILE }


### PR DESCRIPTION
This rewrites the Deprecated Classes linter to use `better-html` which is a ERB-aware html parser that I wrote some time ago. I would like to use this parser in other linters too.

@jeremyhansonfinger @nwtn 