### PR TITLE
Offense alignment test

### DIFF
--- a/spec/erb_lint/fixtures/cops/auto_correct_cop.rb
+++ b/spec/erb_lint/fixtures/cops/auto_correct_cop.rb
@@ -15,8 +15,10 @@ module RuboCop
         alias_method :on_csend, :on_send
 
         def autocorrect(node)
+          return if node.method_name == :dont_auto_correct_me
+
           lambda do |corrector|
-            corrector.replace(node.loc.selector, 'safe_method') if node.method_name == :auto_correct_me
+            corrector.replace(node.loc.selector, 'safe_method')
           end
         end
       end

--- a/spec/erb_lint/fixtures/cops/auto_correct_cop.rb
+++ b/spec/erb_lint/fixtures/cops/auto_correct_cop.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module ErbLint
-      class ArbitraryRule < Cop
+      class AutoCorrectCop < Cop
         MSG = 'An arbitrary rule has been violated.'
 
         def on_send(node)

--- a/spec/erb_lint/fixtures/cops/auto_correct_cop.rb
+++ b/spec/erb_lint/fixtures/cops/auto_correct_cop.rb
@@ -5,15 +5,18 @@ module RuboCop
     module ErbLint
       class AutoCorrectCop < Cop
         MSG = 'An arbitrary rule has been violated.'
+        METHODS_TO_WATCH = %i(auto_correct_me dont_auto_correct_me)
 
         def on_send(node)
-          add_offense(node, location: :selector) if node.command?(:banned_method)
+          return unless METHODS_TO_WATCH.include?(node.method_name)
+
+          add_offense(node, location: :selector)
         end
         alias_method :on_csend, :on_send
 
         def autocorrect(node)
           lambda do |corrector|
-            corrector.replace(node.loc.selector, 'safe_method')
+            corrector.replace(node.loc.selector, 'safe_method') if node.method_name == :auto_correct_me
           end
         end
       end

--- a/spec/erb_lint/linters/rubocop_spec.rb
+++ b/spec/erb_lint/linters/rubocop_spec.rb
@@ -225,6 +225,14 @@ describe ERBLint::Linters::Rubocop do
     end
   end
 
+  context 'autocorrected and not autocorrected offenses are aligned' do
+    let(:file) { <<~FILE }
+      <% dont_auto_correct_me(auto_correct_me(dont_auto_correct_me)) %>
+    FILE
+
+    it { expect(corrected_content).to eq "<% dont_auto_correct_me(safe_method(dont_auto_correct_me)) %>\n" }
+  end
+
   private
 
   def arbitrary_error_message(range)

--- a/spec/erb_lint/linters/rubocop_spec.rb
+++ b/spec/erb_lint/linters/rubocop_spec.rb
@@ -33,11 +33,11 @@ describe ERBLint::Linters::Rubocop do
 
   context 'when rubocop finds offenses in ruby statements' do
     let(:file) { <<~FILE }
-      <% banned_method %>
+      <% auto_correct_me %>
     FILE
 
-    it { expect(subject).to eq [arbitrary_error_message(3..15)] }
-    it { expect(subject.first.source_range.source).to eq "banned_method" }
+    it { expect(subject).to eq [arbitrary_error_message(3..17)] }
+    it { expect(subject.first.source_range.source).to eq "auto_correct_me" }
 
     context 'when autocorrecting' do
       subject { corrected_content }
@@ -48,10 +48,10 @@ describe ERBLint::Linters::Rubocop do
 
   context 'when rubocop finds offenses in ruby expressions' do
     let(:file) { <<~FILE }
-      <%= banned_method %>
+      <%= auto_correct_me %>
     FILE
 
-    it { expect(subject).to eq [arbitrary_error_message(4..16)] }
+    it { expect(subject).to eq [arbitrary_error_message(4..18)] }
 
     context 'when autocorrecting' do
       subject { corrected_content }
@@ -63,17 +63,17 @@ describe ERBLint::Linters::Rubocop do
   context 'when multiple offenses are found in the same block' do
     let(:file) { <<~FILE }
       <%
-      banned_method(:foo)
-      banned_method(:bar)
-      banned_method(:baz)
+      auto_correct_me(:foo)
+      auto_correct_me(:bar)
+      auto_correct_me(:baz)
       %>
     FILE
 
     it 'finds offenses' do
       expect(subject).to eq [
-        arbitrary_error_message(3..15),
-        arbitrary_error_message(23..35),
-        arbitrary_error_message(43..55),
+        arbitrary_error_message(3..17),
+        arbitrary_error_message(25..39),
+        arbitrary_error_message(47..61),
       ]
     end
 
@@ -84,8 +84,8 @@ describe ERBLint::Linters::Rubocop do
       it { expect(subject).to eq <<~FILE }
         <%
         safe_method(:foo)
-        banned_method(:bar)
-        banned_method(:baz)
+        auto_correct_me(:bar)
+        auto_correct_me(:baz)
         %>
       FILE
     end
@@ -93,7 +93,7 @@ describe ERBLint::Linters::Rubocop do
 
   context 'partial ruby statements are ignored' do
     let(:file) { <<~FILE }
-      <% if banned_method %>
+      <% if auto_correct_me %>
         foo
       <% end %>
     FILE
@@ -103,12 +103,12 @@ describe ERBLint::Linters::Rubocop do
 
   context 'statements with partial block expression is processed' do
     let(:file) { <<~FILE }
-      <% banned_method.each do %>
+      <% auto_correct_me.each do %>
         foo
       <% end %>
     FILE
 
