### PR TITLE
Add `ProcessedSource` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,11 +208,9 @@ module ERBLint
     end
     self.config_schema = ConfigSchema
 
-    protected
-
-    def lint_lines(lines)
+    def offenses(processed_source)
       errors = []
-      unless lines.include?('this file is fine')
+      unless processed_source.file_content.include?('this file is fine')
         errors << Offense.new(
           self,
           1..1,

--- a/lib/erb_lint.rb
+++ b/lib/erb_lint.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
-require 'erb_lint/version'
-require 'erb_lint/offense'
+require 'erb_lint/file_loader'
 require 'erb_lint/linter_config'
 require 'erb_lint/linter_registry'
 require 'erb_lint/linter'
+require 'erb_lint/offense'
+require 'erb_lint/processed_source'
 require 'erb_lint/runner_config'
 require 'erb_lint/runner'
-require 'erb_lint/file_loader'
+require 'erb_lint/version'
 
 # Load linters
 Dir[File.expand_path('erb_lint/linters/**/*.rb', File.dirname(__FILE__))].each do |file|

--- a/lib/erb_lint/linter.rb
+++ b/lib/erb_lint/linter.rb
@@ -41,16 +41,7 @@ module ERBLint
       @config.excludes_file?(filename)
     end
 
-    def lint_file(file_content)
-      lines = file_content.scan(/[^\n]*\n|[^\n]+/)
-      lint_lines(lines)
-    end
-
-    protected
-
-    # The lint_lines method that contains the logic for the linter and returns a list of errors.
-    # Must be implemented by the concrete inheriting class.
-    def lint_lines(_lines)
+    def offenses(_processed_source)
       raise NotImplementedError, "must implement ##{__method__}"
     end
   end

--- a/lib/erb_lint/linters/erb_safety.rb
+++ b/lib/erb_lint/linters/erb_safety.rb
@@ -21,13 +21,13 @@ module ERBLint
         @config_filename = @config.better_html_config
       end
 
-      def lint_file(file_content)
-        errors = []
-        tester = Tester.new(file_content, config: better_html_config)
+      def offenses(processed_source)
+        offenses = []
+        tester = Tester.new(processed_source.file_content, config: better_html_config)
         tester.errors.each do |error|
-          errors << format_offense(error)
+          offenses << format_offense(error)
         end
-        errors
+        offenses
       end
 
       private

--- a/lib/erb_lint/linters/final_newline.rb
+++ b/lib/erb_lint/linters/final_newline.rb
@@ -16,28 +16,28 @@ module ERBLint
         @new_lines_should_be_present = @config.present?
       end
 
-      protected
+      def offenses(processed_source)
+        lines = processed_source.file_content.scan(/[^\n]*\n|[^\n]+/)
 
-      def lint_lines(lines)
-        errors = []
-        return errors if lines.empty?
+        offenses = []
+        return offenses if lines.empty?
 
         ends_with_newline = lines.last.chars[-1] == "\n"
 
         if @new_lines_should_be_present && !ends_with_newline
-          errors << Offense.new(
+          offenses << Offense.new(
             self,
             Range.new(lines.length, lines.length),
             'Missing a trailing newline at the end of the file.'
           )
         elsif !@new_lines_should_be_present && ends_with_newline
-          errors << Offense.new(
+          offenses << Offense.new(
             self,
             Range.new(lines.length, lines.length),
             'Remove the trailing newline at the end of the file.'
           )
         end
-        errors
+        offenses
       end
     end
   end

--- a/lib/erb_lint/processed_source.rb
+++ b/lib/erb_lint/processed_source.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ERBLint
+  class ProcessedSource
+    attr_reader :file_content, :parser
+
+    def initialize(file_content)
+      @file_content = file_content
+      @parser = BetterHtml::Parser.new(file_content, template_language: :html)
+    end
+
+    def ast
+      @parser.ast
+    end
+  end
+end

--- a/lib/erb_lint/runner.rb
+++ b/lib/erb_lint/runner.rb
@@ -16,11 +16,12 @@ module ERBLint
     end
 
     def run(filename, file_content)
+      source = ProcessedSource.new(file_content)
       offenses = []
       @linters
         .reject { |linter| linter.excludes_file?(filename) }
         .each do |linter|
-        offenses += linter.lint_file(file_content)
+        offenses += linter.offenses(source)
       end
       offenses
     end

--- a/spec/erb_lint/cli_spec.rb
+++ b/spec/erb_lint/cli_spec.rb
@@ -28,7 +28,7 @@ describe ERBLint::CLI do
   module ERBLint
     module Linters
       class LinterWithErrors < Linter
-        def lint_lines(_lines)
+        def offenses(_processed_source)
           [
             Offense.new(
               self,
@@ -40,7 +40,7 @@ describe ERBLint::CLI do
       end
 
       class LinterWithoutErrors < Linter
-        def lint_lines(_lines)
+        def offenses(_processed_source)
           []
         end
       end

--- a/spec/erb_lint/linter_spec.rb
+++ b/spec/erb_lint/linter_spec.rb
@@ -6,61 +6,15 @@ describe ERBLint::Linter do
   context 'when inheriting from the Linter class' do
     let(:linter_config) { ERBLint::LinterConfig.new }
     let(:file_loader)   { ERBLint::FileLoader.new('.') }
-    subject             { ERBLint::Linters::Fake.new(file_loader, linter_config) }
+    let(:linter) { ERBLint::Linters::Fake.new(file_loader, linter_config) }
+    let(:processed_source) { ERBLint::ProcessedSource.new(file) }
+    subject { linter }
 
     module ERBLint
       module Linters
         class Fake < ERBLint::Linter
-          protected
-
-          def lint_lines(_lines)
+          def offenses(_processed_source)
           end
-        end
-      end
-    end
-
-    describe '#lint_file' do
-      after do
-        subject.lint_file(file)
-      end
-
-      context 'when the file is empty' do
-        let(:file) { '' }
-
-        it 'calls lint_lines with an empty list' do
-          expect(subject).to receive(:lint_lines).with([])
-        end
-      end
-
-      context 'when the file does not end with a newline' do
-        let(:file) { <<~FILE.chomp }
-          Line1
-          Line2
-          Line3
-        FILE
-
-        it 'calls lint_lines with the list of lines' do
-          expect(subject).to receive(:lint_lines).with(%W(
-            Line1\n
-            Line2\n
-            Line3
-          ))
-        end
-      end
-
-      context 'when the file ends with a newline' do
-        let(:file) { <<~FILE }
-          Line1
-          Line2
-          Line3
-        FILE
-
-        it 'calls lint_lines with the list of lines' do
-          expect(subject).to receive(:lint_lines).with(%W(
-            Line1\n
-            Line2\n
-            Line3\n
-          ))
         end
       end
     end

--- a/spec/erb_lint/linters/deprecated_classes_spec.rb
+++ b/spec/erb_lint/linters/deprecated_classes_spec.rb
@@ -11,8 +11,8 @@ describe ERBLint::Linters::DeprecatedClasses do
 
   let(:file_loader) { ERBLint::FileLoader.new('.') }
   let(:linter) { described_class.new(file_loader, linter_config) }
-
-  subject(:linter_errors) { linter.lint_file(file) }
+  let(:processed_source) { ERBLint::ProcessedSource.new(file) }
+  subject(:offenses) { linter.offenses(processed_source) }
 
   context 'when the rule set is empty' do
     let(:rule_set) { [] }
@@ -20,8 +20,8 @@ describe ERBLint::Linters::DeprecatedClasses do
     context 'when the file is empty' do
       let(:file) { '' }
 
-      it 'does not report any errors' do
-        expect(linter_errors).to eq []
+      it 'does not report any offense' do
+        expect(subject).to eq []
       end
     end
 
@@ -32,8 +32,8 @@ describe ERBLint::Linters::DeprecatedClasses do
         </div>
       FILE
 
-      it 'does not report any errors' do
-        expect(linter_errors).to eq []
+      it 'does not report any offenses' do
+        expect(subject).to eq []
       end
     end
   end
@@ -60,8 +60,8 @@ describe ERBLint::Linters::DeprecatedClasses do
     context 'when the file is empty' do
       let(:file) { '' }
 
-      it 'does not report any errors' do
-        expect(linter_errors).to eq []
+      it 'does not report any offenses' do
+        expect(subject).to eq []
       end
     end
 
@@ -72,8 +72,8 @@ describe ERBLint::Linters::DeprecatedClasses do
         </div>
       FILE
 
-      it 'does not report any errors' do
-        expect(linter_errors).to eq []
+      it 'does not report any offenses' do
+        expect(subject).to eq []
       end
     end
 
@@ -84,12 +84,12 @@ describe ERBLint::Linters::DeprecatedClasses do
         </div>
       FILE
 
-      it 'reports 1 error' do
-        expect(linter_errors.size).to eq 1
+      it 'reports 1 offense' do
+        expect(subject.size).to eq 1
       end
 
-      it 'reports an error with message containing suggestion 1' do
-        expect(linter_errors.first.message).to include suggestion_1
+      it 'reports an offense with message containing suggestion 1' do
+        expect(subject.first.message).to include suggestion_1
       end
     end
 
@@ -102,12 +102,12 @@ describe ERBLint::Linters::DeprecatedClasses do
         </script>
       FILE
 
-      it 'reports 1 error' do
-        expect(linter_errors.size).to eq 1
+      it 'reports 1 offense' do
+        expect(subject.size).to eq 1
       end
 
-      it 'reports an error with message containing suggestion 1' do
-        expect(linter_errors.first.message).to include suggestion_1
+      it 'reports an offense with message containing suggestion 1' do
+        expect(subject.first.message).to include suggestion_1
       end
     end
 
@@ -119,13 +119,13 @@ describe ERBLint::Linters::DeprecatedClasses do
           </div>
         FILE
 
-        it 'reports 2 errors' do
-          expect(linter_errors.size).to eq 2
+        it 'reports 2 offenses' do
+          expect(subject.size).to eq 2
         end
 
-        it 'reports errors with messages containing suggestion 1' do
-          expect(linter_errors[0].message).to include suggestion_1
-          expect(linter_errors[1].message).to include suggestion_1
+        it 'reports offenses with messages containing suggestion 1' do
+          expect(subject[0].message).to include suggestion_1
+          expect(subject[1].message).to include suggestion_1
         end
       end
 
@@ -136,13 +136,13 @@ describe ERBLint::Linters::DeprecatedClasses do
           </div>
         FILE
 
-        it 'reports 2 errors' do
-          expect(linter_errors.size).to eq 2
+        it 'reports 2 offenses' do
+          expect(subject.size).to eq 2
         end
 
-        it 'reports errors with messages containing suggestion 1' do
-          expect(linter_errors[0].message).to include suggestion_1
-          expect(linter_errors[1].message).to include suggestion_1
+        it 'reports offenses with messages containing suggestion 1' do
+          expect(subject[0].message).to include suggestion_1
+          expect(subject[1].message).to include suggestion_1
         end
       end
     end
@@ -154,13 +154,13 @@ describe ERBLint::Linters::DeprecatedClasses do
         </div>
       FILE
 
-      it 'reports 2 errors' do
-        expect(linter_errors.size).to eq 2
+      it 'reports 2 offenses' do
+        expect(subject.size).to eq 2
       end
 
-      it 'reports errors with messages containing suggestion 2' do
-        expect(linter_errors[0].message).to include suggestion_2
-        expect(linter_errors[1].message).to include suggestion_2
+      it 'reports offenses with messages containing suggestion 2' do
+        expect(subject[0].message).to include suggestion_2
+        expect(subject[1].message).to include suggestion_2
       end
     end
 
@@ -176,8 +176,8 @@ describe ERBLint::Linters::DeprecatedClasses do
       context 'when the file is empty' do
         let(:file) { '' }
 
-        it 'does not report any errors' do
-          expect(linter_errors).to eq []
+        it 'does not report any offenses' do
+          expect(subject).to eq []
         end
       end
 
@@ -188,12 +188,12 @@ describe ERBLint::Linters::DeprecatedClasses do
           </div>
         FILE
 
-        it 'reports 1 error' do
-          expect(linter_errors.size).to eq 1
+        it 'reports 1 offense' do
+          expect(subject.size).to eq 1
         end
 
-        it 'reports an error with its message ending with the addendum' do
-          expect(linter_errors.first.message).to end_with addendum
+        it 'reports an offense with its message ending with the addendum' do
+          expect(subject.first.message).to end_with addendum
         end
       end
     end
@@ -208,8 +208,8 @@ describe ERBLint::Linters::DeprecatedClasses do
       context 'when the file is empty' do
         let(:file) { '' }
 
-        it 'does not report any errors' do
-          expect(linter_errors).to eq []
+        it 'does not report any offenses' do
+          expect(subject).to eq []
         end
       end
 
@@ -220,12 +220,12 @@ describe ERBLint::Linters::DeprecatedClasses do
           </div>
         FILE
 
-        it 'reports 1 error' do
-          expect(linter_errors.size).to eq 1
+        it 'reports 1 offense' do
+          expect(subject.size).to eq 1
         end
 
-        it 'reports an error with its message ending with the suggestion' do
-          expect(linter_errors.first.message).to end_with suggestion_1
+        it 'reports an offense with its message ending with the suggestion' do
+          expect(subject.first.message).to end_with suggestion_1
         end
       end
     end
@@ -235,8 +235,8 @@ describe ERBLint::Linters::DeprecatedClasses do
         <div superlongpotentialattributename"small">
       FILE
 
-      it 'does not report any errors' do
-        expect(linter_errors).to eq []
+      it 'does not report any offenses' do
+        expect(subject).to eq []
       end
     end
   end

--- a/spec/erb_lint/linters/final_newline_spec.rb
+++ b/spec/erb_lint/linters/final_newline_spec.rb
@@ -7,8 +7,8 @@ describe ERBLint::Linters::FinalNewline do
 
   let(:file_loader) { ERBLint::FileLoader.new('.') }
   let(:linter) { described_class.new(file_loader, linter_config) }
-
-  subject(:linter_errors) { linter.lint_file(file) }
+  let(:processed_source) { ERBLint::ProcessedSource.new(file) }
+  subject(:offenses) { linter.offenses(processed_source) }
 
   context 'when trailing newline is preferred' do
     let(:present) { true }
@@ -16,8 +16,8 @@ describe ERBLint::Linters::FinalNewline do
     context 'when the file is empty' do
       let(:file) { '' }
 
-      it 'does not report any errors' do
-        expect(linter_errors).to eq []
+      it 'does not report any offenses' do
+        expect(subject).to eq []
       end
     end
 
@@ -25,19 +25,19 @@ describe ERBLint::Linters::FinalNewline do
       let(:file) { "<div id=\"a\">\nContent\n</div>\n" }
 
       it 'does not report any errors' do
-        expect(linter_errors).to eq []
+        expect(subject).to eq []
       end
     end
 
     context 'when the file does not end with a newline' do
       let(:file) { "<div id=\"a\">\nContent\n</div>" }
 
-      it 'reports 1 error' do
-        expect(linter_errors.size).to eq 1
+      it 'reports 1 offense' do
+        expect(subject.size).to eq 1
       end
 
-      it 'reports an error on the last line' do
-        expect(linter_errors.first.line_range).to eq 3..3
+      it 'reports an offense on the last line' do
+        expect(subject.first.line_range).to eq 3..3
       end
     end
   end
@@ -48,28 +48,28 @@ describe ERBLint::Linters::FinalNewline do
     context 'when the file is empty' do
       let(:file) { '' }
 
-      it 'does not report any errors' do
-        expect(linter_errors).to eq []
+      it 'does not report any offenses' do
+        expect(subject).to eq []
       end
     end
 
     context 'when the file ends with a newline' do
       let(:file) { "<div id=\"a\">\nContent\n</div>\n" }
 
-      it 'reports 1 error' do
-        expect(linter_errors.size).to eq 1
+      it 'reports 1 offense' do
+        expect(subject.size).to eq 1
       end
 
-      it 'reports an error on the last line' do
-        expect(linter_errors.first.line_range).to eq 3..3
+      it 'reports an offense on the last line' do
+        expect(subject.first.line_range).to eq 3..3
       end
     end
 
     context 'when the file does not end with a newline' do
       let(:file) { "<div id=\"a\">\nContent\n</div>" }
 
-      it 'does not report any errors' do
-        expect(linter_errors).to eq []
+      it 'does not report any offenses' do
+        expect(subject).to eq []
       end
     end
   end
@@ -80,28 +80,28 @@ describe ERBLint::Linters::FinalNewline do
     context 'when the file is empty' do
       let(:file) { '' }
 
-      it 'does not report any errors' do
-        expect(linter_errors).to eq []
+      it 'does not report any offenses' do
+        expect(subject).to eq []
       end
     end
 
     context 'when the file ends with a newline' do
       let(:file) { "<div id=\"a\">\nContent\n</div>\n" }
 
-      it 'does not report any errors' do
-        expect(linter_errors).to eq []
+      it 'does not report any offenses' do
+        expect(subject).to eq []
       end
     end
 
     context 'when the file does not end with a newline' do
       let(:file) { "<div id=\"a\">\nContent\n</div>" }
 
-      it 'reports 1 error' do
-        expect(linter_errors.size).to eq 1
+      it 'reports 1 offense' do
+        expect(subject.size).to eq 1
       end
 
-      it 'reports an error on the last line' do
-        expect(linter_errors.first.line_range).to eq 3..3
+      it 'reports an offense on the last line' do
+        expect(subject.first.line_range).to eq 3..3
       end
     end
   end

--- a/spec/erb_lint/linters/rubocop_spec.rb
+++ b/spec/erb_lint/linters/rubocop_spec.rb
@@ -17,7 +17,8 @@ describe ERBLint::Linters::Rubocop do
   end
   let(:file_loader) { ERBLint::FileLoader.new('.') }
   let(:linter) { described_class.new(file_loader, linter_config) }
-  subject(:linter_errors) { linter.lint_file(file) }
+  let(:processed_source) { ERBLint::ProcessedSource.new(file) }
+  subject(:linter_errors) { linter.offenses(processed_source) }
 
   context 'when rubocop finds no offenses' do
     let(:file) { <<~FILE }

--- a/spec/erb_lint/runner_spec.rb
+++ b/spec/erb_lint/runner_spec.rb
@@ -16,7 +16,7 @@ describe ERBLint::Runner do
   module ERBLint
     module Linters
       class FakeLinter1 < Linter
-        def lint_file(_file_content)
+        def offenses(_processed_source)
           [Offense.new(self, 1..1, "#{self.class.name} error")]
         end
       end


### PR DESCRIPTION
This changes the linter classes, removing the `lint_file` and `lint_lines` methods in favor of a single `offenses` method which returns an array of offenses (naming copied from rubocop). The new `offenses` method takes a `ProcessedSource` object which holds the source file as well as a parsed AST of that source file (again similar to rubocop). I changed the "errors" wording in all specs to "offenses".

This means the source file will be parsed only once instead of being parsed by each linter. In turn, this means AST nodes will be the same for all linters, which I believe is a requirement to rewrite the source using `Parser::Source::Rewriter` (for autocorrect-like functionality).

FYI @rafaelfranca @Edouard-chin 