### PR TITLE
Match starting and closing erb tag indent

### DIFF
--- a/lib/erb_lint/linters/closing_erb_tag_indent.rb
+++ b/lib/erb_lint/linters/closing_erb_tag_indent.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module ERBLint
+  module Linters
+    # When `<%` isn't followed by a newline, ensure `%>` isn't preceeded by a newline.
+    # When `%>` is preceeded by a newline, indent it at the same level as the corresponding `<%`.
+    class ClosingErbTagIndent < Linter
+      include LinterRegistry
+
+      START_SPACES = /\A([[:space:]]*)/m
+      END_SPACES = /([[:space:]]*)\z/m
+
+      def offenses(processed_source)
+        processed_source.ast.descendants(:erb).each_with_object([]) do |erb_node, offenses|
+          indicator, ltrim, code_node, rtrim = *erb_node
+          code = code_node.children.first
+
+          start_spaces = code.match(START_SPACES)&.captures&.first || ""
+          end_spaces = code.match(END_SPACES)&.captures&.first || ""
+
+          start_with_newline = start_spaces.include?("\n")
+          end_with_newline = end_spaces.include?("\n")
+
+          if !start_with_newline && end_with_newline
+            offenses << Offense.new(
+              self,
+              processed_source.to_source_range(code_node.loc.stop - end_spaces.size + 1, code_node.loc.stop),
+              "Remove newline before `%>` to match start of tag.",
+              ' '
+            )
+          elsif start_with_newline && !end_with_newline
+            offenses << Offense.new(
+              self,
+              processed_source.to_source_range(code_node.loc.stop, code_node.loc.stop),
+              "Insert newline before `%>` to match start of tag.",
+              "\n"
+            )
+          elsif start_with_newline && end_with_newline
+            current_indent = end_spaces.split("\n", -1).last
+            if erb_node.loc.column != current_indent.size
+              offenses << Offense.new(
+                self,
+                processed_source.to_source_range(code_node.loc.stop - current_indent.size + 1, code_node.loc.stop),
+                "Indent `%>` on column #{erb_node.loc.column} to match start of tag.",
+                ' ' * erb_node.loc.column
+              )
+            end
+          end
+        end
+      end
+
+      def autocorrect(_processed_source, offense)
+        lambda do |corrector|
+          corrector.replace(offense.source_range, offense.context)
+        end
+      end
+    end
+  end
+end

--- a/lib/erb_lint/linters/closing_erb_tag_indent.rb
+++ b/lib/erb_lint/linters/closing_erb_tag_indent.rb
@@ -12,7 +12,7 @@ module ERBLint
 
       def offenses(processed_source)
         processed_source.ast.descendants(:erb).each_with_object([]) do |erb_node, offenses|
-          indicator, ltrim, code_node, rtrim = *erb_node
+          _, _, code_node, = *erb_node
           code = code_node.children.first
 
           start_spaces = code.match(START_SPACES)&.captures&.first || ""

--- a/lib/erb_lint/runner_config.rb
+++ b/lib/erb_lint/runner_config.rb
@@ -44,6 +44,7 @@ module ERBLint
             SpaceAroundErbTag: { enabled: true },
             NoJavascriptTagHelper: { enabled: true },
             AllowedScriptType: { enabled: true },
+            ClosingErbTagIndent: { enabled: true },
           },
         )
       end