-    it { expect(subject).to eq [arbitrary_error_message(3..15)] }
+    it { expect(subject).to eq [arbitrary_error_message(3..17)] }
 
     context 'when autocorrecting' do
       subject { corrected_content }
@@ -126,14 +126,14 @@ describe ERBLint::Linters::Rubocop do
       <div>
         <%
           if foo?
-            banned_method
+            auto_correct_me
           end
         %>
       </div>
     FILE
 
-    it { expect(subject).to eq [arbitrary_error_message(29..41)] }
-    it { expect(subject.first.source_range.source).to eq "banned_method" }
+    it { expect(subject).to eq [arbitrary_error_message(29..43)] }
+    it { expect(subject.first.source_range.source).to eq "auto_correct_me" }
   end
 
   context 'supports loading nested config' do
@@ -163,7 +163,7 @@ describe ERBLint::Linters::Rubocop do
 
     context 'rules from nested config are merged' do
       let(:file) { <<~FILE }
-        <% banned_method %>
+        <% auto_correct_me %>
       FILE
 
       it { expect(subject).to eq [] }

--- a/spec/erb_lint/linters/rubocop_spec.rb
+++ b/spec/erb_lint/linters/rubocop_spec.rb
@@ -6,9 +6,9 @@ require 'better_html'
 describe ERBLint::Linters::Rubocop do
   let(:linter_config) do
     described_class.config_schema.new(
-      only: ['ErbLint/ArbitraryRule'],
+      only: ['ErbLint/AutoCorrectCop'],
       rubocop_config: {
-        require: [File.expand_path('../../fixtures/cops/example_cop', __FILE__)],
+        require: [File.expand_path('../../fixtures/cops/auto_correct_cop', __FILE__)],
         AllCops: {
           TargetRubyVersion: '2.4',
         },
@@ -139,7 +139,7 @@ describe ERBLint::Linters::Rubocop do
   context 'supports loading nested config' do
     let(:linter_config) do
       described_class.config_schema.new(
-        only: ['ErbLint/ArbitraryRule'],
+        only: ['ErbLint/AutoCorrectCop'],
         rubocop_config: {
           inherit_from: 'custom_rubocop.yml',
           AllCops: {
@@ -151,7 +151,7 @@ describe ERBLint::Linters::Rubocop do
 
     let(:nested_config) do
       {
-        'ErbLint/ArbitraryRule': {
+        'ErbLint/AutoCorrectCop': {
           'Enabled': false
         }
       }.deep_stringify_keys
@@ -231,7 +231,7 @@ describe ERBLint::Linters::Rubocop do
     ERBLint::Offense.new(
       linter,
       processed_source.to_source_range(range.min, range.max),
-      "ErbLint/ArbitraryRule: An arbitrary rule has been violated."
+      "ErbLint/AutoCorrectCop: An arbitrary rule has been violated."
     )
   end
 end

--- a/spec/erb_lint/linters/rubocop_text_spec.rb
+++ b/spec/erb_lint/linters/rubocop_text_spec.rb
@@ -6,9 +6,9 @@ require 'better_html'
 describe ERBLint::Linters::RubocopText do
   let(:linter_config) do
     described_class.config_schema.new(
-      only: ['ErbLint/ArbitraryRule'],
+      only: ['ErbLint/AutoCorrectCop'],
       rubocop_config: {
-        require: [File.expand_path('../../fixtures/cops/example_cop', __FILE__)],
+        require: [File.expand_path('../../fixtures/cops/auto_correct_cop', __FILE__)],
         AllCops: {
           TargetRubyVersion: '2.4',
         },
@@ -22,7 +22,7 @@ describe ERBLint::Linters::RubocopText do
 
   context 'when file does not contain any erb text node' do
     let(:file) { <<~FILE }
-      <span class="<%= banned_method %>"></span>
+      <span class="<%= auto_correct_me %>"></span>
     FILE
 
     it { expect(subject).to eq [] }
@@ -30,10 +30,10 @@ describe ERBLint::Linters::RubocopText do
 
   context 'when rubocop find offenses inside erb text node' do
     let(:file) { <<~FILE }
-      <span> <%= banned_method %> </span>
+      <span> <%= auto_correct_me %> </span>
     FILE
 
-    it { expect(subject).to eq [arbitrary_error_message(11..23)] }
+    it { expect(subject).to eq [arbitrary_error_message(11..25)] }
   end
 
   context 'when rubocop does not find offenses inside erb text node' do
@@ -50,7 +50,7 @@ describe ERBLint::Linters::RubocopText do
     ERBLint::Offense.new(
       linter,
       processed_source.to_source_range(range.min, range.max),
-      "ErbLint/ArbitraryRule: An arbitrary rule has been violated."
+      "ErbLint/AutoCorrectCop: An arbitrary rule has been violated."
     )
   end
 end


### PR DESCRIPTION
Rename the ArbitraryRuleCop for a more explicit name:

- ArbitraryCop -> AutoCorrectCop, the reason is that we need to add a test cop (in the future) that doesn't auto-correct in order to make sure erblint report properly

-------------------

Test cop will watch for two methods:

- `autocorrect_me` which as the name says will get autocorrected
- `dont_autocorrect_me` which as the name says will not get autocorrected
- The reason for this change is that we need to add a test in case a Cop doesn't autocorrect all offenses; When generating the ErbLintOffense, it should not mess the offset. Ref https://github.com/Shopify/erb-lint/pull/48#discussion_r163403670


---------------

Add a test to make sure autocorrected and not autocorrected offenses are aligned

cc/ @rafaelfranca 