### PR TITLE
ParserErrors linter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    erb_lint (0.0.17)
+    erb_lint (0.0.18)
       activesupport
-      better_html (~> 1.0.0)
+      better_html (~> 1.0.3)
       colorize
       html_tokenizer
       rubocop (~> 0.51)
@@ -24,12 +24,12 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     ast (2.3.0)
-    better_html (1.0.1)
+    better_html (1.0.3)
       actionview (>= 4.0)
       activesupport (>= 4.0)
       ast (~> 2.0)
       erubi (~> 1.4)
-      html_tokenizer (~> 0.0.5)
+      html_tokenizer (~> 0.0.6)
       parser (>= 2.4)
       smart_properties
     builder (3.2.3)
@@ -39,7 +39,7 @@ GEM
     diff-lcs (1.3)
     erubi (1.7.0)
     fakefs (0.11.3)
-    html_tokenizer (0.0.5)
+    html_tokenizer (0.0.6)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
     loofah (2.1.1)

--- a/erb_lint.gemspec
+++ b/erb_lint.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.bindir = 'exe'
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
-  s.add_dependency 'better_html', '~> 1.0.2'
+  s.add_dependency 'better_html', '~> 1.0.3'
   s.add_dependency 'html_tokenizer'
   s.add_dependency 'rubocop', '~> 0.51'
   s.add_dependency 'activesupport'

--- a/lib/erb_lint/linters/deprecated_classes.rb
+++ b/lib/erb_lint/linters/deprecated_classes.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'better_html'
 require 'better_html/parser'
 
 module ERBLint

--- a/lib/erb_lint/linters/parser_errors.rb
+++ b/lib/erb_lint/linters/parser_errors.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ERBLint
+  module Linters
+    class ParserErrors < Linter
+      include LinterRegistry
+
+      def offenses(processed_source)
+        processed_source.parser.parser_errors.map do |error|
+          Offense.new(
+            self,
+            processed_source.to_source_range(error.loc.start, error.loc.stop - 1),
+            "#{error.message} (at #{error.loc.source})"
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/erb_lint/linters/parser_error_spec.rb
+++ b/spec/erb_lint/linters/parser_error_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ERBLint::Linters::ParserErrors do
+  let(:linter_config) { described_class.config_schema.new }
+
+  let(:file_loader) { ERBLint::FileLoader.new('.') }
+  let(:linter) { described_class.new(file_loader, linter_config) }
+  let(:processed_source) { ERBLint::ProcessedSource.new('file.rb', file) }
+  let(:offenses) { linter.offenses(processed_source) }
+  let(:corrector) { ERBLint::Corrector.new(processed_source, offenses) }
+  let(:corrected_content) { corrector.corrected_content }
+
+  describe 'offenses' do
+    subject { offenses }
+
+    context 'when file is valid' do
+      let(:file) { "<a>" }
+      it { expect(subject).to eq [] }
+    end
+
+    context 'when file is invalid' do
+      let(:file) { "<>" }
+      it do
+        expect(subject).to eq [
+          build_offense(1..1, "expected '/' or tag name (at >)")
+        ]
+      end
+    end
+  end
+
+  private
+
+  def build_offense(range, message)
+    ERBLint::Offense.new(
+      linter,
+      processed_source.to_source_range(range.begin, range.end),
+      message
+    )
+  end
+end


### PR DESCRIPTION
The html_tokenizer gem sometimes detects basic errors, this linter makes these errors visible.