### PR TITLE
Created the `HardCodedString` linter:

### DIFF
--- a/lib/erb_lint/linters/hard_coded_string.rb
+++ b/lib/erb_lint/linters/hard_coded_string.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'better_html/tree/tag'
+
+module ERBLint
+  module Linters
+    # Checks for hardcoded strings. Useful if you want to ensure a string can be translated using i18n.
+    class HardCodedString < Linter
+      include LinterRegistry
+
+      def offenses(processed_source)
+        hardcoded_strings = processed_source.ast.descendants(:text).each_with_object([]) do |text_node, to_check|
+          next if javascript?(processed_source, text_node)
+
+          offended_str = text_node.to_a.find { |node| relevant_node(node) }
+          to_check << [text_node, offended_str] if offended_str
+        end
+
+        hardcoded_strings.compact.map do |text_node, offended_str|
+          Offense.new(
+            self,
+            processed_source.to_source_range(text_node.loc.start, text_node.loc.stop),
+            message(offended_str)
+          )
+        end
+      end
+
+      private
+
+      def javascript?(processed_source, text_node)
+        ast = processed_source.parser.ast.to_a
+        index = ast.find_index(text_node)
+
+        previous_node = ast[index - 1]
+
+        if previous_node.type == :tag
+          tag = BetterHtml::Tree::Tag.from_node(previous_node)
+
+          tag.name == "script" && !tag.closing?
+        end
+      end
+
+      def relevant_node(inner_node)
+        if inner_node.is_a?(String)
+          inner_node.strip.empty? ? false : inner_node
+        else
+          false
+        end
+      end
+
+      def message(string)
+        stripped_string = string.strip
+
+        if stripped_string.length > 1
+          "String not translated: #{stripped_string}"
+        else
+          "Consider using Rails helpers to move out the single character `#{stripped_string}` from the html."
+        end
+      end
+    end
+  end
+end

--- a/spec/erb_lint/linters/hard_coded_string_spec.rb
+++ b/spec/erb_lint/linters/hard_coded_string_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ERBLint::Linters::HardCodedString do
+  let(:linter_config) do
+    described_class.config_schema.new
+  end
+  let(:file_loader) { ERBLint::FileLoader.new('.') }
+  let(:linter) { described_class.new(file_loader, linter_config) }
+  let(:processed_source) { ERBLint::ProcessedSource.new('file.rb', file) }
+  subject(:offenses) { linter.offenses(processed_source) }
+
+  context 'when file contains hard coded string' do
+    let(:file) { <<~FILE }
+      <span> Hello </span>
+    FILE
+
+    it { expect(subject).to eq [untranslated_string_error(6..12, 'String not translated: Hello')] }
+  end
+
+  context 'when file contains nested hard coded string' do
+    let(:file) { <<~FILE }
+      <span class="example">
+        <div id="hero">
+          <span id="cat"> Example </span>
+        </div>
+      </span>
+    FILE
+
+    it { expect(subject).to eq [untranslated_string_error(60..68, 'String not translated: Example')] }
+  end
+
+  context 'when file contains a mix of hard coded string and erb' do
+    let(:file) { <<~FILE }
+      <span><%= foo %> Example </span>
+    FILE
+
+    it { expect(subject).to eq [untranslated_string_error(6..24, 'String not translated: Example')] }
+  end
+
+  context 'when file contains hard coded string nested inside erb' do
+    let(:file) { <<~FILE }
+      <span>
+        <% foo do %>
+          <span> Example </span>
+        <% end %>
+      </span>
+    FILE
+
+    it { expect(subject).to eq [untranslated_string_error(32..40, 'String not translated: Example')] }
+  end
+
+  context 'when file contains multiple hard coded string' do
+    let(:file) { <<~FILE }
+      <span> Example </span>
+      <span> Foo </span>
+      <span> Test </span>
+    FILE
+
+    it 'find all offenses' do
+      expect(subject).to eq [
+        untranslated_string_error(6..14, 'String not translated: Example'),
+        untranslated_string_error(29..33, 'String not translated: Foo'),
+        untranslated_string_error(48..53, 'String not translated: Test')
+      ]
+    end
+  end
+
+  context 'when file does not contain any hard coded string' do
+    let(:file) { <<~FILE }
+      <span class="example">
+        <div id="hero">
+          <span id="cat"> <%= t(:hello) %> </span>
+        </div>
+      </span>
+    FILE
+
+    it { expect(subject).to eq [] }
+  end
+
+  context 'when file contains irrelevant hard coded string' do
+    let(:file) { <<~FILE }
+      <span class="example">
+        <% discounted_by %>%
+
+
+      </span>
+    FILE
+
+    it 'add offense' do
+      expected = untranslated_string_error(
+        22..47,
+        "Consider using Rails helpers to move out the single character \`%\` from the html."
+      )
+      expect(subject).to eq [expected]
+    end
+  end
+
+  context 'when file contains hard coded string inside javascript' do
+    let(:file) { <<~FILE }
+      <script type="text/template">
+        const TEMPLATE = `
+          <div class="example" data-modal-backdrop>
+            <span> Hardcoded String </span>
+          </div>`;
+      </script>
+    FILE
+
+    it { expect(subject).to eq [] }
+  end
+
+  context 'when file contains hard coded string following a javascript block' do
+    let(:file) { <<~FILE }
+      <script type="text/template">
+        const TEMPLATE = `
+          <div class="example" data-modal-backdrop>
+            <span> Hardcoded String </span>
+          </div>`;
+      </script>
+      Example
+    FILE
+
+    it { expect(subject).to eq [untranslated_string_error(157..165, "String not translated: Example")] }
+  end
+
+  private
+
+  def untranslated_string_error(range, string)
+    ERBLint::Offense.new(
+      linter,
+      processed_source.to_source_range(range.min, range.max),
+      string
+    )
+  end
+end


### PR DESCRIPTION
(Thanks @rafaelfranca for the original code, I just polished it)

Created the `HardCodedString` linter:

- This linter will be responsible to check if there is visible hardcoded string in the dom, our use case being to see if a string is not ready for translation
- The linter will *not* check for hardcoded string that are nested inside a javascript tag, nor strings that are `< 1` character (after removing spaces)

cc/ @Shopify/i18n 