### PR TITLE
Use character position for offense instead of line position

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -40,7 +40,8 @@ module ERBLint
       runner_config = @config.merge(runner_config_override)
       runner = ERBLint::Runner.new(file_loader, runner_config)
       lint_files.each do |filename|
-        offenses = runner.run(filename, File.read(filename))
+        processed_source = ERBLint::ProcessedSource.new(filename, File.read(filename))
+        offenses = runner.run(processed_source)
         offenses.each do |offense|
           puts <<~EOF
             #{offense.message}

--- a/lib/erb_lint/linters/deprecated_classes.rb
+++ b/lib/erb_lint/linters/deprecated_classes.rb
@@ -29,19 +29,34 @@ module ERBLint
       end
 
       def offenses(processed_source)
-        results = []
-        class_name_with_loc(processed_source).each do |class_name, loc|
-          range = processed_source.to_source_range(loc.start, loc.stop)
-          results.push(*generate_errors(class_name, range))
-        end
-        text_tags_content(processed_source).each do |content|
-          sub_source = ProcessedSource.new(processed_source.filename, content)
-          results.push(*offenses(sub_source))
-        end
-        results
+        process_nested_offenses(
+          source: processed_source,
+          offset: 0,
+          parent_source: processed_source,
+        )
       end
 
       private
+
+      def process_nested_offenses(source:, offset:, parent_source:)
+        offenses = []
+        class_name_with_loc(source).each do |class_name, loc|
+          range = parent_source.to_source_range(
+            offset + loc.start,
+            offset + loc.stop
+          )
+          offenses += generate_errors(class_name, range)
+        end
+        text_tags_content(source).each do |content_node|
+          sub_source = ProcessedSource.new(source.filename, content_node.loc.source)
+          offenses += process_nested_offenses(
+            source: sub_source,
+            offset: offset + content_node.loc.start,
+            parent_source: parent_source
+          )
+        end
+        offenses
+      end
 
       def class_name_with_loc(processed_source)
         Enumerator.new do |yielder|
@@ -63,7 +78,7 @@ module ERBLint
               index = processed_source.ast.to_a.find_index(tag.node)
               next_node = processed_source.ast.to_a[index + 1]
 
-              yielder.yield(next_node.loc.source) if next_node.type == :text
+              yielder.yield(next_node) if next_node.type == :text
             end
         end
       end

--- a/lib/erb_lint/linters/erb_safety.rb
+++ b/lib/erb_lint/linters/erb_safety.rb
@@ -25,7 +25,11 @@ module ERBLint
         offenses = []
         tester = Tester.new(processed_source.file_content, config: better_html_config)
         tester.errors.each do |error|
-          offenses << format_offense(error)
+          offenses << Offense.new(
+            self,
+            processed_source.to_source_range(error.location.start, error.location.stop),
+            error.message
+          )
         end
         offenses
       end
@@ -42,14 +46,6 @@ module ERBLint
             end
           BetterHtml::Config.new(**config_hash)
         end
-      end
-
-      def format_offense(error)
-        Offense.new(
-          self,
-          error.location.line_range,
-          error.message
-        )
       end
     end
   end

--- a/lib/erb_lint/linters/final_newline.rb
+++ b/lib/erb_lint/linters/final_newline.rb
@@ -17,24 +17,25 @@ module ERBLint
       end
 
       def offenses(processed_source)
-        lines = processed_source.file_content.scan(/[^\n]*\n|[^\n]+/)
+        file_content = processed_source.file_content
 
         offenses = []
-        return offenses if lines.empty?
+        return offenses if file_content.empty?
 
