### PR TITLE
Right trim linter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     erb_lint (0.0.18)
       activesupport
-      better_html (~> 1.0.3)
+      better_html (~> 1.0.4)
       colorize
       html_tokenizer
       rubocop (~> 0.51)
@@ -24,7 +24,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     ast (2.3.0)
-    better_html (1.0.3)
+    better_html (1.0.4)
       actionview (>= 4.0)
       activesupport (>= 4.0)
       ast (~> 2.0)
@@ -40,7 +40,7 @@ GEM
     erubi (1.7.0)
     fakefs (0.11.3)
     html_tokenizer (0.0.6)
-    i18n (0.9.1)
+    i18n (0.9.3)
       concurrent-ruby (~> 1.0)
     loofah (2.1.1)
       crass (~> 1.0.2)

--- a/README.md
+++ b/README.md
@@ -191,6 +191,24 @@ Linter-Specific Option | Description
 `rubocop_config`       | A valid rubocop configuration hash. Mandatory when this cop is enabled. See [rubocop's manual entry on Configuration](http://rubocop.readthedocs.io/en/latest/configuration/)
 `only`                 | Only run cops listed in this array instead of all cops.
 
+### RightTrim
+
+Trimming at the right of an ERB tag can be done with either `=%>` or `-%>`, this linter enforces one of these two styles.
+
+Example configuration:
+
+```yaml
+---
+linters:
+  RightTrim:
+    enabled: true
+    enforced_style: '-'
+```
+
+Linter-Specific Option | Description
+-----------------------|---------------------------------------------------------
+`enforced_style`       | Which style to enforce, can be either `-` or `=`. Optional. Defaults to `-`.
+
 ## Custom Linters
 
 `erb-lint` allows you to create custom linters specific to your project. It will load linters from the `.erb-linters` directory in the root of your

--- a/erb_lint.gemspec
+++ b/erb_lint.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.bindir = 'exe'
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
-  s.add_dependency 'better_html', '~> 1.0.3'
+  s.add_dependency 'better_html', '~> 1.0.4'
   s.add_dependency 'html_tokenizer'
   s.add_dependency 'rubocop', '~> 0.51'
   s.add_dependency 'activesupport'

--- a/lib/erb_lint/linters/right_trim.rb
+++ b/lib/erb_lint/linters/right_trim.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module ERBLint
+  module Linters
+    # In ERB, right trim can be either =%> or -%>
+    # this linter will force one or the other.
+    class RightTrim < Linter
+      include LinterRegistry
+
+      class ConfigSchema < LinterConfig
+        property :enforced_style, accepts: ['-', '='], default: '-'
+      end
+      self.config_schema = ConfigSchema
+
+      def offenses(processed_source)
+        [].tap do |offenses|
+          processed_source.ast.descendants(:erb).each do |erb_node|
+            _, _, _, trim_node = *erb_node
+            next if trim_node.nil? || trim_node.loc.source == @config.enforced_style
+
+            offenses << Offense.new(
+              self,
+              processed_source.to_source_range(trim_node.loc.start, trim_node.loc.stop),
+              "Prefer #{@config.enforced_style}%> instead of #{trim_node.loc.source}%> for trimming on the right."
+            )
+          end
+        end
+      end
+
+      def autocorrect(_processed_source, offense)
+        lambda do |corrector|
+          corrector.replace(offense.source_range, @config.enforced_style)
+        end
+      end
+    end
+  end
+end

--- a/spec/erb_lint/linters/right_trim_spec.rb
+++ b/spec/erb_lint/linters/right_trim_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ERBLint::Linters::RightTrim do
+  let(:linter_config) { described_class.config_schema.new(enforced_style: enforced_style) }
+
+  let(:file_loader) { ERBLint::FileLoader.new('.') }
+  let(:linter) { described_class.new(file_loader, linter_config) }
+  let(:processed_source) { ERBLint::ProcessedSource.new('file.rb', file) }
+  let(:offenses) { linter.offenses(processed_source) }
+  let(:corrector) { ERBLint::Corrector.new(processed_source, offenses) }
+  let(:corrected_content) { corrector.corrected_content }
+
+  describe 'offenses' do
+    subject { offenses }
+
+    context 'when enforced_style is -' do
+      let(:enforced_style) { '-' }
+
+      context 'when trim is correct' do
+        let(:file) { "<% foo -%>" }
+        it { expect(subject).to eq [] }
+      end
+
+      context 'when trim is incorrect' do
+        let(:file) { "<% foo =%>" }
+        it do
+          expect(subject).to eq [
+            build_offense(7..7, "Prefer -%> instead of =%> for trimming on the right.")
+          ]
+        end
+      end
+    end
+
+    context 'when enforced_style is =' do
+      let(:enforced_style) { '=' }
+
+      context 'when trim is correct' do
+        let(:file) { "<% foo =%>" }
+        it { expect(subject).to eq [] }
+      end
+
+      context 'when trim is incorrect' do
+        let(:file) { "<% foo -%>" }
+        it do
+          expect(subject).to eq [
+            build_offense(7..7, "Prefer =%> instead of -%> for trimming on the right.")
+          ]
+        end
+      end
+    end
+  end
+
+  describe 'autocorrect' do
+    subject { corrected_content }
+
+    context 'when enforced_style is -' do
+      let(:enforced_style) { '-' }
+
+      context 'when trim is correct' do
+        let(:file) { "<% foo -%>" }
+        it { expect(subject).to eq file }
+      end
+
+      context 'when trim is incorrect' do
+        let(:file) { "<% foo =%>" }
+        it { expect(subject).to eq "<% foo -%>" }
+      end
+    end
+
+    context 'when enforced_style is =' do
+      let(:enforced_style) { '=' }
+
+      context 'when trim is correct' do
+        let(:file) { "<% foo =%>" }
+        it { expect(subject).to eq file }
+      end
+
+      context 'when trim is incorrect' do
+        let(:file) { "<% foo -%>" }
+        it { expect(subject).to eq "<% foo =%>" }
+      end
+    end
+  end
+
+  private
+
+  def build_offense(range, message)
+    ERBLint::Offense.new(
+      linter,
+      processed_source.to_source_range(range.begin, range.end),
+      message
+    )
+  end
+end


### PR DESCRIPTION
Add linter for enforcing `=%>` or `-%>` for right trims in ERB tags.