### PR TITLE
The `team` method got removed in f3de80566da3c6c8076dd57431c8737f5cc50a57…

### DIFF
--- a/lib/erb_lint/linters/rubocop_text.rb
+++ b/lib/erb_lint/linters/rubocop_text.rb
@@ -27,11 +27,10 @@ module ERBLint
         erb_nodes
       end
 
-      def team
+      def cop_classes
         selected_cops = RuboCop::Cop::Cop.all.select { |cop| cop.match?(@only_cops) }
-        cop_classes = RuboCop::Cop::Registry.new(selected_cops)
 
-        RuboCop::Cop::Team.new(cop_classes, @rubocop_config, extra_details: true, display_cop_names: true)
+        RuboCop::Cop::Registry.new(selected_cops)
       end
     end
   end


### PR DESCRIPTION
The `team` method got removed in f3de80566da3c6c8076dd57431c8737f5cc50a57:

- It's now called `cop_classes`