### PR TITLE
Add command line interface `bin/erblint`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,10 @@
 
 source 'https://rubygems.org'
 
+gem 'activesupport', '~> 5.1'
+
+group 'test' do
+  gem 'fakefs'
+end
+
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     erb_lint (0.0.9)
       activesupport
       better_html (~> 1.0.0)
+      colorize
       html_tokenizer
       rubocop (~> 0.51)
       smart_properties
@@ -32,10 +33,12 @@ GEM
       parser (>= 2.4)
       smart_properties
     builder (3.2.3)
+    colorize (0.8.1)
     concurrent-ruby (1.0.5)
     crass (1.0.3)
     diff-lcs (1.3)
     erubi (1.7.0)
+    fakefs (0.11.3)
     html_tokenizer (0.0.5)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
@@ -87,7 +90,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport (~> 5.1)
   erb_lint!
+  fakefs
   rspec
   rubocop
 

--- a/bin/erblint
+++ b/bin/erblint
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift("#{__dir__}/../lib")
+
+require 'erb_lint/cli'
+
+cli = ERBLint::CLI.new
+exit cli.run

--- a/bin/erblint
+++ b/bin/erblint
@@ -1,9 +1,0 @@
-#!/usr/bin/env ruby
-# frozen_string_literal: true
-
-$LOAD_PATH.unshift("#{__dir__}/../lib")
-
-require 'erb_lint/cli'
-
-cli = ERBLint::CLI.new
-exit cli.run

--- a/erb_lint.gemspec
+++ b/erb_lint.gemspec
@@ -14,8 +14,9 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/justinthec/erb-lint'
   s.license = 'MIT'
 
-  s.files = Dir['lib/**/*.rb', 'bin/*']
-  s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  s.files = Dir['lib/**/*.rb', 'exe/*']
+  s.bindir = 'exe'
+  s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
   s.add_dependency 'better_html', '~> 1.0.0'
   s.add_dependency 'html_tokenizer'

--- a/erb_lint.gemspec
+++ b/erb_lint.gemspec
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+$LOAD_PATH.push File.expand_path("../lib", __FILE__)
+
+require 'erb_lint/version'
+
 Gem::Specification.new do |s|
   s.name = 'erb_lint'
-  s.version = '0.0.9'
+  s.version = ERBLint::VERSION
   s.authors = ['Justin Chan']
   s.email = ['justin.the.c@gmail.com']
   s.summary = 'ERB lint tool'
@@ -10,13 +14,15 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/justinthec/erb-lint'
   s.license = 'MIT'
 
-  s.files = Dir['lib/**/*.rb']
+  s.files = Dir['lib/**/*.rb', 'bin/*']
+  s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
 
   s.add_dependency 'better_html', '~> 1.0.0'
   s.add_dependency 'html_tokenizer'
   s.add_dependency 'rubocop', '~> 0.51'
   s.add_dependency 'activesupport'
   s.add_dependency 'smart_properties'
+  s.add_dependency 'colorize'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'

--- a/lib/erb_lint.rb
+++ b/lib/erb_lint.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'erb_lint/version'
 require 'erb_lint/linter_config'
 require 'erb_lint/linter_registry'
 require 'erb_lint/linter'

