### PR TITLE
Ensure the config can be loaded even when rubocop_config is not specified

### DIFF
--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -13,7 +13,7 @@ module ERBLint
 
       class ConfigSchema < LinterConfig
         property :only, accepts: array_of?(String)
-        property :rubocop_config, accepts: Hash
+        property :rubocop_config, accepts: Hash, default: {}
       end
 
       self.config_schema = ConfigSchema
@@ -150,7 +150,7 @@ module ERBLint
       end
 
       def config_from_hash(hash)
-        inherit_from = hash.delete('inherit_from')
+        inherit_from = hash&.delete('inherit_from')
         resolve_inheritance(hash, inherit_from)
 
         tempfile_from('.erblint-rubocop', hash.to_yaml) do |tempfile|

--- a/spec/erb_lint/linters/rubocop_spec.rb
+++ b/spec/erb_lint/linters/rubocop_spec.rb
@@ -23,6 +23,16 @@ describe ERBLint::Linters::Rubocop do
   let(:corrected_content) { corrector.corrected_content }
   subject { offenses }
 
+  context 'config is valid when rubocop_config is not explicitly provided' do
+    let(:linter_config) do
+      described_class.config_schema.new(only: ['NotALinter'])
+    end
+    let(:file) { <<~FILE }
+      <% not_banned_method %>
+    FILE
+    it { expect(subject).to eq [] }
+  end
+
   context 'when rubocop finds no offenses' do
     let(:file) { <<~FILE }
       <% not_banned_method %>


### PR DESCRIPTION
without the safe navigation operator, an exception is raised when `rubocop_config` isn't specified:
```
     Failure/Error: inherit_from = hash.delete('inherit_from')

     NoMethodError:
       undefined method `delete' for nil:NilClass
```