--- a/spec/erb_lint/linters/closing_erb_tag_indent_spec.rb
+++ b/spec/erb_lint/linters/closing_erb_tag_indent_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ERBLint::Linters::ClosingErbTagIndent do
+  let(:linter_config) { described_class.config_schema.new }
+
+  let(:file_loader) { ERBLint::FileLoader.new('.') }
+  let(:linter) { described_class.new(file_loader, linter_config) }
+  let(:processed_source) { ERBLint::ProcessedSource.new('file.rb', file) }
+  let(:offenses) { linter.offenses(processed_source) }
+  let(:corrector) { ERBLint::Corrector.new(processed_source, offenses) }
+  let(:corrected_content) { corrector.corrected_content }
+
+  describe 'offenses' do
+    subject { offenses }
+
+    context 'when tag is correct' do
+      let(:file) { "<% foo %>" }
+      it { expect(subject).to eq [] }
+    end
+
+    context 'when tag starts and ends with a newline' do
+      let(:file) { <<~ERB }
+        <%
+          foo
+        %>
+      ERB
+      it { expect(subject).to eq [] }
+    end
+
+    context 'when tag start and end are misaligned' do
+      let(:file) { <<~ERB }
+        <%
+          foo
+            %>
+      ERB
+      it do
+        expect(subject).to eq [
+          build_offense(9..12, "Indent `%>` on column 0 to match start of tag.")
+        ]
+      end
+    end
+
+    context 'when tag start and end are misaligned with extra newlines' do
+      let(:file) { <<~ERB }
+        x <%
+          foo
+
+
+            %>
+      ERB
+      it do
+        expect(subject).to eq [
+          build_offense(13..16, "Indent `%>` on column 2 to match start of tag.")
+        ]
+      end
+    end
+
+    context 'when tag starts with newline but ends on same line' do
+      let(:file) { <<~ERB }
+        <%
+          foo %>
+      ERB
+      it do
+        expect(subject).to eq [
+          build_offense(8..8, "Insert newline before `%>` to match start of tag.")
+        ]
+      end
+    end
+
+    context 'when tag starts on same line but ends with newline' do
+      let(:file) { <<~ERB }
+        <% foo
+        %>
+      ERB
+      it do
+        expect(subject).to eq [
+          build_offense(6..6, "Remove newline before `%>` to match start of tag.")
+        ]
+      end
+    end
+  end
+
+  describe 'autocorrect' do
+    subject { corrected_content }
+
+    context 'when tag is correct' do
+      let(:file) { "<% foo %>" }
+      it { expect(subject).to eq file }
+    end
+
+    context 'when tag starts and ends with a newline' do
+      let(:file) { <<~ERB }
+        <%
+          foo
+        %>
+      ERB
+      it { expect(subject).to eq file }
+    end
+
+    context 'when tag start and end are misaligned' do
+      let(:file) { <<~ERB }
+        <%
+          foo
+            %>
+      ERB
+      it { expect(subject).to eq <<~ERB }
+        <%
+          foo
+        %>
+      ERB
+    end
+
+    context 'when tag start and end are misaligned with extra newlines' do
+      let(:file) { <<~ERB }
+        <div><%
+          foo
+
+                %>
+      ERB
+      it { expect(subject).to eq <<~ERB }
+        <div><%
+          foo
+
+             %>
+      ERB
+    end
+
+    context 'when tag starts with newline but ends on same line' do
+      let(:file) { <<~ERB }
+        <%
+          foo %>
+      ERB
+      it { expect(subject).to eq <<~ERB }
+        <%
+          foo
+        %>
+      ERB
+    end
+
+    context 'when tag starts on same line but ends with newline' do
+      let(:file) { <<~ERB }
+        <% foo
+        %>
+      ERB
+      it { expect(subject).to eq <<~ERB }
+        <% foo %>
+      ERB
+    end
+  end
+
+  private
+
+  def build_offense(range, message)
+    ERBLint::Offense.new(
+      linter,
+      processed_source.to_source_range(range.begin, range.end),
+      message
+    )
+  end
+end


### PR DESCRIPTION
When `<%` is followed by a newline, ensure `%>`  is also broken down on its own line and aligned with `<%`. Otherwise make sure `%>` is not on its own line to match `<%`.

bad:
```
<% foo
%>

<% 
foo %>

   <% 
     foo 
        %>
```

good:
```
<% foo %>

   <% 
     foo 
   %>
```