--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+require 'erb_lint'
+require 'active_support'
+require 'active_support/inflector'
+require 'optparse'
+require 'psych'
+require 'yaml'
+require 'colorize'
+
+module ERBLint
+  class CLI
+    DEFAULT_CONFIG_FILENAME = '.erb-lint.yml'
+    DEFAULT_LINT_ALL_GLOB = "**/*.html{+*,}.erb"
+
+    class ExitWithFailure < RuntimeError; end
+    class ExitWithSuccess < RuntimeError; end
+
+    def initialize
+      @options = {}
+      @config = nil
+      @files = []
+    end
+
+    def run(args = ARGV)
+      load_options(args)
+      @files = args.dup
+
+      if lint_files.empty?
+        success!("no files given...\n#{option_parser}")
+      end
+
+      load_config
+      ensure_files_exist(lint_files)
+
+      puts "Linting #{lint_files.size} files with #{enabled_linter_classes.size} linters..."
+      puts
+
+      errors_found = false
+      runner_config = @config.merge(runner_config_override)
+      runner = ERBLint::Runner.new(file_loader, runner_config)
+      lint_files.each do |filename|
+        lint_result = runner.run(filename, File.read(filename))
+        errors = lint_result.map { |r| r[:errors] }.flatten
+        errors.each do |lint_error|
+          puts <<~EOF
+            #{lint_error[:message]}
+            In file: #{relative_filename(filename)}:#{lint_error[:line]}
+
+          EOF
+          errors_found = true
+        end
+      end
+
+      if errors_found
+        warn "Errors were found in ERB files".red
+      else
+        puts "No errors were found in ERB files".green
+      end
+
+      !errors_found
+    rescue OptionParser::InvalidOption, OptionParser::InvalidArgument, ExitWithFailure => e
+      warn e.message.red
+      false
+    rescue ExitWithSuccess => e
+      puts e.message
+      true
+    rescue => e
+      warn "#{e.class}: #{e.message}\n#{e.backtrace.join("\n")}".red
+      false
+    end
+
+    private
+
+    def config_filename
+      @config_filename ||= @options[:config] || DEFAULT_CONFIG_FILENAME
+    end
+
+    def load_config
+      if File.exist?(config_filename)
+        @config = RunnerConfig.new(file_loader.yaml(config_filename))
+      else
+        warn "#{config_filename} not found: using default config".yellow
+        @config = RunnerConfig.default
+      end
+    rescue Psych::SyntaxError => e
+      failure!("error parsing config: #{e.message}")
+    end
+
+    def file_loader
+      @file_loader ||= ERBLint::FileLoader.new(Dir.pwd)
+    end
+
+    def load_options(args)
+      option_parser.parse!(args)
+    end
+
+    def lint_files
+      if @options[:lint_all]
+        pattern = File.expand_path(DEFAULT_LINT_ALL_GLOB, Dir.pwd)
+        Dir[pattern]
+      else
+        @files.map { |f| f.include?('*') ? Dir[f] : f }.flatten.map { |f| File.expand_path(f, Dir.pwd) }
+      end
+    end
+
+    def failure!(msg)
+      raise ExitWithFailure, msg
+    end
+
+    def success!(msg)
+      raise ExitWithSuccess, msg
+    end
+
+    def ensure_files_exist(files)
+      files.each do |filename|
+        unless File.exist?(filename)
+          failure!("#{filename}: does not exist")
+        end
+      end
+    end
+
+    def known_linter_names
+      @known_linter_names ||= ERBLint::LinterRegistry.linters
+        .map(&:simple_name)
+        .map(&:underscore)
+    end
+
+    def enabled_linter_names
+      @enabled_linter_names ||=
+        @options[:enabled_linters] ||
+        known_linter_names.select { |klass| @config.for_linter(klass).enabled? }
+    end
+
+    def enabled_linter_classes
+      @enabled_linter_classes ||= ERBLint::LinterRegistry.linters
+        .select { |klass| enabled_linter_names.include?(klass.simple_name.underscore) }
+    end
+
+    def relative_filename(filename)
+      filename.sub("#{File.expand_path('.', Dir.pwd)}/", '')
+    end
+
+    def runner_config_override
+      if @options[:enabled_linters].present?
+        RunnerConfig.new(
+          linters: {}.tap do |linters|
+            ERBLint::LinterRegistry.linters.map do |klass|
+              linters[klass.simple_name] = { 'enabled' => enabled_linter_classes.include?(klass) }
+            end
+          end
+        )
+      else
+        RunnerConfig.new
+      end
+    end
+
+    def option_parser
+      OptionParser.new do |opts|
+        opts.banner = "Usage: erblint [options] [file1, file2, ...]"
+
+        opts.on("--config FILENAME", "Config file [default: #{DEFAULT_CONFIG_FILENAME}]") do |config|
+          if File.exist?(config)
+            @options[:config] = config
+          else
+            failure!("#{config}: does not exist")
+          end
+        end
+
+        opts.on("--lint-all", "Lint all files matching #{DEFAULT_LINT_ALL_GLOB}") do |config|
+          @options[:lint_all] = config
+        end
+
+        opts.on("--enable-all-linters", "Enable all known linters") do
+          @options[:enabled_linters] = known_linter_names
+        end
+
+        opts.on("--enable-linters LINTER[,LINTER,...]", Array,
+          "Only use specified linter", "Known linters are: #{known_linter_names.join(', ')}") do |linters|
+          linters.each do |linter|
+            unless known_linter_names.include?(linter)
+              failure!("#{linter}: not a valid linter name (#{known_linter_names.join(', ')})")
+            end
+          end
+          @options[:enabled_linters] = linters
+        end
+
+        opts.on_tail("-h", "--help", "Show this message") do
+          success!(opts)
+        end
+
+        opts.on_tail("--version", "Show version") do
+          success!(ERBLint::VERSION)
+        end
+      end
+    end
+  end
+end

--- a/lib/erb_lint/version.rb
+++ b/lib/erb_lint/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module ERBLint
+  VERSION = '0.0.9'
+end