-        ends_with_newline = lines.last.chars[-1] == "\n"
+        match = file_content.match(/(\n+)\z/)
+        ends_with_newline = match.present?
 
         if @new_lines_should_be_present && !ends_with_newline
           offenses << Offense.new(
             self,
-            Range.new(lines.length, lines.length),
+            processed_source.to_source_range(file_content.size, file_content.size - 1),
             'Missing a trailing newline at the end of the file.'
           )
         elsif !@new_lines_should_be_present && ends_with_newline
           offenses << Offense.new(
             self,
-            Range.new(lines.length, lines.length),
-            'Remove the trailing newline at the end of the file.'
+            processed_source.to_source_range(match.begin(0), match.end(0) - 1),
+            "Remove #{match[0].size} trailing newline at the end of the file."
           )
         end
         offenses

--- a/lib/erb_lint/offense.rb
+++ b/lib/erb_lint/offense.rb
@@ -3,25 +3,32 @@
 module ERBLint
   # Defines common functionality available to all linters.
   class Offense
-    attr_reader :linter, :line_range, :message
+    attr_reader :linter, :source_range, :message
 
-    def initialize(linter, line_range, message)
+    def initialize(linter, source_range, message)
+      unless source_range.is_a?(Parser::Source::Range)
+        raise ArgumentError, "expected Parser::Source::Range for arg 2"
+      end
       @linter = linter
-      @line_range = line_range
+      @source_range = source_range
       @message = message
     end
 
     def inspect
       "#<#{self.class.name} linter=#{linter.class.name} "\
-        "line_range=#{line_range} "\
+        "source_range=#{source_range.begin_pos}..#{source_range.end_pos - 1} "\
         "message=#{message}>"
     end
 
     def ==(other)
       other.class == self.class &&
         other.linter == linter &&
-        other.line_range == line_range &&
+        other.source_range == source_range &&
         other.message == message
+    end
+
+    def line_range
+      Range.new(source_range.line, source_range.last_line)
     end
   end
 end

--- a/lib/erb_lint/processed_source.rb
+++ b/lib/erb_lint/processed_source.rb
@@ -2,15 +2,28 @@
 
 module ERBLint
   class ProcessedSource
-    attr_reader :file_content, :parser
+    attr_reader :filename, :file_content, :parser
 
-    def initialize(file_content)
+    def initialize(filename, file_content)
+      @filename = filename
       @file_content = file_content
       @parser = BetterHtml::Parser.new(file_content, template_language: :html)
     end
 
     def ast
       @parser.ast
+    end
+
+    def source_buffer
+      @source_buffer ||= begin
+        buffer = Parser::Source::Buffer.new(filename)
+        buffer.source = file_content
+        buffer
+      end
+    end
+
+    def to_source_range(begin_pos, end_pos)
+      Parser::Source::Range.new(source_buffer, begin_pos, end_pos + 1)
     end
   end
 end

--- a/lib/erb_lint/runner.rb
+++ b/lib/erb_lint/runner.rb
@@ -15,13 +15,12 @@ module ERBLint
       end
     end
 
-    def run(filename, file_content)
-      source = ProcessedSource.new(file_content)
+    def run(processed_source)
       offenses = []
       @linters
-        .reject { |linter| linter.excludes_file?(filename) }
+        .reject { |linter| linter.excludes_file?(processed_source.filename) }
         .each do |linter|
-        offenses += linter.offenses(source)
+        offenses += linter.offenses(processed_source)
       end
       offenses
     end

--- a/spec/erb_lint/cli_spec.rb
+++ b/spec/erb_lint/cli_spec.rb
@@ -28,11 +28,11 @@ describe ERBLint::CLI do
   module ERBLint
     module Linters
       class LinterWithErrors < Linter
-        def offenses(_processed_source)
+        def offenses(processed_source)
           [
             Offense.new(
               self,
-              1..1,
+              processed_source.to_source_range(1, 1),
               'fake message from a fake linter'
             )
           ]

--- a/spec/erb_lint/fixtures/cops/example_cop.rb
+++ b/spec/erb_lint/fixtures/cops/example_cop.rb
@@ -7,7 +7,7 @@ module RuboCop
         MSG = 'An arbitrary rule has been violated.'
 
         def on_send(node)
