### PR TITLE
Add AllowedScriptType linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,62 @@ Linter-Specific Option | Description
 -----------------------|---------------------------------------------------------
 `correction_style`     | When configured with `cdata`, adds CDATA markers. When configured with `plain`, don't add makers. Defaults to `cdata`.
 
+### AllowedScriptType
+
+This linter prevent the addition of `<script>` tags that have `type` attributes that are not in a white-list of allowed values.
+
+It is common practice for web developers to use `<script>` tags with non-executable
+`type` attributes, such as `application/json` or `text/html` to pass arbitrary data into an html page.
+Despite not being executable, these tags are subject to the same parsing quirks as executable script tags, and
+it is therefore more difficult to prevent security issues from creeping in. Consider for instance an application
+where it is possible to inject the string `</script><script>` unescaped into a `text/html` tag, the application
+would be vulnerable to XSS.
+
+This pattern can easily be replaced by `<div>` tags with `data` attributes that can just as easily be read
+from javascript, and have the added benefit of being safer. When `content_tag(:div)` or `tag.div()` is used
+to pass arbitrary user data into the html document, it becomes much harder to inadvertently introduce a
+security issue.
+
+It may also be desirable to avoid typos in `type` attributes.
+
+```html
+Bad ❌
+<script type="text/javacsrïpt"></script>
+Good ✅
+<script type="text/javascript"></script>
+```
+
+By default, this linter allows the `type` attribute to be omitted, as the behavior in browsers is to
+consider `<script>` to be the same as `<script type="text/javascript">`. When the linter is configured with
+`allow_blank: false`, instances of `<script>` tags without a type will be auto-corrected
+to `<script type="text/javascript">`.
+
+It may also be desirable to disallow `<script>` tags from appearing anywhere in your application.
+For instance, Rails applications can benefit from serving static javascript code from the asset
+pipeline, as well as other security benefits.
+The `disallow_inline_scripts: true` config option may be used for that purpose.
+
+Example configuration:
+
+```yaml
+---
+linters:
+  AllowedScriptType:
+    enabled: true
+    allowed_types:
+      - 'application/json'
+      - 'text/javascript'
+      - 'text/html'
+    allow_blank: false
+    disallow_inline_scripts: false
+```
+
+Linter-Specific Option    | Description
+--------------------------|---------------------------------------------------------
+`allowed_types`           | An array of allowed types. Defaults to `["text/javascript"]`.
+`allow_blank`             | True or false, depending on whether or not the `type` attribute may be omitted entirely from a `<script>` tag.
+`disallow_inline_scripts` | Do not allow inline `<script>` tags anywhere in ERB templates. Defaults to `false`.
+
 ## Custom Linters
 
 `erb-lint` allows you to create custom linters specific to your project. It will load linters from the `.erb-linters` directory in the root of your

--- a/lib/erb_lint/linters/allowed_script_type.rb
+++ b/lib/erb_lint/linters/allowed_script_type.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'better_html'
+require 'better_html/tree/tag'
+
+module ERBLint
+  module Linters
+    # Allow `<script>` tags in ERB that have specific `type` attributes.
+    # This only validates inline `<script>` tags, a separate rubocop cop
+    # may be used to enforce the same rule when `javascript_tag` is called.
+    class AllowedScriptType < Linter
+      include LinterRegistry
+
+      class ConfigSchema < LinterConfig
+        property :allowed_types, accepts: array_of?(String),
+          default: ['text/javascript']
+        property :allow_blank, accepts: [true, false], default: true, reader: :allow_blank?
+        property :disallow_inline_scripts, accepts: [true, false], default: false, reader: :disallow_inline_scripts?
+      end
+      self.config_schema = ConfigSchema
+
+      def offenses(processed_source)
+        parser = processed_source.parser
+        [].tap do |offenses|
+          parser.nodes_with_type(:tag).each do |tag_node|
+            tag = BetterHtml::Tree::Tag.from_node(tag_node)
+            next if tag.closing?
+            next unless tag.name == 'script'
+
+            if @config.disallow_inline_scripts?
+              name_node = tag_node.to_a[1]
+              offenses << Offense.new(
+                self,
+                processed_source.to_source_range(name_node.loc.start, name_node.loc.stop),
+                "Avoid using inline `<script>` tags altogether. "\
+                "Instead, move javascript code into a static file."
+              )
+              next
+            end
+
+            type_attribute = tag.attributes['type']
+            type_present = type_attribute.present? && type_attribute.value_node.present?
+
+            if !type_present && !@config.allow_blank?
+              name_node = tag_node.to_a[1]
+              offenses << Offense.new(
+                self,
+                processed_source.to_source_range(name_node.loc.start, name_node.loc.stop),
+                "Missing a `type=\"text/javascript\"` attribute to `<script>` tag.",
+                [type_attribute]
+              )
+            elsif type_present && !@config.allowed_types.include?(type_attribute.value)
+              offenses << Offense.new(
+                self,
+                processed_source.to_source_range(type_attribute.loc.start, tag_node.loc.stop),
+                "Avoid using #{type_attribute.value.inspect} as type for `<script>` tag. "\
+                "Must be one of: #{@config.allowed_types.join(', ')}"\
+                "#{' (or no type attribute)' if @config.allow_blank?}."
+              )
+            end
+          end
+        end
+      end
+
+      def autocorrect(processed_source, offense)
+        return unless offense.context
+        lambda do |corrector|
+          type_attribute, = *offense.context
+          if type_attribute.nil?
+            corrector.insert_after(offense.source_range, ' type="text/javascript"')
+          elsif !type_attribute.value.present?
+            range = processed_source.to_source_range(type_attribute.node.loc.start, type_attribute.node.loc.stop)
+            corrector.replace(range, 'type="text/javascript"')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/erb_lint/runner_config.rb
+++ b/lib/erb_lint/runner_config.rb
@@ -43,6 +43,7 @@ module ERBLint
             RightTrim: { enabled: true },
             SpaceAroundErbTag: { enabled: true },
             NoJavascriptTagHelper: { enabled: true },
