### PR TITLE
Support config without "only" keyword

### DIFF
--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -15,7 +15,7 @@ module ERBLint
 
       def initialize(file_loader, config_hash)
         super
-        @enabled_cops = config_hash.delete('only')
+        @only_cops = config_hash.delete('only')
         tempfile_from('.erblint-rubocop', config_hash.except('enabled').to_yaml) do |tempfile|
           custom_config = RuboCop::ConfigLoader.load_file(tempfile.path)
           @config = RuboCop::ConfigLoader.merge_with_default(custom_config, '')
@@ -63,8 +63,15 @@ module ERBLint
       end
 
       def team
-        selected_cops = RuboCop::Cop::Cop.all.select { |cop| cop.match?(@enabled_cops) }
-        cop_classes = RuboCop::Cop::Registry.new(selected_cops)
+        cop_classes =
+          if @only_cops.present?
+            selected_cops = RuboCop::Cop::Cop.all.select { |cop| cop.match?(@only_cops) }
+            RuboCop::Cop::Registry.new(selected_cops)
+          elsif @config['Rails']['Enabled']
+            RuboCop::Cop::Registry.new(RuboCop::Cop::Cop.all)
+          else
+            RuboCop::Cop::Cop.non_rails
+          end
         RuboCop::Cop::Team.new(cop_classes, @config, extra_details: true, display_cop_names: true)
       end
 


### PR DESCRIPTION
Support linter config without the `only` keyword, which falls back to enabling all cops. Same as policial does: https://github.com/volmer/policial/blob/31d6b2a2f3b2764bdeeeae81d025147e78e0c220/lib/policial/linters/ruby.rb#L32-L40