-          add_offense(node, location: :selector) if node.command?(:banned_method)
+          add_offense(node, location: :expression) if node.command?(:banned_method)
         end
         alias_method :on_csend, :on_send
       end

--- a/spec/erb_lint/linter_spec.rb
+++ b/spec/erb_lint/linter_spec.rb
@@ -7,7 +7,7 @@ describe ERBLint::Linter do
     let(:linter_config) { ERBLint::LinterConfig.new }
     let(:file_loader)   { ERBLint::FileLoader.new('.') }
     let(:linter) { ERBLint::Linters::Fake.new(file_loader, linter_config) }
-    let(:processed_source) { ERBLint::ProcessedSource.new(file) }
+    let(:processed_source) { ERBLint::ProcessedSource.new('file.rb', file) }
     subject { linter }
 
     module ERBLint

--- a/spec/erb_lint/linters/deprecated_classes_spec.rb
+++ b/spec/erb_lint/linters/deprecated_classes_spec.rb
@@ -109,6 +109,12 @@ describe ERBLint::Linters::DeprecatedClasses do
       it 'reports an offense with message containing suggestion 1' do
         expect(subject.first.message).to include suggestion_1
       end
+
+      it 'reports an offense with position range that is adjusted in the nested context' do
+        expect(subject.first.source_range.begin_pos).to eq 28
+        expect(subject.first.source_range.end_pos).to eq 45
+        expect(subject.first.source_range.source).to eq "<div class=\"abc\">"
+      end
     end
 
     context 'when the file contains both classes from set 1' do

--- a/spec/erb_lint/linters/deprecated_classes_spec.rb
+++ b/spec/erb_lint/linters/deprecated_classes_spec.rb
@@ -11,7 +11,7 @@ describe ERBLint::Linters::DeprecatedClasses do
 
   let(:file_loader) { ERBLint::FileLoader.new('.') }
   let(:linter) { described_class.new(file_loader, linter_config) }
-  let(:processed_source) { ERBLint::ProcessedSource.new(file) }
+  let(:processed_source) { ERBLint::ProcessedSource.new('file.rb', file) }
   subject(:offenses) { linter.offenses(processed_source) }
 
   context 'when the rule set is empty' do

--- a/spec/erb_lint/linters/final_newline_spec.rb
+++ b/spec/erb_lint/linters/final_newline_spec.rb
@@ -82,12 +82,16 @@ describe ERBLint::Linters::FinalNewline do
     end
 
     context 'when the file ends with multiple newlines' do
-      let(:file) { "foo\n\n" }
+      let(:file) { "foo\n\n\n\n" }
 
       it 'the offense range includes all newline characters' do
         expect(subject.first.source_range.begin_pos).to eq 3
-        expect(subject.first.source_range.end_pos).to eq 5
-        expect(subject.first.source_range.source).to eq "\n\n"
+        expect(subject.first.source_range.end_pos).to eq 7
+        expect(subject.first.source_range.source).to eq "\n\n\n\n"
+      end
+
+      it 'reports meaningful message' do
+        expect(subject.first.message).to eq 'Remove 4 trailing newline at the end of the file.'
       end
     end
 

--- a/spec/erb_lint/linters/final_newline_spec.rb
+++ b/spec/erb_lint/linters/final_newline_spec.rb
@@ -7,7 +7,7 @@ describe ERBLint::Linters::FinalNewline do
 
   let(:file_loader) { ERBLint::FileLoader.new('.') }
   let(:linter) { described_class.new(file_loader, linter_config) }
-  let(:processed_source) { ERBLint::ProcessedSource.new(file) }
+  let(:processed_source) { ERBLint::ProcessedSource.new('file.rb', file) }
   subject(:offenses) { linter.offenses(processed_source) }
 
   context 'when trailing newline is preferred' do
