### PR TITLE
Linter for spaces around ERB tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,35 @@ Linter-Specific Option | Description
 -----------------------|---------------------------------------------------------
 `enforced_style`       | Which style to enforce, can be either `-` or `=`. Optional. Defaults to `-`.
 
+### SpaceAroundErbTag
+
+Enforce a single space after `<%` and before `%>` in the ERB source.
+This linter ignores opening ERB tags (`<%`) that are followed by a newline,
+and closing ERB tags (`%>`) that are preceded by a newline.
+
+
+```erb
+Bad ❌
+<%foo%>
+<%=foo-%>
+
+Good ✅
+<% foo %>
+
+<%
+  foo
+%>
+```
+
+Example configuration:
+
+```yaml
+---
+linters:
+  SpaceAroundErbTag:
+    enabled: true
+```
+
 ## Custom Linters
 
 `erb-lint` allows you to create custom linters specific to your project. It will load linters from the `.erb-linters` directory in the root of your

--- a/lib/erb_lint/linters/space_around_erb_tag.rb
+++ b/lib/erb_lint/linters/space_around_erb_tag.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module ERBLint
+  module Linters
+    # Enforce a single space after `<%` and before `%>` in the erb source.
+    # This linter ignores opening erb tags (`<%`) that are followed by a newline,
+    # and closing erb tags (`%>`) that are preceeded by a newline.
+    class SpaceAroundErbTag < Linter
+      include LinterRegistry
+
+      START_SPACES = /\A([[:space:]]*)/m
+      END_SPACES = /([[:space:]]*)\z/m
+
+      def offenses(processed_source)
+        [].tap do |offenses|
+          processed_source.ast.descendants(:erb).each do |erb_node|
+            indicator, ltrim, code_node, rtrim = *erb_node
+            code = code_node.children.first
+
+            start_spaces = code.match(START_SPACES)&.captures&.first || ""
+            if start_spaces.size != 1 && !start_spaces.include?("\n")
+              offenses << Offense.new(
+                self,
+                processed_source.to_source_range(code_node.loc.start, code_node.loc.start + start_spaces.size - 1),
+                "Use 1 space after `<%#{indicator&.loc&.source}#{ltrim&.loc&.source}` "\
+                "instead of #{start_spaces.size} space#{'s' if start_spaces.size > 1}."
+              )
+            end
+
+            end_spaces = code.match(END_SPACES)&.captures&.first || ""
+            if end_spaces.size != 1 && !end_spaces.include?("\n")
+              offenses << Offense.new(
+                self,
+                processed_source.to_source_range(code_node.loc.stop - end_spaces.size + 1, code_node.loc.stop),
+                "Use 1 space before `#{rtrim&.loc&.source}%>` "\
+                "instead of #{end_spaces.size} space#{'s' if start_spaces.size > 1}."
+              )
+            end
+          end
+        end
+      end
+
+      def autocorrect(_processed_source, offense)
+        lambda do |corrector|
+          corrector.replace(offense.source_range, ' ')
+        end
+      end
+    end
+  end
+end

--- a/lib/erb_lint/linters/space_around_erb_tag.rb
+++ b/lib/erb_lint/linters/space_around_erb_tag.rb
@@ -28,14 +28,13 @@ module ERBLint
             end
 
             end_spaces = code.match(END_SPACES)&.captures&.first || ""
-            if end_spaces.size != 1 && !end_spaces.include?("\n")
-              offenses << Offense.new(
-                self,
-                processed_source.to_source_range(code_node.loc.stop - end_spaces.size + 1, code_node.loc.stop),
-                "Use 1 space before `#{rtrim&.loc&.source}%>` "\
-                "instead of #{end_spaces.size} space#{'s' if start_spaces.size > 1}."
-              )
-            end
+            next unless end_spaces.size != 1 && !end_spaces.include?("\n")
+            offenses << Offense.new(
+              self,
+              processed_source.to_source_range(code_node.loc.stop - end_spaces.size + 1, code_node.loc.stop),
+              "Use 1 space before `#{rtrim&.loc&.source}%>` "\
+              "instead of #{end_spaces.size} space#{'s' if start_spaces.size > 1}."
+            )
           end
         end
       end

--- a/lib/erb_lint/runner_config.rb
+++ b/lib/erb_lint/runner_config.rb
@@ -41,6 +41,7 @@ module ERBLint
             FinalNewline: { enabled: true },
             ParserErrors: { enabled: true },
             RightTrim: { enabled: true },
+            SpaceAroundErbTag: { enabled: true },
           },
         )
       end

