### PR TITLE
Symbolize keys after loading yml

### DIFF
--- a/lib/erb_lint/linters/erb_safety.rb
+++ b/lib/erb_lint/linters/erb_safety.rb
@@ -32,7 +32,7 @@ module ERBLint
             if @config_filename.nil?
               {}
             else
-              @file_loader.yaml(@config_filename)
+              @file_loader.yaml(@config_filename).symbolize_keys
             end
           BetterHtml::Config.new(**config_hash)
         end

--- a/spec/erb_lint/linters/erb_safety_spec.rb
+++ b/spec/erb_lint/linters/erb_safety_spec.rb
@@ -143,6 +143,11 @@ describe ERBLint::Linters::ErbSafety do
       let(:better_html_config) { { javascript_safe_methods: ['foobar'] } }
       it { expect(linter_errors).to eq [] }
     end
+
+    context 'with string keys in config' do
+      let(:better_html_config) { { 'javascript_safe_methods' => ['foobar'] } }
+      it { expect(linter_errors).to eq [] }
+    end
   end
 
   private


### PR DESCRIPTION
symbolize keys after loading yml file, otherwise `BetterHtml::Config.new(**config_hash)` fails with `wrong argument type String (expected Symbol)`