### PR TITLE
`for_linter` method takes a class name

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -129,7 +129,7 @@ module ERBLint
     def enabled_linter_names
       @enabled_linter_names ||=
         @options[:enabled_linters] ||
-        known_linter_names.select { |klass| @config.for_linter(klass).enabled? }
+        known_linter_names.select { |name| @config.for_linter(name.camelize).enabled? }
     end
 
     def enabled_linter_classes


### PR DESCRIPTION
Small fix, `for_linter` takes a camel-case class name but `known_linter_names` is a list of `underscore`'d names.