### PR TITLE
Support config inheritance

### DIFF
--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -16,10 +16,8 @@ module ERBLint
       def initialize(file_loader, config_hash)
         super
         @enabled_cops = config_hash.delete('only')
-        tempfile_from('.erblint-rubocop', config_hash.except('enabled').to_yaml) do |tempfile|
-          custom_config = RuboCop::ConfigLoader.load_file(tempfile.path)
-          @config = RuboCop::ConfigLoader.merge_with_default(custom_config, '')
-        end
+        custom_config = config_from_hash(config_hash.except('enabled'))
+        @config = RuboCop::ConfigLoader.merge_with_default(custom_config, '')
       end
 
       def lint_file(file_content)
@@ -73,6 +71,37 @@ module ERBLint
           line: token.location.line + offense.line - 1,
           message: offense.message.strip
         }
+      end
+
+      def config_from_hash(hash)
+        inherit_from = hash.delete('inherit_from')
+        resolve_inheritance(hash, inherit_from)
+
+        tempfile_from('.erblint-rubocop', hash.to_yaml) do |tempfile|
+          RuboCop::ConfigLoader.load_file(tempfile.path)
+        end
+      end
+
+      def resolve_inheritance(hash, inherit_from)
+        base_configs(inherit_from)
+          .reverse_each do |base_config|
+          base_config.each do |k, v|
+            hash[k] = hash.key?(k) ? RuboCop::ConfigLoader.merge(v, hash[k]) : v if v.is_a?(Hash)
+          end
+        end
+      end
+
+      def base_configs(inherit_from)
+        regex = URI::DEFAULT_PARSER.make_regexp(%w[http https])
+        configs = Array(inherit_from).compact.map do |base_name|
+          if base_name =~ /\A#{regex}\z/
+            RuboCop::ConfigLoader.load_file(RuboCop::RemoteConfig.new(base_name, Dir.pwd))
+          else
+            config_from_hash(@file_loader.yaml(base_name))
+          end
+        end
+
+        configs.compact
       end
     end
   end

--- a/spec/erb_lint/linters/rubocop_spec.rb
+++ b/spec/erb_lint/linters/rubocop_spec.rb
@@ -75,6 +75,38 @@ describe ERBLint::Linters::Rubocop do
     it { expect(linter_errors).to eq [arbitrary_error_message(line: 4)] }
   end
 
+  context 'supports loading nested config' do
+    let(:linter_config) do
+      {
+        only: ['ErbLint/ArbitraryRule'],
+        inherit_from: 'custom_rubocop.yml',
+        AllCops: {
+          TargetRubyVersion: '2.3',
+        },
+      }.deep_stringify_keys
+    end
+
+    let(:nested_config) do
+      {
+        'ErbLint/ArbitraryRule': {
+          'Enabled': false
+        }
+      }.deep_stringify_keys
+    end
+
+    before do
+      expect(file_loader).to receive(:yaml).with('custom_rubocop.yml').and_return(nested_config)
+    end
+
+    context 'rules from nested config are merged' do
+      let(:file) { <<~FILE }
+        <% banned_method %>
+      FILE
+
+      it { expect(linter_errors).to eq [] }
+    end
+  end
+
   private
 
   def arbitrary_error_message(line: 1)


### PR DESCRIPTION
Adds support for `inherit_from` keyword in rubocop linter configuration. This duplicates a bit of code from `RuboCop::ConfigLoader` because files must be loaded through the linter's `file_loader` if we want to support policial's loader which pulls files from github.

This code is from https://github.com/bbatsov/rubocop/blob/60211ad3e0d5911d56d5909b248ae28a92138f06/lib/rubocop/config_loader_resolver.rb#L20-L27
