### PR TITLE
Put back the Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@
 .bundle
 
 .rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml
-Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_install:
+  - rm ./Gemfile.lock
 rvm:
   - 2.4.2
 script:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,102 @@
+PATH
+  remote: .
+  specs:
+    erb_lint (0.0.17)
+      activesupport
+      better_html (~> 1.0.0)
+      colorize
+      html_tokenizer
+      rubocop (~> 0.51)
+      smart_properties
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actionview (5.1.4)
+      activesupport (= 5.1.4)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    activesupport (5.1.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    ast (2.3.0)
+    better_html (1.0.1)
+      actionview (>= 4.0)
+      activesupport (>= 4.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      html_tokenizer (~> 0.0.5)
+      parser (>= 2.4)
+      smart_properties
+    builder (3.2.3)
+    colorize (0.8.1)
+    concurrent-ruby (1.0.5)
+    crass (1.0.3)
+    diff-lcs (1.3)
+    erubi (1.7.0)
+    fakefs (0.11.3)
+    html_tokenizer (0.0.5)
+    i18n (0.9.1)
+      concurrent-ruby (~> 1.0)
+    loofah (2.1.1)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    mini_portile2 (2.3.0)
+    minitest (5.11.1)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
+    parallel (1.12.0)
+    parser (2.4.0.2)
+      ast (~> 2.3)
+    powerpack (0.1.1)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.0.3)
+      loofah (~> 2.0)
+    rainbow (3.0.0)
+    rake (12.3.0)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.0)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.0)
+    rubocop (0.52.0)
+      parallel (~> 1.10)
+      parser (>= 2.4.0.2, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.9.0)
+    smart_properties (1.13.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.4)
+      thread_safe (~> 0.1)
+    unicode-display_width (1.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activesupport (~> 5.1)
+  erb_lint!
+  fakefs
+  rake
+  rspec
+  rubocop
+
+BUNDLED WITH
+   1.16.0


### PR DESCRIPTION
Put back the Gemfile.lock under version control:

- So I always thought that the `Gemfile.lock` should never be inside a gem after reading http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/ couple years ago
- That approach is actually not ideal since any developers should have all tests passed as soon as they clone the repo. This might not be the case because all developers could have multiple  different dependencies version

------------------------------

Remove the Gemfile.lock on CI:

- On CI we don't want to install deps from the Gemfile.lock but the latest version of each deps, this way we can tell whenever a dependency introduces a change that breaks our test
