### PR TITLE
Enable ParserErrors and RightTrim in default config

### DIFF
--- a/lib/erb_lint/runner_config.rb
+++ b/lib/erb_lint/runner_config.rb
@@ -38,9 +38,9 @@ module ERBLint
       def default
         new(
           linters: {
-            FinalNewline: {
-              enabled: true,
-            },
+            FinalNewline: { enabled: true },
+            ParserErrors: { enabled: true },
+            RightTrim: { enabled: true },
           },
         )
       end


### PR DESCRIPTION
Enable `ParserErrors` and `RightTrim` by default.