--- a/spec/erb_lint/cli_spec.rb
+++ b/spec/erb_lint/cli_spec.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'erb_lint/cli'
+require 'pp'
+require 'fakefs'
+require 'fakefs/spec_helpers'
+
+describe ERBLint::CLI do
+  include FakeFS::SpecHelpers
+
+  let(:args) { [] }
+  let(:cli) { described_class.new }
+
+  around do |example|
+    FakeFS do
+      example.run
+    end
+  end
+
+  before do
+    allow(ERBLint::LinterRegistry).to receive(:linters)
+      .and_return([ERBLint::Linters::LinterWithErrors,
+                   ERBLint::Linters::LinterWithoutErrors,
+                   ERBLint::Linters::FinalNewline])
+  end
+
+  module ERBLint
+    module Linters
+      class LinterWithErrors < Linter
+        def lint_lines(_file_content)
+          [{
+            message: 'fake message from a fake linter',
+            line: 1
+          }]
+        end
+      end
+
+      class LinterWithoutErrors < Linter
+        def lint_lines(_file_content)
+          []
+        end
+      end
+    end
+  end
+
+  describe '#run' do
+    subject { cli.run(args) }
+
+    context 'with no arguments' do
+      it 'shows usage' do
+        expect { subject }.to output(/erblint \[options\] \[file1, file2, ...\]/).to_stdout
+      end
+
+      it 'shows all known linters' do
+        expect { subject }.to output(
+          /Known linters are: linter_with_errors, linter_without_errors, final_newline/
+        ).to_stdout
+      end
+
+      it 'is successful' do
+        expect(subject).to be(true)
+      end
+    end
+
+    context 'with --version' do
+      let(:args) { ['--version'] }
+      it { expect { subject }.to output("#{ERBLint::VERSION}\n").to_stdout }
+    end
+
+    context 'with --help' do
+      let(:args) { ['--help'] }
+
+      it 'shows usage' do
+        expect { subject }.to output(/erblint \[options\] \[file1, file2, ...\]/).to_stdout
+      end
+      it 'is successful' do
+        expect(subject).to be(true)
+      end
+    end
+
+    context 'with --config' do
+      context 'when file does not exist' do
+        let(:args) { ['--config', '.somefile.yml'] }
+
+        it { expect { subject }.to output(/.somefile.yml: does not exist/).to_stderr }
+        it 'is not successful' do
+          expect(subject).to be(false)
+        end
+      end
+    end
+
+    context 'with file as argument' do
+      context 'when file does not exist' do
+        let(:linted_file) { '/path/to/myfile.html.erb' }
+        let(:args) { [linted_file] }
+
+        it { expect { subject }.to output(/#{Regexp.escape(linted_file)}: does not exist/).to_stderr }
+        it { expect(subject).to be(false) }
+      end
+
+      context 'when file exists' do
+        let(:linted_file) { 'app/views/template.html.erb' }
+        let(:args) { ['--enable-linter', 'linter_with_errors,final_newline', linted_file] }
+        let(:file_content) { "this is a fine file" }
+
+        before do
+          FileUtils.mkdir_p(File.dirname(linted_file))
+          File.write(linted_file, file_content)
+        end
+
+        context 'without --config' do
+          context 'when default config does not exist' do
+            it { expect { subject }.to output(/\.erb-lint\.yml not found: using default config/).to_stderr }
+          end
+        end
+
+        it 'shows how many files and linters are used' do
+          expect { subject }.to output(/Linting 1 files with 2 linters/).to_stdout
+        end
+
+        context 'when errors are found' do
+          it 'shows all error messages and line numbers' do
+            expect { subject }.to output(Regexp.new(Regexp.escape(<<~EOF))).to_stdout
+              fake message from a fake linter
+              In file: /app/views/template.html.erb:1
+
+              Missing a trailing newline at the end of the file.
+              In file: /app/views/template.html.erb:1
+            EOF
+          end
+
+          it 'prints that errors were found to stdout' do
+            expect { subject }.to output(/Errors were found in ERB files/).to_stderr
+          end
+
+          it 'is not successful' do
+            expect(subject).to be(false)
+          end
+        end
+
+        context 'when no errors are found' do
+          let(:args) { ['--enable-linter', 'linter_without_errors', linted_file] }
+
+          it 'shows no that errors were found to stderr' do
+            expect { subject }.to output(/No errors were found in ERB files/).to_stdout
+          end
+
+          it 'is successful' do
+            expect(subject).to be(true)
+          end
+        end
+      end
+    end
+
+    context 'with unknown argument' do
+      let(:args) { ['--foo'] }
+
+      it { expect { subject }.to output(/invalid option: --foo/).to_stderr }
+
+      it 'is not successful' do
+        expect(subject).to be(false)
+      end
+    end
+
+    context 'with invalid --enable-linters argument' do
+      let(:args) { ['--enable-linter', 'foo'] }
+
+      it do
+        expect { subject }.to output(
+          /foo: not a valid linter name \(linter_with_errors, linter_without_errors, final_newline\)/
+        ).to_stderr
+      end
+
+      it 'is not successful' do
+        expect(subject).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a basic command line interface:

```bash
$ bin/erblint
Usage: erblint [options] [file1, file2, ...]
        --config FILENAME            Config file [default: .erb-lint.yml]
        --lint-all                   Lint all files matching **/*.html{+*,}.erb
        --enable-all-linters         Enable all known linters
        --enable-linters LINTER[,LINTER,...]
                                     Only use specified linter
                                     Known linters are: erb_safety, rubocop, final_newline, deprecated_classes
    -h, --help                       Show this message
        --version                    Show version
```