### PR TITLE
Add config objects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     erb_lint (0.0.9)
+      activesupport
       better_html (~> 1.0.0)
       html_tokenizer
       rubocop (~> 0.51)
@@ -53,9 +54,7 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    rainbow (2.2.2)
-      rake
-    rake (12.3.0)
+    rainbow (3.0.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -69,11 +68,11 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
-    rubocop (0.51.0)
+    rubocop (0.52.0)
       parallel (~> 1.10)
-      parser (>= 2.3.3.1, < 3.0)
+      parser (>= 2.4.0.2, < 3.0)
       powerpack (~> 0.1)
-      rainbow (>= 2.2.2, < 3.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)

--- a/erb_lint.gemspec
+++ b/erb_lint.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'better_html', '~> 1.0.0'
   s.add_dependency 'html_tokenizer'
   s.add_dependency 'rubocop', '~> 0.51'
+  s.add_dependency 'activesupport'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'

--- a/lib/erb_lint.rb
+++ b/lib/erb_lint.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
+require 'erb_lint/linter_config'
 require 'erb_lint/linter_registry'
 require 'erb_lint/linter'
+require 'erb_lint/runner_config'
 require 'erb_lint/runner'
 require 'erb_lint/file_loader'
 

--- a/lib/erb_lint/linter.rb
+++ b/lib/erb_lint/linter.rb
@@ -20,8 +20,19 @@ module ERBLint
     end
 
     # Must be implemented by the concrete inheriting class.
-    def initialize(file_loader, _config)
+    def initialize(file_loader, config)
       @file_loader = file_loader
+      @config = config
+      raise ArgumentError, "expect `config` to be LinterConfig instance, "\
+        "not #{config.class}" unless config.is_a?(LinterConfig)
+    end
+
+    def enabled?
+      @config.enabled?
+    end
+
+    def excludes_file?(filename)
+      @config.excludes_file?(filename)
     end
 
     def lint_file(file_content)

--- a/lib/erb_lint/linter_config.rb
+++ b/lib/erb_lint/linter_config.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'active_support'
+
+module ERBLint
+  class LinterConfig
+    def initialize(config = {})
+      @config = config.dup.deep_stringify_keys
+    end
+
+    def to_hash
+      @config.dup
+    end
+
+    def [](key)
+      @config[key.to_s]
+    end
+
+    def fetch(key, *args, &block)
+      @config.fetch(key.to_s, *args, &block)
+    end
+
+    def enabled?
+      !!@config['enabled']
+    end
+
+    def excludes_file?(filename)
+      fetch(:exclude, []).any? do |path|
+        File.fnmatch?(path, filename)
+      end
+    end
+  end
+end

--- a/lib/erb_lint/linters/final_newline.rb
+++ b/lib/erb_lint/linters/final_newline.rb
@@ -8,7 +8,7 @@ module ERBLint
 
       def initialize(file_loader, config)
         super
-        @new_lines_should_be_present = config['present'].nil? ? true : config['present']
+        @new_lines_should_be_present = config.fetch(:present, true)
       end
 
       protected

--- a/lib/erb_lint/runner.rb
+++ b/lib/erb_lint/runner.rb
@@ -3,52 +3,26 @@
 module ERBLint
   # Runs all enabled linters against an html.erb file.
   class Runner
-    def initialize(file_loader, config = {})
+    def initialize(file_loader, config)
       @file_loader = file_loader
-      @config = default_config.merge(config || {})
+      @config = config || RunnerConfig.default
+      raise ArgumentError, 'expect `config` to be a RunnerConfig instance' unless @config.is_a?(RunnerConfig)
 
       LinterRegistry.load_custom_linters
-      @linters = LinterRegistry.linters.select { |linter_class| linter_enabled?(linter_class) }
-      @linters.map! do |linter_class|
-        linter_config = @config.dig('linters', linter_class.simple_name)
-        linter_class.new(@file_loader, linter_config)
+      linter_classes = LinterRegistry.linters.select { |klass| @config.for_linter(klass).enabled? }
+      @linters = linter_classes.map do |linter_class|
+        linter_class.new(@file_loader, @config.for_linter(linter_class))
       end
     end
 
     def run(filename, file_content)
-      linters_for_file = @linters.reject { |linter| linter_excludes_file?(linter, filename) }
+      linters_for_file = @linters.reject { |linter| linter.excludes_file?(filename) }
       linters_for_file.map do |linter|
         {
           linter_name: linter.class.simple_name,
           errors: linter.lint_file(file_content)
         }
       end
-    end
-
-    private
-
-    def linter_enabled?(linter_class)
-      linter_config = @config.dig('linters', linter_class.simple_name)
-      return false if linter_config.nil?
-      linter_config['enabled'] || false
-    end
-
-    def linter_excludes_file?(linter, filename)
-      excluded_filepaths = @config.dig('linters', linter.class.simple_name, 'exclude') || []
-      excluded_filepaths.each do |path|
-        return true if File.fnmatch?(path, filename)
-      end
-      false
-    end
-
-    def default_config
-      {
-        'linters' => {
-          'FinalNewline' => {
-            'enabled' => true
-          }
-        }
-      }
     end
   end
 end

--- a/lib/erb_lint/runner_config.rb
+++ b/lib/erb_lint/runner_config.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module ERBLint
+  class RunnerConfig
+    def initialize(config = nil)
+      @config = (config || {}).dup.deep_stringify_keys
+    end
+
+    def to_hash
+      @config.dup
+    end
+
+    def for_linter(klass)
+      klass_name = if klass.is_a?(String)
+        klass.to_s
+      elsif klass.is_a?(Class) && klass <= ERBLint::Linter
+        klass.simple_name
+      else
+        raise ArgumentError, 'expected String or linter class'
+      end
+      LinterConfig.new(linters_config[klass_name] || {})
+    end
+
+    def merge(other_config)
+      self.class.new(@config.deep_merge(other_config.to_hash))
+    end
+
+    def merge!(other_config)
+      @config.deep_merge!(other_config.to_hash)
+      self
+    end
+
+    class << self
+      def default
+        new(
+          linters: {
+            FinalNewline: {
+              enabled: true,
+            },
+          },
+        )
+      end
+    end
+
+    private
+
+    def linters_config
+      @config['linters'] || {}
+    end
+  end
+end

--- a/spec/erb_lint/linter_config_spec.rb
+++ b/spec/erb_lint/linter_config_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ERBLint::LinterConfig do
+  context 'with custom config' do
+    let(:linter_config) { described_class.new(config_hash) }
+
+    describe '#to_hash' do
+      subject { linter_config.to_hash }
+
+      context 'with empty hash' do
+        let(:config_hash) { {} }
+
+        it { expect(subject).to eq({}) }
+      end
+
+      context 'with custom data' do
+        let(:config_hash) { { foo: true } }
+
+        it { expect(subject).to eq('foo' => true) }
+      end
+    end
+
+    describe '#[]' do
+      subject { linter_config[key] }
+
+      context 'with empty hash' do
+        let(:config_hash) { {} }
+        let(:key) { 'foo' }
+
+        it { expect(subject).to eq(nil) }
+      end
+
+      context 'with custom data' do
+        let(:config_hash) { { foo: 'custom value' } }
+        let(:key) { 'foo' }
+
+        it { expect(subject).to eq('custom value') }
+      end
+
+      context 'with string data and symbol key' do
+        let(:config_hash) { { 'foo' => 'custom value' } }
+        let(:key) { :foo }
+
+        it { expect(subject).to eq('custom value') }
+      end
+    end
+
+    describe '#fetch' do
+      let(:config_hash) { { foo: 'custom value' } }
+
+      context 'with existing key and no default' do
+        subject { linter_config.fetch('foo') }
+        it { expect(subject).to eq('custom value') }
+      end
+
+      context 'with missing key and no default' do
+        subject { linter_config.fetch('no such key') }
+        it { expect { subject }.to raise_error(KeyError) }
+      end
+
+      context 'with missing key and a default' do
+        subject { linter_config.fetch('no such key', 'fallback') }
+        it { expect(subject).to eq('fallback') }
+      end
+    end
+
+    describe '#enabled?' do
+      subject { linter_config.enabled? }
+
+      context 'when enabled is true' do
+        let(:config_hash) { { enabled: true } }
+        it { expect(subject).to eq(true) }
+      end
+
+      context 'when enabled is false' do
+        let(:config_hash) { { enabled: false } }
+        it { expect(subject).to eq(false) }
+      end
+
+      context 'when enabled key is missing' do
+        let(:config_hash) { {} }
+        it { expect(subject).to eq(false) }
+      end
+
+      context 'when enabled key is truthy' do
+        let(:config_hash) { { enabled: 42 } }
+        it { expect(subject).to eq(true) }
+      end
+
+      context 'when enabled key is falsy' do
+        let(:config_hash) { { enabled: nil } }
+        it { expect(subject).to eq(false) }
+      end
+    end
+
+    describe '#excludes_file?' do
+      context 'when glob matches' do
+        let(:config_hash) { { exclude: ['vendor/**/*'] } }
+        subject { linter_config.excludes_file?('vendor/gem/foo.rb') }
+        it { expect(subject).to eq(true) }
+      end
+
+      context 'when glob does not match' do
+        let(:config_hash) { { exclude: ['vendor/**/*'] } }
+        subject { linter_config.excludes_file?('app/foo.rb') }
+        it { expect(subject).to eq(false) }
+      end
+    end
+  end
+end

--- a/spec/erb_lint/linter_spec.rb
+++ b/spec/erb_lint/linter_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe ERBLint::Linter do
   context 'when inheriting from the Linter class' do
-    let(:linter_config) { {} }
+    let(:linter_config) { ERBLint::LinterConfig.new }
     let(:file_loader)   { ERBLint::FileLoader.new('.') }
     subject             { ERBLint::Linters::Fake.new(file_loader, linter_config) }
 

--- a/spec/erb_lint/linters/deprecated_classes_spec.rb
+++ b/spec/erb_lint/linters/deprecated_classes_spec.rb
@@ -4,9 +4,9 @@ require 'spec_helper'
 
 describe ERBLint::Linters::DeprecatedClasses do
   let(:linter_config) do
-    {
-      'rule_set' => rule_set
-    }
+    ERBLint::LinterConfig.new(
+      rule_set: rule_set
+    )
   end
 
   let(:file_loader) { ERBLint::FileLoader.new('.') }
@@ -166,10 +166,10 @@ describe ERBLint::Linters::DeprecatedClasses do
 
     context 'when an addendum is present' do
       let(:linter_config) do
-        {
-          'rule_set' => rule_set,
-          'addendum' => addendum
-        }
+        ERBLint::LinterConfig.new(
+          rule_set: rule_set,
+          addendum: addendum,
+        )
       end
       let(:addendum) { 'Addendum badoo ba!' }
 
@@ -200,9 +200,9 @@ describe ERBLint::Linters::DeprecatedClasses do
 
     context 'when an addendum is absent' do
       let(:linter_config) do
-        {
-          'rule_set' => rule_set
-        }
+        ERBLint::LinterConfig.new(
+          rule_set: rule_set
+        )
       end
 
       context 'when the file is empty' do

--- a/spec/erb_lint/linters/erb_safety_spec.rb
+++ b/spec/erb_lint/linters/erb_safety_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'better_html'
 
 describe ERBLint::Linters::ErbSafety do
-  let(:linter_config) { {} }
+  let(:linter_config) { ERBLint::LinterConfig.new }
   let(:better_html_config) do
     {
       javascript_safe_methods: ['to_json']
@@ -129,7 +129,7 @@ describe ERBLint::Linters::ErbSafety do
   end
 
   context 'changing better-html config file works' do
-    let(:linter_config) { { 'better-html-config' => '.better-html.yml' } }
+    let(:linter_config) { ERBLint::LinterConfig.new('better-html-config' => '.better-html.yml') }
     let(:file) { <<~FILE }
       <script><%= foobar %></script>
     FILE

--- a/spec/erb_lint/linters/final_newline_spec.rb
+++ b/spec/erb_lint/linters/final_newline_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe ERBLint::Linters::FinalNewline do
-  let(:linter_config) { { 'present' => present } }
+  let(:linter_config) { ERBLint::LinterConfig.new(present: present) }
 
   let(:file_loader) { ERBLint::FileLoader.new('.') }
   let(:linter) { described_class.new(file_loader, linter_config) }
@@ -75,7 +75,7 @@ describe ERBLint::Linters::FinalNewline do
   end
 
   context 'when trailing newline preference is not stated' do
-    let(:linter_config) { {} }
+    let(:linter_config) { ERBLint::LinterConfig.new }
 
     context 'when the file is empty' do
       let(:file) { '' }

--- a/spec/erb_lint/linters/rubocop_spec.rb
+++ b/spec/erb_lint/linters/rubocop_spec.rb
@@ -5,13 +5,13 @@ require 'better_html'
 
 describe ERBLint::Linters::Rubocop do
   let(:linter_config) do
-    {
+    ERBLint::LinterConfig.new(
       only: ['ErbLint/ArbitraryRule'],
       require: [File.expand_path('../../fixtures/cops/example_cop', __FILE__)],
       AllCops: {
         TargetRubyVersion: '2.4',
       },
-    }.deep_stringify_keys
+    )
   end
   let(:file_loader) { ERBLint::FileLoader.new('.') }
   let(:linter) { described_class.new(file_loader, linter_config) }
@@ -77,13 +77,13 @@ describe ERBLint::Linters::Rubocop do
 
   context 'supports loading nested config' do
     let(:linter_config) do
-      {
+      ERBLint::LinterConfig.new(
         only: ['ErbLint/ArbitraryRule'],
         inherit_from: 'custom_rubocop.yml',
         AllCops: {
           TargetRubyVersion: '2.3',
         },
-      }.deep_stringify_keys
+      )
     end
 
     let(:nested_config) do
@@ -109,7 +109,7 @@ describe ERBLint::Linters::Rubocop do
 
   context 'code is aligned to the column matching start of erb tag' do
     let(:linter_config) do
-      {
+      ERBLint::LinterConfig.new(
         only: ['Layout/AlignParameters'],
         AllCops: {
           TargetRubyVersion: '2.4',
@@ -120,7 +120,7 @@ describe ERBLint::Linters::Rubocop do
           SupportedStyles: %w(with_first_parameter with_fixed_indentation),
           IndentationWidth: nil,
         }
-      }.deep_stringify_keys
+      )
     end
 
     context 'when alignment is correct' do

--- a/spec/erb_lint/runner_config_spec.rb
+++ b/spec/erb_lint/runner_config_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ERBLint::RunnerConfig do
+  describe '.default' do
+    subject(:runner_config) { described_class.default }
+
+    it 'returns expected class' do
+      expect(subject.class).to be(described_class)
+    end
+
+    it 'has FinalNewline enabled' do
+      expect(subject.for_linter('FinalNewline').enabled?).to be(true)
+    end
+  end
+
+  context 'with custom config' do
+    let(:runner_config) { described_class.new(config_hash) }
+
+    describe '#to_hash' do
+      subject { runner_config.to_hash }
+
+      context 'with empty hash' do
+        let(:config_hash) { {} }
+
+        it { expect(subject).to eq({}) }
+      end
+
+      context 'with custom data' do
+        let(:config_hash) { { foo: true } }
+
+        it { expect(subject).to eq('foo' => true) }
+      end
+    end
+
+    describe '#for_linter' do
+      subject { runner_config.for_linter(linter) }
+
+      class MyCustomLinter < ERBLint::Linter
+      end
+
+      before do
+        allow(ERBLint::LinterRegistry).to receive(:linters)
+          .and_return([ERBLint::Linters::FinalNewline, MyCustomLinter])
+      end
+
+      context 'with string argument' do
+        let(:linter) { 'MyCustomLinter' }
+        let(:config_hash) { { linters: { 'MyCustomLinter' => { 'my_option' => 'custom value' } } } }
+
+        it { expect(subject.class).to eq(ERBLint::LinterConfig) }
+        it { expect(subject['my_option']).to eq('custom value') }
+      end
+
+      context 'with class argument' do
+        let(:linter) { MyCustomLinter }
+        let(:config_hash) { { linters: { 'MyCustomLinter' => { my_option: 'custom value' } } } }
+
+        it { expect(subject.class).to eq(ERBLint::LinterConfig) }
+      end
+
+      context 'with argument that isnt a string and does not inherit from Linter' do
+        let(:linter) { Object }
+        let(:config_hash) { { linters: { 'MyCustomLinter' => { my_option: 'custom value' } } } }
+
+        it { expect { subject }.to raise_error(ArgumentError) }
+      end
+
+      context 'for linter not present in config hash' do
+        let(:linter) { 'FinalNewline' }
+        let(:config_hash) {}
+
+        it { expect(subject.class).to eq(ERBLint::LinterConfig) }
+        it 'returns empty config' do
+          expect(subject.to_hash).to eq({})
+        end
+        it 'is disabled by default' do
+          expect(subject.enabled?).to eq(false)
+        end
+      end
+    end
+
+    describe '#merge' do
+      let(:first_config) { described_class.new(foo: 1) }
+      let(:second_config) { described_class.new(bar: 2) }
+      subject { first_config.merge(second_config) }
+
+      context 'creates a new object' do
+        it { expect(subject.class).to be(described_class) }
+        it { expect(subject).to_not be(first_config) }
+        it { expect(subject).to_not be(second_config) }
+      end
+
+      context 'new object has keys from both configs' do
+        it { expect(subject.to_hash).to eq('foo' => 1, 'bar' => 2) }
+      end
+
+      context 'second object overwrites keys from first object' do
+        let(:second_config) { described_class.new(foo: 42) }
+        it { expect(subject.to_hash).to eq('foo' => 42) }
+      end
+
+      context 'performs a deep merge' do
+        let(:first_config) { described_class.new(nested: { foo: 1 }) }
+        let(:second_config) { described_class.new(nested: { bar: 2 }) }
+        it { expect(subject.to_hash).to eq('nested' => { 'foo' => 1, 'bar' => 2 }) }
+      end
+    end
+
+    describe '#merge!' do
+      let(:first_config) { described_class.new(foo: 1) }
+      let(:second_config) { described_class.new(bar: 2) }
+      subject { first_config.merge!(second_config) }
+
+      context 'returns first object' do
+        it { expect(subject).to be(first_config) }
+      end
+
+      context 'first object has keys from both configs' do
+        it { expect(subject.to_hash).to eq('foo' => 1, 'bar' => 2) }
+      end
+
+      context 'second object overwrites keys from first object' do
+        let(:second_config) { described_class.new(foo: 42) }
+        it { expect(subject.to_hash).to eq('foo' => 42) }
+      end
+
+      context 'performs a deep merge' do
+        let(:first_config) { described_class.new(nested: { foo: 1 }) }
+        let(:second_config) { described_class.new(nested: { bar: 2 }) }
+        it { expect(subject.to_hash).to eq('nested' => { 'foo' => 1, 'bar' => 2 }) }
+      end
+    end
+  end
+end

--- a/spec/erb_lint/runner_spec.rb
+++ b/spec/erb_lint/runner_spec.rb
@@ -42,12 +42,12 @@ describe ERBLint::Runner do
 
     context 'when all linters are enabled' do
       let(:config) do
-        {
-          'linters' => {
+        ERBLint::RunnerConfig.new(
+          linters: {
             'FakeLinter1' => { 'enabled' => true },
             'FakeLinter2' => { 'enabled' => true }
           }
-        }
+        )
       end
 
       it 'returns each linter with their errors' do
@@ -66,12 +66,12 @@ describe ERBLint::Runner do
 
     context 'when only some linters are enabled' do
       let(:config) do
-        {
-          'linters' => {
+        ERBLint::RunnerConfig.new(
+          linters: {
             'FakeLinter1' => { 'enabled' => true },
             'FakeLinter2' => { 'enabled' => false }
           }
-        }
+        )
       end
 
       it 'returns only enabled linters with their errors' do
@@ -86,12 +86,12 @@ describe ERBLint::Runner do
 
     context 'when all linters are disabled' do
       let(:config) do
-        {
-          'linters' => {
+        ERBLint::RunnerConfig.new(
+          linters: {
             'FakeLinter1' => { 'enabled' => false },
             'FakeLinter2' => { 'enabled' => false }
           }
-        }
+        )
       end
 
       it 'returns no linters' do
@@ -101,12 +101,12 @@ describe ERBLint::Runner do
 
     context 'when all linters exclude the file' do
       let(:config) do
-        {
-          'linters' => {
+        ERBLint::RunnerConfig.new(
+          linters: {
             'FakeLinter1' => { 'enabled' => true, 'exclude' => ['**/otherfolder/**'] },
             'FakeLinter2' => { 'enabled' => true, 'exclude' => ['somefolder/**.html.erb'] }
           }
-        }
+        )
       end
 
       it 'returns no linters' do
@@ -115,15 +115,10 @@ describe ERBLint::Runner do
     end
 
     context 'when the config has no linters' do
-      let(:config) { {} }
+      let(:config) { ERBLint::RunnerConfig.new }
 
-      it 'returns default linters with their errors' do
-        expect(subject).to eq [
-          {
-            linter_name: 'FinalNewline',
-            errors: fake_final_newline_errors
-          }
-        ]
+      it 'has all linters disabled' do
+        expect(subject).to eq []
       end
     end
 


### PR DESCRIPTION
Creates config objects instead of using hashes. tests fail because of rubocop pending https://github.com/Shopify/erb-lint/pull/26 being merged

@rafaelfranca @volmer 