### PR TITLE
Autocorrect multiple final newlines

### DIFF
--- a/lib/erb_lint/linters/final_newline.rb
+++ b/lib/erb_lint/linters/final_newline.rb
@@ -23,19 +23,30 @@ module ERBLint
         return offenses if file_content.empty?
 
         match = file_content.match(/(\n+)\z/)
-        ends_with_newline = match.present?
+        final_newline = match&.captures&.first || ""
 
-        if @new_lines_should_be_present && !ends_with_newline
-          offenses << Offense.new(
-            self,
-            processed_source.to_source_range(file_content.size, file_content.size - 1),
-            'Missing a trailing newline at the end of the file.'
-          )
-        elsif !@new_lines_should_be_present && ends_with_newline
+        if @new_lines_should_be_present && final_newline.size != 1
+          if final_newline.empty?
+            offenses << Offense.new(
+              self,
+              processed_source.to_source_range(file_content.size, file_content.size - 1),
+              'Missing a trailing newline at the end of the file.',
+              :insert
+            )
+          else
+            offenses << Offense.new(
+              self,
+              processed_source.to_source_range(file_content.size - final_newline.size + 1, file_content.size - 1),
+              'Remove multiple trailing newline at the end of the file.',
+              :remove
+            )
+          end
+        elsif !@new_lines_should_be_present && !final_newline.empty?
           offenses << Offense.new(
             self,
             processed_source.to_source_range(match.begin(0), match.end(0) - 1),
-            "Remove #{match[0].size} trailing newline at the end of the file."
+            "Remove #{final_newline.size} trailing newline at the end of the file.",
+            :remove
           )
         end
         offenses
@@ -43,7 +54,7 @@ module ERBLint
 
       def autocorrect(_processed_source, offense)
         lambda do |corrector|
-          if @new_lines_should_be_present
+          if offense.context == :insert
             corrector.insert_after(offense.source_range, "\n")
           else
             corrector.remove_trailing(offense.source_range, offense.source_range.size)

--- a/spec/erb_lint/linters/final_newline_spec.rb
+++ b/spec/erb_lint/linters/final_newline_spec.rb
@@ -32,6 +32,26 @@ describe ERBLint::Linters::FinalNewline do
       end
     end
 
+    context 'when the file ends with multiple newlines' do
+      let(:file) { "<div id=\"a\">\nContent\n</div>\n\n\n" }
+
+      it 'reports 1 offense' do
+        expect(subject.size).to eq 1
+      end
+
+      it 'the offense range is set to an empty range after the last character of the file' do
+        expect(subject.first.source_range.begin_pos).to eq 28
+        expect(subject.first.source_range.end_pos).to eq 30
+        expect(subject.first.source_range.source).to eq "\n\n"
+        expect(subject.first.message).to eq \
+          "Remove multiple trailing newline at the end of the file."
+      end
+
+      it 'autocorrects' do
+        expect(corrected_content).to eq "<div id=\"a\">\nContent\n</div>\n"
+      end
+    end
+
     context 'when the file does not end with a newline' do
       let(:file) { "<div id=\"a\">\nContent\n</div>" }
 


### PR DESCRIPTION
The `FinalNewline` linter can ensure that at least one newline is present at the end of the file. When a file ends in multiple final newlines, it should also remove the extra newlines and autocorrect to a single newline.