+            AllowedScriptType: { enabled: true },
           },
         )
       end

--- a/spec/erb_lint/linters/allowed_script_type_spec.rb
+++ b/spec/erb_lint/linters/allowed_script_type_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ERBLint::Linters::AllowedScriptType do
+  let(:linter_config) { described_class.config_schema.new }
+
+  let(:file_loader) { ERBLint::FileLoader.new('.') }
+  let(:linter) { described_class.new(file_loader, linter_config) }
+  let(:processed_source) { ERBLint::ProcessedSource.new('file.rb', file) }
+  let(:offenses) { linter.offenses(processed_source) }
+  let(:corrector) { ERBLint::Corrector.new(processed_source, offenses) }
+  let(:corrected_content) { corrector.corrected_content }
+
+  describe 'offenses' do
+    subject { offenses }
+
+    context 'when type is correct' do
+      let(:file) { '<script type="text/javascript">' }
+      it { expect(subject).to eq [] }
+    end
+
+    context 'when type is incorrect' do
+      let(:file) { '<script type="text/yavascript">' }
+      it do
+        expect(subject).to eq [
+          build_offense(8..30,
+            "Avoid using \"text/yavascript\" as type for `<script>` tag. "\
+            "Must be one of: text/javascript (or no type attribute).")
+        ]
+      end
+    end
+
+    context 'when disallow_inline_scripts=true' do
+      let(:linter_config) { described_class.config_schema.new(disallow_inline_scripts: true) }
+
+      context 'with any script tag' do
+        let(:file) { '<script>' }
+        it do
+          expect(subject).to eq [
+            build_offense(1..6,
+              "Avoid using inline `<script>` tags altogether. "\
+              "Instead, move javascript code into a static file.")
+          ]
+        end
+      end
+    end
+
+    context 'when allow_blank=true' do
+      let(:linter_config) { described_class.config_schema.new(allow_blank: true) }
+
+      context 'when type is absent' do
+        let(:file) { '<script>' }
+        it { expect(subject).to eq [] }
+      end
+
+      context 'when type value is missing' do
+        let(:file) { '<script type>' }
+        it { expect(subject).to eq [] }
+      end
+
+      context 'when type value is present but blank' do
+        let(:file) { '<script type="">' }
+        it 'is not valid' do
+          expect(subject).to eq [
+            build_offense(8..15,
+              "Avoid using \"\" as type for `<script>` tag. Must be one of: text/javascript (or no type attribute).")
+          ]
+        end
+      end
+    end
+
+    context 'when allow_blank=false' do
+      let(:linter_config) { described_class.config_schema.new(allow_blank: false) }
+
+      context 'when type is blank' do
+        let(:file) { '<script>' }
+        it do
+          expect(subject).to eq [
+            build_offense(1..6,
+              "Missing a `type=\"text/javascript\"` attribute to `<script>` tag.")
+          ]
+        end
+      end
+
+      context 'when type is empty' do
+        let(:file) { '<script type>' }
+        it do
+          expect(subject).to eq [
+            build_offense(1..6,
+              "Missing a `type=\"text/javascript\"` attribute to `<script>` tag.")
+          ]
+        end
+      end
+    end
+  end
+
+  describe 'autocorrect' do
+    subject { corrected_content }
+
+    context 'file remains the same' do
+      context 'when type is correct' do
+        let(:file) { '<script type="text/javascript">' }
+        it { expect(subject).to eq file }
+      end
+
+      context 'when type is incorrect' do
+        let(:file) { '<script type="text/yavascript">' }
+        it { expect(subject).to eq file }
+      end
+
+      context 'when allow_blank=true' do
+        let(:linter_config) { described_class.config_schema.new(allow_blank: true) }
+
+        context 'when type is blank' do
+          let(:file) { '<script>' }
+          it { expect(subject).to eq file }
+        end
+
+        context 'when type is empty' do
+          let(:file) { '<script type>' }
+          it { expect(subject).to eq file }
+        end
+      end
+    end
+
+    context 'file is autocorrected' do
+      context 'when allow_blank=false' do
+        let(:linter_config) { described_class.config_schema.new(allow_blank: false) }
+
+        context 'when type is blank' do
+          let(:file) { '<script>' }
+          it { expect(subject).to eq '<script type="text/javascript">' }
+        end
+
+        context 'when type is empty' do
+          let(:file) { '<script type>' }
+          it { expect(subject).to eq '<script type="text/javascript">' }
+        end
+      end
+    end
+  end
+
+  private
+
+  def build_offense(range, message)
+    ERBLint::Offense.new(
+      linter,
+      processed_source.to_source_range(range.begin, range.end),
+      message
+    )
+  end
+end


### PR DESCRIPTION
Adds a `AllowedScriptType` linter:
* Can restrict `<script>` tags to a whitelist of known types, to prevent typos or prevent devs from using some types when a better pattern is already established in the application.
* Can disallow `<script>` tags altogether to make it easier to deploy a content security policy without `unsafe-inline`, for example.