### PR TITLE
Schema for config validation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       better_html (~> 1.0.0)
       html_tokenizer
       rubocop (~> 0.51)
+      smart_properties
 
 GEM
   remote: https://rubygems.org/

--- a/erb_lint.gemspec
+++ b/erb_lint.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'html_tokenizer'
   s.add_dependency 'rubocop', '~> 0.51'
   s.add_dependency 'activesupport'
+  s.add_dependency 'smart_properties'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'

--- a/lib/erb_lint/linter_config.rb
+++ b/lib/erb_lint/linter_config.rb
@@ -1,31 +1,58 @@
 # frozen_string_literal: true
 
 require 'active_support'
+require 'smart_properties'
 
 module ERBLint
   class LinterConfig
+    include SmartProperties
+
+    class Error < StandardError; end
+
+    class << self
+      def array_of?(klass)
+        lambda { |value| value.is_a?(Array) && value.all? { |s| s.is_a?(klass) } }
+      end
+
+      def to_array_of(klass)
+        lambda { |entries| entries.map { |entry| klass.new(entry) } }
+      end
+    end
+
+    property :enabled, accepts: [true, false], default: false, reader: :enabled?
+    property :exclude, accepts: array_of?(String), default: []
+
     def initialize(config = {})
-      @config = config.dup.deep_stringify_keys
+      config = config.dup.deep_stringify_keys
+      allowed_keys = self.class.properties.keys.map(&:to_s)
+      given_keys = config.keys
+      if (extra_keys = given_keys - allowed_keys).any?
+        raise Error, "Given key is not allowed: #{extra_keys.join(', ')}"
+      end
+      super(config)
+    rescue SmartProperties::InitializationError => e
+      raise Error, "The following properties are required to be set: #{e.properties}"
+    rescue SmartProperties::InvalidValueError => e
+      raise Error, e.message
+    end
+
+    def [](name)
+      unless self.class.properties.key?(name)
+        raise Error, "No such property: #{name}"
+      end
+      super
     end
 
     def to_hash
-      @config.dup
-    end
-
-    def [](key)
-      @config[key.to_s]
-    end
-
-    def fetch(key, *args, &block)
-      @config.fetch(key.to_s, *args, &block)
-    end
-
-    def enabled?
-      !!@config['enabled']
+      {}.tap do |hash|
+        self.class.properties.to_hash.each_key do |key|
+          hash[key.to_s] = self[key]
+        end
+      end
     end
 
     def excludes_file?(filename)
-      fetch(:exclude, []).any? do |path|
+      exclude.any? do |path|
         File.fnmatch?(path, filename)
       end
     end

--- a/lib/erb_lint/linter_registry.rb
+++ b/lib/erb_lint/linter_registry.rb
@@ -13,6 +13,10 @@ module ERBLint
         @linters << linter_class
       end
 
+      def find_by_name(name)
+        linters.detect { |linter| linter.simple_name == name }
+      end
+
       def load_custom_linters(directory = CUSTOM_LINTERS_DIR)
         ruby_files = Dir.glob(File.expand_path(File.join(directory, '**', '*.rb')))
         ruby_files.each { |file| require file }

--- a/lib/erb_lint/linters/erb_safety.rb
+++ b/lib/erb_lint/linters/erb_safety.rb
@@ -10,9 +10,15 @@ module ERBLint
       include LinterRegistry
       include BetterHtml::TestHelper::SafeErbTester
 
+      class ConfigSchema < LinterConfig
+        property :better_html_config, accepts: String
+      end
+
+      self.config_schema = ConfigSchema
+
       def initialize(file_loader, config)
         super
-        @config_filename = config['better-html-config']
+        @config_filename = @config.better_html_config
       end
 
       def lint_file(file_content)

--- a/lib/erb_lint/linters/final_newline.rb
+++ b/lib/erb_lint/linters/final_newline.rb
@@ -6,9 +6,14 @@ module ERBLint
     class FinalNewline < Linter
       include LinterRegistry
 
+      class ConfigSchema < LinterConfig
+        property :present, accepts: [true, false], default: true, reader: :present?
+      end
+      self.config_schema = ConfigSchema
+
       def initialize(file_loader, config)
         super
-        @new_lines_should_be_present = config.fetch(:present, true)
+        @new_lines_should_be_present = @config.present?
       end
 
       protected

--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -10,13 +10,20 @@ module ERBLint
     class Rubocop < Linter
       include LinterRegistry
 
+      class ConfigSchema < LinterConfig
+        property :only, accepts: array_of?(String)
+        property :rubocop_config, accepts: Hash
+      end
+
+      self.config_schema = ConfigSchema
+
       # copied from Rails: action_view/template/handlers/erb/erubi.rb
       BLOCK_EXPR = /\s*((\s+|\))do|\{)(\s*\|[^|]*\|)?\s*\Z/
 
       def initialize(file_loader, config)
         super
-        @only_cops = config['only']
-        custom_config = config_from_hash(config.to_hash.except('only', 'enabled'))
+        @only_cops = @config.only
+        custom_config = config_from_hash(@config.rubocop_config)
         @rubocop_config = RuboCop::ConfigLoader.merge_with_default(custom_config, '')
       end
 

--- a/lib/erb_lint/runner_config.rb
+++ b/lib/erb_lint/runner_config.rb
@@ -2,6 +2,8 @@
 
 module ERBLint
   class RunnerConfig
+    class Error < StandardError; end
+
     def initialize(config = nil)
       @config = (config || {}).dup.deep_stringify_keys
     end
@@ -18,7 +20,9 @@ module ERBLint
       else
         raise ArgumentError, 'expected String or linter class'
       end
