### PR TITLE
Ensure we keep index aligned between offenses and their corrections

### DIFF
--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -77,7 +77,7 @@ module ERBLint
         team = build_team
         team.inspect_file(source)
         team.cops.each do |cop|
-          cop.offenses.reject(&:disabled?).each_with_index do |rubocop_offense, index|
+          cop.offenses.select(&:corrected?).each_with_index do |rubocop_offense, index|
             correction = cop.corrections[index] if rubocop_offense.corrected?
 
             offset = code_node.loc.start - alignment_column


### PR DESCRIPTION
There seem to be a potential for misalignment between offenses and corrections because `reject` will change indexes given by `each_with_index`.