### PR TITLE
Use shopify styleguide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 
 # Bundle configs
 .bundle
+
+.rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,44 +1,8 @@
+inherit_from:
+  - https://shopify.github.io/ruby-style-guide/rubocop.yml
+
 AllCops:
-  TargetRubyVersion: 2.3
-
-Metrics/LineLength:
-  Max: 120
-
-Metrics/MethodLength:
-  Max: 20
-
-Layout/IndentArray:
-  EnforcedStyle: consistent
-
-Layout/IndentHash:
-  EnforcedStyle: consistent
-
-Style/RegexpLiteral:
-  EnforcedStyle: mixed
-
-Style/Alias:
-  EnforcedStyle: prefer_alias_method
-
-Style/EmptyMethod:
-  Enabled: false
-
-Metrics/ModuleLength:
-  Enabled: false
-
-Style/TrailingCommaInLiteral:
-  Enabled: false
-
-Style/StringLiterals:
-  Enabled: false
-
-Metrics/BlockLength:
-  Enabled: false
-
-Naming/VariableNumber:
-  Enabled: false
-
-Style/SymbolArray:
-  Enabled: false
-
-Metrics/AbcSize:
-  Enabled: false
+  TargetRubyVersion: 2.4
+  Exclude:
+    - 'vendor/**/*'
+  DisplayCopNames: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.3.0
+  - 2.4.2
 script:
   - bundle exec rspec spec
   - bundle exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,4 @@
 
 source 'https://rubygems.org'
 
-gem 'rubocop', '~> 0.50.0', require: false
-
-gem 'better_html'
-gem 'html_tokenizer'
-
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     erb_lint (0.0.9)
       better_html (~> 0.0.10)
       html_tokenizer
-      rubocop
+      rubocop (~> 0.51)
 
 GEM
   remote: https://rubygems.org/
@@ -44,8 +44,8 @@ GEM
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.0)
-    parser (2.4.0.0)
-      ast (~> 2.2)
+    parser (2.4.0.2)
+      ast (~> 2.3)
     powerpack (0.1.1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
@@ -54,7 +54,7 @@ GEM
       loofah (~> 2.0)
     rainbow (2.2.2)
       rake
-    rake (12.2.1)
+    rake (12.3.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -68,7 +68,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
-    rubocop (0.50.0)
+    rubocop (0.51.0)
       parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
@@ -86,11 +86,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  better_html
   erb_lint!
-  html_tokenizer
   rspec
-  rubocop (~> 0.50.0)
+  rubocop
 
 BUNDLED WITH
    1.16.0

--- a/erb_lint.gemspec
+++ b/erb_lint.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'better_html', '~> 0.0.10'
   s.add_dependency 'html_tokenizer'
-  s.add_dependency 'rubocop'
+  s.add_dependency 'rubocop', '~> 0.51'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'

--- a/lib/erb_lint/linters/deprecated_classes.rb
+++ b/lib/erb_lint/linters/deprecated_classes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'better_html'
+require 'better_html/node_iterator'
 
 module ERBLint
   module Linters

--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -101,7 +101,7 @@ module ERBLint
       end
 
       def base_configs(inherit_from)
-        regex = URI::DEFAULT_PARSER.make_regexp(%w[http https])
+        regex = URI::DEFAULT_PARSER.make_regexp(%w(http https))
         configs = Array(inherit_from).compact.map do |base_name|
           if base_name =~ /\A#{regex}\z/
             RuboCop::ConfigLoader.load_file(RuboCop::RemoteConfig.new(base_name, Dir.pwd))

--- a/spec/erb_lint/fixtures/cops/example_cop.rb
+++ b/spec/erb_lint/fixtures/cops/example_cop.rb
@@ -7,7 +7,7 @@ module RuboCop
         MSG = 'An arbitrary rule has been violated.'
 
         def on_send(node)
-          add_offense(node, :selector) if node.command?(:banned_method)
+          add_offense(node, location: :selector) if node.command?(:banned_method)
         end
         alias_method :on_csend, :on_send
       end

--- a/spec/erb_lint/linter_spec.rb
+++ b/spec/erb_lint/linter_spec.rb
@@ -40,11 +40,11 @@ describe ERBLint::Linter do
         FILE
 
         it 'calls lint_lines with the list of lines' do
-          expect(subject).to receive(:lint_lines).with(%W[
+          expect(subject).to receive(:lint_lines).with(%W(
             Line1\n
             Line2\n
             Line3
-          ])
+          ))
         end
       end
 
@@ -56,11 +56,11 @@ describe ERBLint::Linter do
         FILE
 
         it 'calls lint_lines with the list of lines' do
-          expect(subject).to receive(:lint_lines).with(%W[
+          expect(subject).to receive(:lint_lines).with(%W(
             Line1\n
             Line2\n
             Line3\n
-          ])
+          ))
         end
       end
     end

--- a/spec/erb_lint/linters/rubocop_spec.rb
+++ b/spec/erb_lint/linters/rubocop_spec.rb
@@ -117,7 +117,7 @@ describe ERBLint::Linters::Rubocop do
         'Layout/AlignParameters': {
           Enabled: true,
           EnforcedStyle: 'with_fixed_indentation',
-          SupportedStyles: %w[with_first_parameter with_fixed_indentation],
+          SupportedStyles: %w(with_first_parameter with_fixed_indentation),
           IndentationWidth: nil,
         }
       }.deep_stringify_keys


### PR DESCRIPTION
Inherit rubocop config from https://shopify.github.io/ruby-style-guide/rubocop.yml for this project. Also update to rubocop 0.51 which introduces a new signature for `Cop#add_offense` so I locked the version ~> 0.51