@@ -39,6 +39,12 @@ describe ERBLint::Linters::FinalNewline do
       it 'reports an offense on the last line' do
         expect(subject.first.line_range).to eq 3..3
       end
+
+      it 'the offense range is set to an empty range after the last character of the file' do
+        expect(subject.first.source_range.begin_pos).to eq 27
+        expect(subject.first.source_range.end_pos).to eq 27
+        expect(subject.first.source_range.source).to eq ""
+      end
     end
   end
 
@@ -60,8 +66,28 @@ describe ERBLint::Linters::FinalNewline do
         expect(subject.size).to eq 1
       end
 
+      it 'reports meaningful message' do
+        expect(subject.first.message).to eq 'Remove 1 trailing newline at the end of the file.'
+      end
+
       it 'reports an offense on the last line' do
-        expect(subject.first.line_range).to eq 3..3
+        expect(subject.first.line_range).to eq 3..4
+      end
+
+      it 'the offense range is set to the newline character' do
+        expect(subject.first.source_range.begin_pos).to eq 27
+        expect(subject.first.source_range.end_pos).to eq 28
+        expect(subject.first.source_range.source).to eq "\n"
+      end
+    end
+
+    context 'when the file ends with multiple newlines' do
+      let(:file) { "foo\n\n" }
+
+      it 'the offense range includes all newline characters' do
+        expect(subject.first.source_range.begin_pos).to eq 3
+        expect(subject.first.source_range.end_pos).to eq 5
+        expect(subject.first.source_range.source).to eq "\n\n"
       end
     end
 

--- a/spec/erb_lint/linters/rubocop_spec.rb
+++ b/spec/erb_lint/linters/rubocop_spec.rb
@@ -34,6 +34,7 @@ describe ERBLint::Linters::Rubocop do
     FILE
 
     it { expect(subject).to eq [arbitrary_error_message(3..15)] }
+    it { expect(subject.first.source_range.source).to eq "banned_method" }
   end
 
   context 'when rubocop finds offenses in ruby expressions' do
@@ -147,6 +148,9 @@ describe ERBLint::Linters::Rubocop do
 
       it do
         expect(subject.size).to eq(1)
+        expect(subject[0].source_range.begin_pos).to eq 25
+        expect(subject[0].source_range.end_pos).to eq 38
+        expect(subject[0].source_range.source).to eq "checked: true"
         expect(subject[0].line_range).to eq 2..2
         expect(subject[0].message).to \
           eq "Layout/AlignParameters: Use one level of indentation for "\

--- a/spec/erb_lint/runner_spec.rb
+++ b/spec/erb_lint/runner_spec.rb
@@ -16,8 +16,8 @@ describe ERBLint::Runner do
   module ERBLint
     module Linters
       class FakeLinter1 < Linter
-        def offenses(_processed_source)
-          [Offense.new(self, 1..1, "#{self.class.name} error")]
+        def offenses(processed_source)
+          [Offense.new(self, processed_source.to_source_range(1, 1), "#{self.class.name} error")]
         end
       end
       class FakeLinter2 < FakeLinter1; end
@@ -27,7 +27,8 @@ describe ERBLint::Runner do
   describe '#run' do
     let(:file) { 'DummyFileContent' }
     let(:filename) { 'somefolder/otherfolder/dummyfile.html.erb' }
-    subject { runner.run(filename, file) }
+    let(:processed_source) { ERBLint::ProcessedSource.new(filename, file) }
+    subject { runner.run(processed_source) }
 
     context 'when all linters are enabled' do
       let(:config) do


### PR DESCRIPTION
To perform automagic offense correction, we need more accurate position of each offense. This change will keep the absolute character position for the offense (begining and end) instead of line numbers. This makes use of `Parser::Source::Range` since this is required to use RuboCop's corrector which can be used as-is in this gem. I added `Offense#line_range` which returns a range object that is the same as the existing `line_range`.