### PR TITLE
Self-closing tag linter

### DIFF
--- a/lib/erb_lint/linters/self_closing_tag.rb
+++ b/lib/erb_lint/linters/self_closing_tag.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module ERBLint
+  module Linters
+    # Warns when a tag is not self-closed properly.
+    class SelfClosingTag < Linter
+      include LinterRegistry
+
+      SELF_CLOSING_TAGS = %w(
+        area base br col command embed hr input keygen
+        link menuitem meta param source track wbr img
+      )
+
+      def offenses(processed_source)
+        processed_source.ast.descendants(:tag).each_with_object([]) do |tag_node, offenses|
+          tag = BetterHtml::Tree::Tag.from_node(tag_node)
+          next unless SELF_CLOSING_TAGS.include?(tag.name)
+
+          if tag.closing?
+            start_solidus = tag_node.children.first
+            offenses << Offense.new(
+              self,
+              processed_source.to_source_range(start_solidus.loc.start, start_solidus.loc.stop),
+              "Tag `#{tag.name}` is self-closing, it must not start with `</`.",
+              ''
+            )
+          end
+
+          if !tag.self_closing?
+            offenses << Offense.new(
+              self,
+              processed_source.to_source_range(tag_node.loc.stop, tag_node.loc.stop - 1),
+              "Tag `#{tag.name}` is self-closing, it must end with `/>`.",
+              '/'
+            )
+          end
+        end
+      end
+
+      def autocorrect(_processed_source, offense)
+        lambda do |corrector|
+          corrector.replace(offense.source_range, offense.context)
+        end
+      end
+    end
+  end
+end

--- a/lib/erb_lint/linters/self_closing_tag.rb
+++ b/lib/erb_lint/linters/self_closing_tag.rb
@@ -26,14 +26,13 @@ module ERBLint
             )
           end
 
-          if !tag.self_closing?
-            offenses << Offense.new(
-              self,
-              processed_source.to_source_range(tag_node.loc.stop, tag_node.loc.stop - 1),
-              "Tag `#{tag.name}` is self-closing, it must end with `/>`.",
-              '/'
-            )
-          end
+          next if tag.self_closing?
+          offenses << Offense.new(
+            self,
+            processed_source.to_source_range(tag_node.loc.stop, tag_node.loc.stop - 1),
+            "Tag `#{tag.name}` is self-closing, it must end with `/>`.",
+            '/'
+          )
         end
       end
 

--- a/spec/erb_lint/linters/self_closing_tag_spec.rb
+++ b/spec/erb_lint/linters/self_closing_tag_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ERBLint::Linters::SelfClosingTag do
+  let(:linter_config) { described_class.config_schema.new }
+
+  let(:file_loader) { ERBLint::FileLoader.new('.') }
+  let(:linter) { described_class.new(file_loader, linter_config) }
+  let(:processed_source) { ERBLint::ProcessedSource.new('file.rb', file) }
+  let(:offenses) { linter.offenses(processed_source) }
+  let(:corrector) { ERBLint::Corrector.new(processed_source, offenses) }
+  let(:corrected_content) { corrector.corrected_content }
+
+  describe 'offenses' do
+    subject { offenses }
+
+    context 'when an element is not self-closing' do
+      let(:file) { "<a></a/>" }
+      it { expect(subject).to eq [] }
+    end
+
+    context 'when an element is self-closed correctly' do
+      let(:file) { "<br/>" }
+      it { expect(subject).to eq [] }
+    end
+
+    context 'when an element is not #self_closing?' do
+      let(:file) { "<br>" }
+      it do
+        expect(subject).to eq [
+          build_offense(3..2, "Tag `br` is self-closing, it must end with `/>`.")
+        ]
+      end
+    end
+
+    context 'when an element is #closing? and #self_closing?' do
+      let(:file) { "</br/>" }
+      it do
+        expect(subject).to eq [
+          build_offense(1..1, "Tag `br` is self-closing, it must not start with `</`.")
+        ]
+      end
+    end
+
+    context 'when an element is #closing?' do
+      let(:file) { "</br>" }
+      it do
+        expect(subject).to eq [
+          build_offense(1..1, "Tag `br` is self-closing, it must not start with `</`."),
+          build_offense(4..3, "Tag `br` is self-closing, it must end with `/>`.")
+        ]
+      end
+    end
+  end
+
+  describe 'autocorrect' do
+    subject { corrected_content }
+
+    context 'when an element is not self-closing' do
+      let(:file) { "<a></a/>" }
+      it { expect(subject).to eq file }
+    end
+
+    context 'when an element is self-closed correctly' do
+      let(:file) { "<br/>" }
+      it { expect(subject).to eq file }
+    end
+
+    context 'when an element is not #self_closing?' do
+      let(:file) { "<br>" }
+      it { expect(subject).to eq "<br/>" }
+    end
+
+    context 'when an element is #closing? and #self_closing?' do
+      let(:file) { "</br/>" }
+      it { expect(subject).to eq "<br/>" }
+    end
+
+    context 'when an element is #closing?' do
+      let(:file) { "</br>" }
+      it { expect(subject).to eq "<br/>" }
+    end
+  end
+
+  private
+
+  def build_offense(range, message)
+    ERBLint::Offense.new(
+      linter,
+      processed_source.to_source_range(range.begin, range.end),
+      message
+    )
+  end
+end


### PR DESCRIPTION
This linter ensures self-closing tags end with `/>`.