### PR TITLE
Forgot to add `require_relative` rubocop:

### DIFF
--- a/lib/erb_lint/linters/rubocop_text.rb
+++ b/lib/erb_lint/linters/rubocop_text.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'rubocop'
+
 module ERBLint
   module Linters
     class RubocopText < Rubocop


### PR DESCRIPTION
Was assuming `ERBLint::Linters::Rubocop` would be defined since we require it all linters in a loop https://github.com/Shopify/erb-lint/blob/06f33b84811f96f522b1a18637e2b517f0f47c0f/lib/erb_lint.rb#L16-L18

But it doesn't seems to appear to always be the case and I'm getting unitialized constant errors.
```
Bundler::GemRequireError: There was an error while trying to load the gem 'erb_lint'.
Gem Load Error is: uninitialized constant ERBLint::Linters::Rubocop
```
 

