### PR TITLE
Add a RubocopText linter:

### DIFF
--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -30,7 +30,7 @@ module ERBLint
 
       def offenses(processed_source)
         offenses = []
-        processed_source.ast.descendants(:erb).each do |erb_node|
+        descendant_nodes(processed_source).each do |erb_node|
           offenses.push(*inspect_content(processed_source, erb_node))
         end
         offenses
@@ -50,6 +50,10 @@ module ERBLint
       end
 
       private
+
+      def descendant_nodes(processed_source)
+        processed_source.ast.descendants(:erb)
+      end
 
       class OffenseWithCorrection < Offense
         attr_reader :correction, :offset, :bound_range

--- a/lib/erb_lint/linters/rubocop_text.rb
+++ b/lib/erb_lint/linters/rubocop_text.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module ERBLint
+  module Linters
+    class RubocopText < Rubocop
+      include LinterRegistry
+
+      class ConfigSchema < LinterConfig
+        property :only, accepts: array_of?(String)
+        property :rubocop_config, accepts: Hash
+      end
+
+      self.config_schema = ConfigSchema
+
+      private
+
+      def descendant_nodes(parser)
+        erb_nodes = []
+
+        parser.ast.descendants(:text).each do |text_node|
+          text_node.descendants(:erb).each do |erb_node|
+            erb_nodes << erb_node
+          end
+        end
+        erb_nodes
+      end
+
+      def team
+        selected_cops = RuboCop::Cop::Cop.all.select { |cop| cop.match?(@only_cops) }
+        cop_classes = RuboCop::Cop::Registry.new(selected_cops)
+
+        RuboCop::Cop::Team.new(cop_classes, @rubocop_config, extra_details: true, display_cop_names: true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a RubocopText linter:

- We have a particular use case where we need to run a rubocop that checks for hardcoded string in erb files
- The original Rubocop linter grabs any `erb` nodes, but for our use case we need only the erb nodes that are children of a text node (visible in the dom) and we don't want to run our cop on embedded erb inside tag attributes for example
- The cop itself has no context nor can detect if the parent was a text node or a tag_attribute node, so I decided to create a whole new linter that inherits from Rubocop but it's sole purpose would be to run a specific list of cops that expects code visible for the end user