--- a/spec/erb_lint/linters/space_around_erb_tag_spec.rb
+++ b/spec/erb_lint/linters/space_around_erb_tag_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ERBLint::Linters::SpaceAroundErbTag do
+  let(:linter_config) { described_class.config_schema.new }
+
+  let(:file_loader) { ERBLint::FileLoader.new('.') }
+  let(:linter) { described_class.new(file_loader, linter_config) }
+  let(:processed_source) { ERBLint::ProcessedSource.new('file.rb', file) }
+  let(:offenses) { linter.offenses(processed_source) }
+  let(:corrector) { ERBLint::Corrector.new(processed_source, offenses) }
+  let(:corrected_content) { corrector.corrected_content }
+
+  describe 'offenses' do
+    subject { offenses }
+
+    context 'when space is correct' do
+      let(:file) { "<% foo %>" }
+      it { expect(subject).to eq [] }
+    end
+
+    context 'when tag starts with a newline' do
+      let(:file) { <<~ERB }
+        <%
+          foo
+        %>
+      ERB
+      it { expect(subject).to eq [] }
+    end
+
+    context 'when tag contains extra spaces and newlines' do
+      let(:file) { "<%  \n  foo  \n %>" }
+      it { expect(subject).to eq [] }
+    end
+
+    context 'when space is missing on the left of statement' do
+      let(:file) { "<%foo %>" }
+      it do
+        expect(subject).to eq [
+          build_offense(2..1, "Use 1 space after `<%` instead of 0 space.")
+        ]
+      end
+    end
+
+    context 'when space is missing on the left of expression' do
+      let(:file) { "<%=foo %>" }
+      it do
+        expect(subject).to eq [
+          build_offense(3..2, "Use 1 space after `<%=` instead of 0 space.")
+        ]
+      end
+    end
+
+    context 'when space is missing on the left of statement with trim' do
+      let(:file) { "<%-foo %>" }
+      it do
+        expect(subject).to eq [
+          build_offense(3..2, "Use 1 space after `<%-` instead of 0 space.")
+        ]
+      end
+    end
+
+    context 'when more than 1 space on the left' do
+      let(:file) { "<%  foo %>" }
+      it do
+        expect(subject).to eq [
+          build_offense(2..3, "Use 1 space after `<%` instead of 2 spaces.")
+        ]
+      end
+    end
+
+    context 'when space is missing on the right' do
+      let(:file) { "<% foo%>" }
+      it do
+        expect(subject).to eq [
+          build_offense(6..5, "Use 1 space before `%>` instead of 0 space.")
+        ]
+      end
+    end
+
+    context 'when space is missing on the right with trim' do
+      let(:file) { "<% foo-%>" }
+      it do
+        expect(subject).to eq [
+          build_offense(6..5, "Use 1 space before `-%>` instead of 0 space.")
+        ]
+      end
+    end
+
+    context 'when more than 1 space on the right' do
+      let(:file) { "<% foo   %>" }
+      it do
+        expect(subject).to eq [
+          build_offense(6..8, "Use 1 space before `%>` instead of 3 space.")
+        ]
+      end
+    end
+  end
+
+  describe 'autocorrect' do
+    subject { corrected_content }
+
+    context 'when space is correct' do
+      let(:file) { "<% foo %>" }
+      it { expect(subject).to eq file }
+    end
+
+    context 'when tag starts with a newline' do
+      let(:file) { <<~ERB }
+        <%
+          foo
+        %>
+      ERB
+      it { expect(subject).to eq file }
+    end
+
+    context 'when tag contains extra spaces and newlines' do
+      let(:file) { "<%  \n  foo  \n %>" }
+      it { expect(subject).to eq file }
+    end
+
+    context 'when space is missing on the left of statement' do
+      let(:file) { "<%foo %>" }
+      it { expect(subject).to eq "<% foo %>" }
+    end
+
+    context 'when space is missing on the left of expression' do
+      let(:file) { "<%=foo %>" }
+      it { expect(subject).to eq "<%= foo %>" }
+    end
+
+    context 'when space is missing on the left of statement with trim' do
+      let(:file) { "<%-foo %>" }
+      it { expect(subject).to eq "<%- foo %>" }
+    end
+
+    context 'when more than 1 space on the left' do
+      let(:file) { "<%  foo %>" }
+      it { expect(subject).to eq "<% foo %>" }
+    end
+
+    context 'when space is missing on the right' do
+      let(:file) { "<% foo%>" }
+      it { expect(subject).to eq "<% foo %>" }
+    end
+
+    context 'when space is missing on the right with trim' do
+      let(:file) { "<% foo-%>" }
+      it { expect(subject).to eq "<% foo -%>" }
+    end
+
+    context 'when more than 1 space on the right' do
+      let(:file) { "<% foo   %>" }
+      it { expect(subject).to eq "<% foo %>" }
+    end
+  end
+
+  private
+
+  def build_offense(range, message)
+    ERBLint::Offense.new(
+      linter,
+      processed_source.to_source_range(range.begin, range.end),
+      message
+    )
+  end
+end


### PR DESCRIPTION
Adds a linter for spaces around `<%` and `%>`

```
    # Enforce a single space after `<%` and before `%>` in the erb source.
    # This linter ignores opening erb tags (`<%`) that are followed by a newline,
    # and closing erb tags (`%>`) that are preceeded by a newline.
```