### PR TITLE
Allow overridable better html config via yml file

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     erb_lint (0.0.7)
-      better_html (~> 0.0.5)
+      better_html (~> 0.0.10)
       html_tokenizer
       rubocop
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,11 +21,13 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     ast (2.3.0)
-    better_html (0.0.9)
+    better_html (0.0.10)
       actionview (>= 4.0)
       activesupport (>= 4.0)
       erubi (~> 1.4)
+      html_tokenizer
       parser (>= 2.4)
+      smart_properties
     builder (3.2.3)
     concurrent-ruby (1.0.5)
     crass (1.0.2)
@@ -74,6 +76,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
+    smart_properties (1.13.0)
     thread_safe (0.3.6)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
@@ -90,4 +93,4 @@ DEPENDENCIES
   rubocop (~> 0.50.0)
 
 BUNDLED WITH
-   1.16.0.pre.3
+   1.16.0

--- a/erb_lint.gemspec
+++ b/erb_lint.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['lib/**/*.rb']
 
-  s.add_dependency 'better_html', '~> 0.0.5'
+  s.add_dependency 'better_html', '~> 0.0.10'
   s.add_dependency 'html_tokenizer'
   s.add_dependency 'rubocop'
 

--- a/lib/erb_lint.rb
+++ b/lib/erb_lint.rb
@@ -3,6 +3,7 @@
 require 'erb_lint/linter_registry'
 require 'erb_lint/linter'
 require 'erb_lint/runner'
+require 'erb_lint/file_loader'
 
 # Load linters
 Dir[File.expand_path('erb_lint/linters/**/*.rb', File.dirname(__FILE__))].each do |file|

--- a/lib/erb_lint/file_loader.rb
+++ b/lib/erb_lint/file_loader.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module ERBLint
+  # Loads file from disk
   class FileLoader
     attr_reader :base_path
 
@@ -21,7 +22,7 @@ module ERBLint
     end
 
     def read_content(filename)
-      File.read(join(base_path, filename))
+      File.read(join(filename))
     end
   end
 end

--- a/lib/erb_lint/file_loader.rb
+++ b/lib/erb_lint/file_loader.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module ERBLint
+  class FileLoader
+    attr_reader :base_path
+
+    def initialize(base_path)
+      @base_path = base_path
+    end
+
+    def yaml(filename)
+      YAML.safe_load(read_content(filename), [Regexp], [], false, filename) || {}
+    rescue Psych::SyntaxError
+      {}
+    end
+
+    private
+
+    def join(filename)
+      File.join(base_path, filename)
+    end
+
+    def read_content(filename)
+      File.read(join(base_path, filename))
+    end
+  end
+end

--- a/lib/erb_lint/linter.rb
+++ b/lib/erb_lint/linter.rb
@@ -20,8 +20,8 @@ module ERBLint
     end
 
     # Must be implemented by the concrete inheriting class.
-    def initialize(_config)
-      raise NotImplementedError, "must implement ##{__method__}"
+    def initialize(file_loader, _config)
+      @file_loader = file_loader
     end
 
     def lint_file(file_content)

--- a/lib/erb_lint/linters/deprecated_classes.rb
+++ b/lib/erb_lint/linters/deprecated_classes.rb
@@ -8,7 +8,9 @@ module ERBLint
     class DeprecatedClasses < Linter
       include LinterRegistry
 
-      def initialize(config)
+      def initialize(file_loader, config)
+        super
+
         @deprecated_ruleset = []
         config.fetch('rule_set', []).each do |rule|
           suggestion = rule.fetch('suggestion', '')

--- a/lib/erb_lint/linters/erb_safety.rb
+++ b/lib/erb_lint/linters/erb_safety.rb
@@ -17,7 +17,7 @@ module ERBLint
 
       def lint_file(file_content)
         errors = []
-        tester = Tester.new(file_content, config: config)
+        tester = Tester.new(file_content, config: better_html_config)
         tester.errors.each do |error|
           errors << format_error(error)
         end
@@ -26,12 +26,12 @@ module ERBLint
 
       private
 
-      def config
-        @config ||= begin
+      def better_html_config
+        @better_html_config ||= begin
           if @config_filename.nil?
             config_hash = {}
           else
-            config_hash = @file_loader.yaml(@config_filename).symbolize_keys
+            config_hash = @file_loader.yaml(@config_filename)
           end
           BetterHtml::Config.new(**config_hash)
         end

--- a/lib/erb_lint/linters/erb_safety.rb
+++ b/lib/erb_lint/linters/erb_safety.rb
@@ -28,11 +28,12 @@ module ERBLint
 
       def better_html_config
         @better_html_config ||= begin
-          config_hash = if @config_filename.nil?
-            {}
-          else
-            @file_loader.yaml(@config_filename)
-          end
+          config_hash =
+            if @config_filename.nil?
+              {}
+            else
+              @file_loader.yaml(@config_filename)
+            end
           BetterHtml::Config.new(**config_hash)
         end
       end

