### PR TITLE
Add global exclude list

### DIFF
--- a/lib/erb_lint/runner_config.rb
+++ b/lib/erb_lint/runner_config.rb
@@ -22,7 +22,11 @@ module ERBLint
       end
       linter_klass = LinterRegistry.find_by_name(klass_name)
       raise Error, "#{klass_name}: linter not found (is it loaded?)" unless linter_klass
-      linter_klass.config_schema.new(linters_config[klass_name] || {})
+      linter_klass.config_schema.new(config_hash_for_linter(klass_name))
+    end
+
+    def global_exclude
+      @config['exclude'] || []
     end
 
     def merge(other_config)
@@ -53,6 +57,13 @@ module ERBLint
 
     def linters_config
       @config['linters'] || {}
+    end
+
+    def config_hash_for_linter(klass_name)
+      config_hash = linters_config[klass_name] || {}
+      config_hash['exclude'] ||= []
+      config_hash['exclude'].concat(global_exclude) if config_hash['exclude'].is_a?(Array)
+      config_hash
     end
   end
 end

--- a/spec/erb_lint/runner_config_spec.rb
+++ b/spec/erb_lint/runner_config_spec.rb
@@ -83,6 +83,24 @@ describe ERBLint::RunnerConfig do
           expect(subject.enabled?).to eq(false)
         end
       end
+
+      context 'when global excludes are specified' do
+        let(:linter) { MyCustomLinter }
+        let(:config_hash) do
+          {
+            linters: {
+              'MyCustomLinter' => { exclude: [ 'foo/bar.rb' ] }
+            },
+            exclude: [
+              '**/node_modules/**'
+            ]
+          }
+        end
+
+        it 'excluded files are merged' do
+          expect(subject.exclude).to eq(['foo/bar.rb', '**/node_modules/**'])
+        end
+      end
     end
 
     describe '#merge' do

--- a/spec/erb_lint/runner_config_spec.rb
+++ b/spec/erb_lint/runner_config_spec.rb
@@ -89,7 +89,7 @@ describe ERBLint::RunnerConfig do
         let(:config_hash) do
           {
             linters: {
-              'MyCustomLinter' => { exclude: [ 'foo/bar.rb' ] }
+              'MyCustomLinter' => { exclude: ['foo/bar.rb'] }
             },
             exclude: [
               '**/node_modules/**'


### PR DESCRIPTION
Add a way to globally exclude certain files, the global list is merged into each linter's exclude list.