-      LinterConfig.new(linters_config[klass_name] || {})
+      linter_klass = LinterRegistry.find_by_name(klass_name)
+      raise Error, "#{klass_name}: linter not found (is it loaded?)" unless linter_klass
+      linter_klass.config_schema.new(linters_config[klass_name] || {})
     end
 
     def merge(other_config)

--- a/spec/erb_lint/linters/deprecated_classes_spec.rb
+++ b/spec/erb_lint/linters/deprecated_classes_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe ERBLint::Linters::DeprecatedClasses do
   let(:linter_config) do
-    ERBLint::LinterConfig.new(
+    described_class.config_schema.new(
       rule_set: rule_set
     )
   end
@@ -166,7 +166,7 @@ describe ERBLint::Linters::DeprecatedClasses do
 
     context 'when an addendum is present' do
       let(:linter_config) do
-        ERBLint::LinterConfig.new(
+        described_class.config_schema.new(
           rule_set: rule_set,
           addendum: addendum,
         )
@@ -200,7 +200,7 @@ describe ERBLint::Linters::DeprecatedClasses do
 
     context 'when an addendum is absent' do
       let(:linter_config) do
-        ERBLint::LinterConfig.new(
+        described_class.config_schema.new(
           rule_set: rule_set
         )
       end

--- a/spec/erb_lint/linters/erb_safety_spec.rb
+++ b/spec/erb_lint/linters/erb_safety_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'better_html'
 
 describe ERBLint::Linters::ErbSafety do
-  let(:linter_config) { ERBLint::LinterConfig.new }
+  let(:linter_config) { described_class.config_schema.new }
   let(:better_html_config) do
     {
       javascript_safe_methods: ['to_json']
@@ -129,7 +129,11 @@ describe ERBLint::Linters::ErbSafety do
   end
 
   context 'changing better-html config file works' do
-    let(:linter_config) { ERBLint::LinterConfig.new('better-html-config' => '.better-html.yml') }
+    let(:linter_config) do
+      described_class.config_schema.new(
+        'better_html_config' => '.better-html.yml'
+      )
+    end
     let(:file) { <<~FILE }
       <script><%= foobar %></script>
     FILE

--- a/spec/erb_lint/linters/final_newline_spec.rb
+++ b/spec/erb_lint/linters/final_newline_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe ERBLint::Linters::FinalNewline do
-  let(:linter_config) { ERBLint::LinterConfig.new(present: present) }
+  let(:linter_config) { described_class.config_schema.new(present: present) }
 
   let(:file_loader) { ERBLint::FileLoader.new('.') }
   let(:linter) { described_class.new(file_loader, linter_config) }
@@ -75,7 +75,7 @@ describe ERBLint::Linters::FinalNewline do
   end
 
   context 'when trailing newline preference is not stated' do
-    let(:linter_config) { ERBLint::LinterConfig.new }
+    let(:linter_config) { described_class.config_schema.new }
 
     context 'when the file is empty' do
       let(:file) { '' }

--- a/spec/erb_lint/linters/rubocop_spec.rb
+++ b/spec/erb_lint/linters/rubocop_spec.rb
@@ -5,11 +5,13 @@ require 'better_html'
 
 describe ERBLint::Linters::Rubocop do
   let(:linter_config) do
-    ERBLint::LinterConfig.new(
+    described_class.config_schema.new(
       only: ['ErbLint/ArbitraryRule'],
-      require: [File.expand_path('../../fixtures/cops/example_cop', __FILE__)],
-      AllCops: {
-        TargetRubyVersion: '2.4',
+      rubocop_config: {
+        require: [File.expand_path('../../fixtures/cops/example_cop', __FILE__)],
+        AllCops: {
+          TargetRubyVersion: '2.4',
+        },
       },
     )
   end
@@ -77,11 +79,13 @@ describe ERBLint::Linters::Rubocop do
 
   context 'supports loading nested config' do
     let(:linter_config) do
-      ERBLint::LinterConfig.new(
+      described_class.config_schema.new(
         only: ['ErbLint/ArbitraryRule'],
-        inherit_from: 'custom_rubocop.yml',
-        AllCops: {
-          TargetRubyVersion: '2.3',
+        rubocop_config: {
+          inherit_from: 'custom_rubocop.yml',
+          AllCops: {
+            TargetRubyVersion: '2.3',
+          },
         },
       )
     end
@@ -109,17 +113,19 @@ describe ERBLint::Linters::Rubocop do
 
   context 'code is aligned to the column matching start of erb tag' do
     let(:linter_config) do
-      ERBLint::LinterConfig.new(
+      described_class.config_schema.new(
         only: ['Layout/AlignParameters'],
-        AllCops: {
-          TargetRubyVersion: '2.4',
+        rubocop_config: {
+          AllCops: {
+            TargetRubyVersion: '2.4',
+          },
+          'Layout/AlignParameters': {
+            Enabled: true,
+            EnforcedStyle: 'with_fixed_indentation',
+            SupportedStyles: %w(with_first_parameter with_fixed_indentation),
+            IndentationWidth: nil,
+          }
         },
-        'Layout/AlignParameters': {
-          Enabled: true,
-          EnforcedStyle: 'with_fixed_indentation',
-          SupportedStyles: %w(with_first_parameter with_fixed_indentation),
-          IndentationWidth: nil,
-        }
       )
     end
 


### PR DESCRIPTION
Allows each linter to declare a config class for itself, validated with the SmartProperties gem. The `LinterConfig` can be subclassed to add custom properties for the linter.

An error is raised when keys are present in the config but not in the schema, and when a key is accessed in the linter that isn't part of the schema.