--- a/lib/erb_lint/linters/erb_safety.rb
+++ b/lib/erb_lint/linters/erb_safety.rb
@@ -24,6 +24,12 @@ module ERBLint
 
       private
 
+      def config
+        BetterHtml::Config.new(
+          **YAML.load(File.read(Rails.root.join('config/better-html.yml'))).symbolize_keys
+        )
+      end
+
       def format_error(error)
         {
           line: error.location.line,

--- a/lib/erb_lint/linters/erb_safety.rb
+++ b/lib/erb_lint/linters/erb_safety.rb
@@ -28,10 +28,10 @@ module ERBLint
 
       def better_html_config
         @better_html_config ||= begin
-          if @config_filename.nil?
-            config_hash = {}
+          config_hash = if @config_filename.nil?
+            {}
           else
-            config_hash = @file_loader.yaml(@config_filename)
+            @file_loader.yaml(@config_filename)
           end
           BetterHtml::Config.new(**config_hash)
         end

--- a/lib/erb_lint/linters/final_newline.rb
+++ b/lib/erb_lint/linters/final_newline.rb
@@ -6,7 +6,8 @@ module ERBLint
     class FinalNewline < Linter
       include LinterRegistry
 
-      def initialize(config)
+      def initialize(file_loader, config)
+        super
         @new_lines_should_be_present = config['present'].nil? ? true : config['present']
       end
 

--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -13,7 +13,8 @@ module ERBLint
       # copied from Rails: action_view/template/handlers/erb/erubi.rb
       BLOCK_EXPR = /\s*((\s+|\))do|\{)(\s*\|[^|]*\|)?\s*\Z/
 
-      def initialize(config_hash)
+      def initialize(file_loader, config_hash)
+        super
         @enabled_cops = config_hash.delete('only')
         tempfile_from('.erblint-rubocop', config_hash.except('enabled').to_yaml) do |tempfile|
           custom_config = RuboCop::ConfigLoader.load_file(tempfile.path)

--- a/lib/erb_lint/runner.rb
+++ b/lib/erb_lint/runner.rb
@@ -3,14 +3,15 @@
 module ERBLint
   # Runs all enabled linters against an html.erb file.
   class Runner
-    def initialize(config = {})
+    def initialize(file_loader, config = {})
+      @file_loader = file_loader
       @config = default_config.merge(config || {})
 
       LinterRegistry.load_custom_linters
       @linters = LinterRegistry.linters.select { |linter_class| linter_enabled?(linter_class) }
       @linters.map! do |linter_class|
         linter_config = @config.dig('linters', linter_class.simple_name)
-        linter_class.new(linter_config)
+        linter_class.new(@file_loader, linter_config)
       end
     end
 

--- a/spec/erb_lint/linter_spec.rb
+++ b/spec/erb_lint/linter_spec.rb
@@ -11,7 +11,6 @@ describe ERBLint::Linter do
     module ERBLint
       module Linters
         class Fake < ERBLint::Linter
-
           protected
 
           def lint_lines(_lines)

--- a/spec/erb_lint/linter_spec.rb
+++ b/spec/erb_lint/linter_spec.rb
@@ -5,13 +5,12 @@ require 'spec_helper'
 describe ERBLint::Linter do
   context 'when inheriting from the Linter class' do
     let(:linter_config) { {} }
-    subject             { ERBLint::Linters::Fake.new(linter_config) }
+    let(:file_loader)   { ERBLint::FileLoader.new('.') }
+    subject             { ERBLint::Linters::Fake.new(file_loader, linter_config) }
 
     module ERBLint
       module Linters
         class Fake < ERBLint::Linter
-          def initialize(_config)
-          end
 
           protected
 

--- a/spec/erb_lint/linters/deprecated_classes_spec.rb
+++ b/spec/erb_lint/linters/deprecated_classes_spec.rb
@@ -9,7 +9,8 @@ describe ERBLint::Linters::DeprecatedClasses do
     }
   end
 
-  let(:linter) { described_class.new(linter_config) }
+  let(:file_loader) { ERBLint::FileLoader.new('.') }
+  let(:linter) { described_class.new(file_loader, linter_config) }
 
   subject(:linter_errors) { linter.lint_file(file) }
 

--- a/spec/erb_lint/linters/erb_safety_spec.rb
+++ b/spec/erb_lint/linters/erb_safety_spec.rb
@@ -5,7 +5,8 @@ require 'better_html'
 
 describe ERBLint::Linters::ErbSafety do
   let(:linter_config) { {} }
-  let(:linter) { described_class.new(linter_config) }
+  let(:file_loader) { ERBLint::FileLoader.new('.') }
+  let(:linter) { described_class.new(file_loader, linter_config) }
   subject(:linter_errors) { linter.lint_file(file) }
 
   before do

--- a/spec/erb_lint/linters/final_newline_spec.rb
+++ b/spec/erb_lint/linters/final_newline_spec.rb
@@ -5,7 +5,8 @@ require 'spec_helper'
 describe ERBLint::Linters::FinalNewline do
   let(:linter_config) { { 'present' => present } }
 
