### PR TITLE
Align code on erb tag

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,3 +39,6 @@ Naming/VariableNumber:
 
 Style/SymbolArray:
   Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false

--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -28,6 +28,8 @@ module ERBLint
         erb.tokens.each do |token|
           next unless [:stmt, :expr_literal, :expr_escaped].include?(token.type)
           ruby_code = token.code.sub(BLOCK_EXPR, '')
+          ruby_code = ruby_code.sub(/\A[[:blank:]]*/, '')
+          ruby_code = "#{' ' * token.location.column}#{ruby_code}"
           offenses = inspect_content(ruby_code)
           offenses&.each do |offense|
             errors << format_error(token, offense)

--- a/spec/erb_lint/linters/rubocop_spec.rb
+++ b/spec/erb_lint/linters/rubocop_spec.rb
@@ -75,6 +75,59 @@ describe ERBLint::Linters::Rubocop do
     it { expect(linter_errors).to eq [arbitrary_error_message(line: 4)] }
   end
 
+  context 'code is aligned to the column matching start of erb tag' do
+    let(:linter_config) do
+      {
+        only: ['Layout/AlignParameters'],
+        AllCops: {
+          TargetRubyVersion: '2.3',
+        },
+        'Layout/AlignParameters': {
+          Enabled: true,
+          EnforcedStyle: 'with_fixed_indentation',
+          SupportedStyles: %w[with_first_parameter with_fixed_indentation],
+          IndentationWidth: nil,
+        }
+      }.deep_stringify_keys
+    end
+
+    context 'when alignment is correct' do
+      let(:file) { <<~FILE }
+        <% ui_helper :foo,
+          checked: true %>
+      FILE
+
+      it { expect(linter_errors).to eq [] }
+    end
+
+    context 'when alignment is incorrect' do
+      let(:file) { <<~FILE }
+        <% ui_helper :foo,
+              checked: true %>
+      FILE
+
+      it do
+        expect(linter_errors).to eq [
+          {
+            line: 2,
+            message:
+              "Layout/AlignParameters: Use one level of indentation for "\
+              "parameters following the first line of a multi-line method call."
+          }
+        ]
+      end
+    end
+
+    context 'correct alignment with html preceeding erb' do
+      let(:file) { <<~FILE }
+        <div><a><br><% ui_helper :foo,
+                      checked: true %>
+      FILE
+
+      it { expect(linter_errors).to eq [] }
+    end
+  end
+
   private
 
   def arbitrary_error_message(line: 1)

--- a/spec/erb_lint/linters/rubocop_spec.rb
+++ b/spec/erb_lint/linters/rubocop_spec.rb
@@ -9,7 +9,7 @@ describe ERBLint::Linters::Rubocop do
       only: ['ErbLint/ArbitraryRule'],
       require: [File.expand_path('../../fixtures/cops/example_cop', __FILE__)],
       AllCops: {
-        TargetRubyVersion: '2.3',
+        TargetRubyVersion: '2.4',
       },
     }.deep_stringify_keys
   end
@@ -80,7 +80,7 @@ describe ERBLint::Linters::Rubocop do
       {
         only: ['Layout/AlignParameters'],
         AllCops: {
-          TargetRubyVersion: '2.3',
+          TargetRubyVersion: '2.4',
         },
         'Layout/AlignParameters': {
           Enabled: true,


### PR DESCRIPTION
This change will ensure ruby code is aligned on the start of ` <%` which makes it possible to run cops like `Layout/AlignParameters` in a way that makes sense.

For example:
```
# no error, param is correctly indented by 2 spaces
<% ui_helper :foo,
  checked: true %>

# Layout/AlignParameters error
<% ui_helper :foo,
          checked: true %>
```