-  let(:linter) { described_class.new(linter_config) }
+  let(:file_loader) { ERBLint::FileLoader.new('.') }
+  let(:linter) { described_class.new(file_loader, linter_config) }
 
   subject(:linter_errors) { linter.lint_file(file) }
 

--- a/spec/erb_lint/linters/rubocop_spec.rb
+++ b/spec/erb_lint/linters/rubocop_spec.rb
@@ -13,7 +13,8 @@ describe ERBLint::Linters::Rubocop do
       },
     }.deep_stringify_keys
   end
-  let(:linter) { described_class.new(linter_config) }
+  let(:file_loader) { ERBLint::FileLoader.new('.') }
+  let(:linter) { described_class.new(file_loader, linter_config) }
   subject(:linter_errors) { linter.lint_file(file) }
 
   context 'when rubocop finds no offenses' do

--- a/spec/erb_lint/runner_spec.rb
+++ b/spec/erb_lint/runner_spec.rb
@@ -3,7 +3,8 @@
 require 'spec_helper'
 
 describe ERBLint::Runner do
-  let(:runner) { described_class.new(config) }
+  let(:file_loader) { ERBLint::FileLoader.new('.') }
+  let(:runner) { described_class.new(file_loader, config) }
 
   before do
     allow(ERBLint::LinterRegistry).to receive(:linters)
@@ -15,10 +16,8 @@ describe ERBLint::Runner do
   module ERBLint
     module Linters
       class FakeLinter1 < Linter
-        def initialize(_config) end
       end
       class FakeLinter2 < Linter
-        def initialize(_config) end
       end
     end
   end

--- a/spec/file_loader_spec.rb
+++ b/spec/file_loader_spec.rb
@@ -15,7 +15,7 @@ describe ERBLint::FileLoader do
 
   describe '.yaml' do
     context "it reads the file from disk" do
-      it { expect(subject).to eq({ 'my_yaml_config' => 123 }) }
+      it { expect(subject).to eq('my_yaml_config' => 123) }
     end
 
     context "it allows regexp to be loaded" do
@@ -24,7 +24,7 @@ describe ERBLint::FileLoader do
         some_config:
           - !ruby/regexp /\\Afoo/i
       YAML
-      it { expect(subject).to eq({ 'some_config' => [/\Afoo/i] }) }
+      it { expect(subject).to eq('some_config' => [/\Afoo/i]) }
     end
 
     context "it does not allow other objects to be loaded" do
@@ -34,7 +34,7 @@ describe ERBLint::FileLoader do
           - !ruby/array:Array
             - fooo
       YAML
-      it { expect{ subject }.to raise_exception(Psych::DisallowedClass) }
+      it { expect { subject }.to raise_exception(Psych::DisallowedClass) }
     end
 
     context "gracefully falls back when syntax is wrong" do

--- a/spec/file_loader_spec.rb
+++ b/spec/file_loader_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ERBLint::FileLoader do
+  let(:yaml_content) { "---\nmy_yaml_config: 123" }
+  let(:base_path) { '/path/to/app' }
+  let(:filename) { '.config.yml' }
+  let(:file_loader) { described_class.new(base_path) }
+  subject(:yaml) { file_loader.yaml(filename) }
+
+  before do
+    allow(File).to receive(:read).with("#{base_path}/#{filename}").and_return yaml_content
+  end
+
+  describe '.yaml' do
+    context "it reads the file from disk" do
+      it { expect(subject).to eq({ 'my_yaml_config' => 123 }) }
+    end
+
+    context "it allows regexp to be loaded" do
+      let(:yaml_content) { <<~YAML }
+        ---
+        some_config:
+          - !ruby/regexp /\\Afoo/i
+      YAML
+      it { expect(subject).to eq({ 'some_config' => [/\Afoo/i] }) }
+    end
+
+    context "it does not allow other objects to be loaded" do
+      let(:yaml_content) { <<~YAML }
+        ---
+        some_config:
+          - !ruby/array:Array
+            - fooo
+      YAML
+      it { expect{ subject }.to raise_exception(Psych::DisallowedClass) }
+    end
+
+    context "gracefully falls back when syntax is wrong" do
+      let(:yaml_content) { "---\n- foo\nbar:" }
+      it { expect(subject).to eq({}) }
+    end
+  end
+end


### PR DESCRIPTION
This adds a `FileLoader` class that every linter can use to load files, this object would be provided by the caller of the linter (the app) with a base path where to load things from. For Shopify's `bin/erblint` this would be initialized to `FileLoader.new(Rails.root)` and for policial this would be a [`ConfigLoader`](https://github.com/volmer/policial/blob/master/lib/policial/config_loader.rb) instance.

This updates `better-html` to v0.0.10 to take advantage of the overridable config: https://github.com/Shopify/better-html/pull/13/files.

After this goes in, we'll be able to specify a better-html config that will apply to the `ErbSafety` linter so policial can use a config specific to each repo, but also `bin/erblint` can share the same config as the rest of the app.

@volmer @rafaelfranca 