### PR TITLE
Space in html tag linter

### DIFF
--- a/lib/erb_lint/linters/space_in_html_tag.rb
+++ b/lib/erb_lint/linters/space_in_html_tag.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+module ERBLint
+  module Linters
+    # Detects extra or missing whitespace in html tags.
+    class SpaceInHtmlTag < Linter
+      include LinterRegistry
+
+      def offenses(processed_source)
+        offenses = []
+        processed_source.ast.descendants(:tag).each do |tag_node|
+          start_solidus, name, attributes, end_solidus = *tag_node.children
+
+          next_loc = name&.loc&.start || attributes&.loc&.start ||
+            end_solidus&.loc&.start || tag_node.loc.stop
+          if start_solidus
+            offenses << no_space(processed_source, tag_node.loc.start + 1, start_solidus.loc.start)
+            offenses << no_space(processed_source, start_solidus.loc.stop + 1, next_loc)
+          else
+            offenses << no_space(processed_source, tag_node.loc.start + 1, next_loc)
+          end
+
+          if attributes
+            offenses << single_space_or_newline(processed_source, name.loc.stop + 1, attributes.loc.start) if name
+            offenses.concat(process_attributes(processed_source, attributes) || [])
+          end
+
+          previous_loc = attributes&.loc&.stop || name&.loc&.stop ||
+            start_solidus&.loc&.stop || tag_node.loc.start
+          if end_solidus
+            offenses << single_space(processed_source, previous_loc + 1, end_solidus.loc.start)
+            offenses << no_space(processed_source, end_solidus.loc.stop + 1, tag_node.loc.stop)
+          else
+            offenses << no_space(processed_source, previous_loc + 1, tag_node.loc.stop)
+          end
+        end
+        offenses.compact
+      end
+
+      def autocorrect(_processed_source, offense)
+        lambda do |corrector|
+          corrector.replace(offense.source_range, offense.context)
+        end
+      end
+
+      private
+
+      def no_space(processed_source, begin_pos, end_pos)
+        range = Range.new(begin_pos, end_pos - 1)
+        chars = processed_source.file_content[range]
+        return if chars.empty?
+
+        Offense.new(
+          self,
+          processed_source.to_source_range(begin_pos, end_pos - 1),
+          "Extra space detected where there should be no space.",
+          ''
+        )
+      end
+
+      def single_space_or_newline(processed_source, begin_pos, end_pos)
+        single_space(processed_source, begin_pos, end_pos, accept_newline: true)
+      end
+
+      def single_space(processed_source, begin_pos, end_pos, accept_newline: false)
+        range = Range.new(begin_pos, end_pos - 1)
+        chars = processed_source.file_content[range]
+        return if chars == ' '
+
+        newlines = chars.include?("\n")
+        expected = newlines && accept_newline ? "\n#{chars.split("\n", -1).last}" : ' '
+        non_space = chars.match(/([^[[:space:]]])/m)
+
+        if non_space && !non_space.captures.empty?
+          Offense.new(
+            self,
+            processed_source.to_source_range(begin_pos, end_pos - 1),
+            "Non-whitespace character(s) detected: #{non_space.captures.map(&:inspect).join(", ")}.",
+            expected
+          )
+        elsif newlines && accept_newline
+          if expected != chars
+            Offense.new(
+              self,
+              processed_source.to_source_range(begin_pos, end_pos - 1),
+              "#{chars.empty? ? 'No' : 'Extra'} space detected where there should be a single space or a single line break.",
+              expected
+            )
+          end
+        else
+          Offense.new(
+            self,
+            processed_source.to_source_range(begin_pos, end_pos - 1),
+            "#{chars.empty? ? 'No' : 'Extra'} space detected where there should be a single space.",
+            expected
+          )
+        end
+      end
+
+      def process_attributes(processed_source, attributes)
+        offenses = []
+        attributes.children.each_with_index do |attribute, index|
+          name, equal, value = *attribute
+          offenses << no_space(processed_source, name.loc.stop + 1, equal.loc.start) if equal
+          offenses << no_space(processed_source, equal.loc.stop + 1, value.loc.start) if equal && value
+
+          next if index >= attributes.children.size - 1
+          next_attribute = attributes.children[index + 1]
+
+          offenses << single_space_or_newline(processed_source,
+            attribute.loc.stop + 1, next_attribute.loc.start)
+        end
+        offenses
+      end
+    end
+  end
+end

--- a/lib/erb_lint/linters/space_in_html_tag.rb
+++ b/lib/erb_lint/linters/space_in_html_tag.rb
@@ -75,7 +75,8 @@ module ERBLint
           Offense.new(
             self,
             processed_source.to_source_range(begin_pos, end_pos - 1),
-            "Non-whitespace character(s) detected: #{non_space.captures.map(&:inspect).join(", ")}.",
+            "Non-whitespace character(s) detected: "\
+              "#{non_space.captures.map(&:inspect).join(', ')}.",
             expected
           )
         elsif newlines && accept_newline
@@ -83,7 +84,8 @@ module ERBLint
             Offense.new(
               self,
               processed_source.to_source_range(begin_pos, end_pos - 1),
-              "#{chars.empty? ? 'No' : 'Extra'} space detected where there should be a single space or a single line break.",
+              "#{chars.empty? ? 'No' : 'Extra'} space detected where there should be "\
+                "a single space or a single line break.",
               expected
             )
           end

--- a/lib/erb_lint/linters/space_in_html_tag.rb
+++ b/lib/erb_lint/linters/space_in_html_tag.rb
@@ -9,7 +9,7 @@ module ERBLint
       def offenses(processed_source)
         offenses = []
         processed_source.ast.descendants(:tag).each do |tag_node|
-          start_solidus, name, attributes, end_solidus = *tag_node.children
+          start_solidus, name, attributes, end_solidus = *tag_node
 
           next_loc = name&.loc&.start || attributes&.loc&.start ||
             end_solidus&.loc&.start || tag_node.loc.stop

--- a/lib/erb_lint/runner_config.rb
+++ b/lib/erb_lint/runner_config.rb
@@ -50,6 +50,7 @@ module ERBLint
             AllowedScriptType: { enabled: true },
             TrailingWhitespace: { enabled: true },
             SpaceIndentation: { enabled: true },
+            SpaceInHtmlTag: { enabled: true },
           },
         )
       end

--- a/spec/erb_lint/linters/space_in_html_tag_spec.rb
+++ b/spec/erb_lint/linters/space_in_html_tag_spec.rb
@@ -1,0 +1,551 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ERBLint::Linters::SpaceInHtmlTag do
+  let(:linter_config) { described_class.config_schema.new }
+
+  let(:file_loader) { ERBLint::FileLoader.new('.') }
+  let(:linter) { described_class.new(file_loader, linter_config) }
+  let(:processed_source) { ERBLint::ProcessedSource.new('file.rb', file) }
+  let(:offenses) { linter.offenses(processed_source) }
+  let(:corrector) { ERBLint::Corrector.new(processed_source, offenses) }
+  let(:corrected_content) { corrector.corrected_content }
+
+  describe 'offenses' do
+    subject { offenses }
+
+    context 'when space is correct' do
+      context 'plain opening tag' do
+        let(:file) { "<div>" }
+        it { expect(subject).to eq [] }
+      end
+
+      context 'self-closing tag without attributes' do
+        let(:file) { "<img />" }
+        it { expect(subject).to eq [] }
+      end
+
+      context 'closing tag' do
+        let(:file) { "</div>" }
+        it { expect(subject).to eq [] }
+      end
+
+      context 'tag with no name' do
+        let(:file) { "</>" }
+        it { expect(subject).to eq [] }
+      end
+
+      context 'plain tag with attribute' do
+        let(:file) { '<div class="foo">' }
+        it { expect(subject).to eq [] }
+      end
+
+      context 'self-closing tag with attribute' do
+        let(:file) { '<input class="foo" />' }
+        it { expect(subject).to eq [] }
+      end
+
+      context 'between attributes' do
+        let(:file) { '<input class="foo" name="bar" />' }
+        it { expect(subject).to eq [] }
+      end
+
+      context 'multi-line tag' do
+        let(:file) { <<~HTML }
+          <input
+            type="password"
+            class="foo" />
+        HTML
+        it { expect(subject).to eq [] }
+      end
+    end
+
+    context 'when no space should be present' do
+      context 'after name' do
+        let(:file) { "<div   >" }
+        it do
+          expect(subject).to eq [
+            build_offense(4..6, "Extra space detected where there should be no space.")
+          ]
+        end
+      end
+
+      context 'before name' do
+        let(:file) { "<   div>" }
+        it do
+          expect(subject).to eq [
+            build_offense(1..3, "Extra space detected where there should be no space.")
+          ]
+        end
+      end
+
+      context 'before start solidus' do
+        let(:file) { "<   /div>" }
+        it do
+          expect(subject).to eq [
+            build_offense(1..3, "Extra space detected where there should be no space.")
+          ]
+        end
+      end
+
+      context 'after start solidus' do
+        let(:file) { "</   div>" }
+        it do
+          expect(subject).to eq [
+            build_offense(2..4, "Extra space detected where there should be no space.")
+          ]
+        end
+      end
+
+      context 'after end solidus' do
+        let(:file) { "<div /   >" }
+        it do
+          expect(subject).to eq [
+            build_offense(6..8, "Extra space detected where there should be no space.")
+          ]
+        end
+      end
+
+      context 'between attribute name and equal' do
+        let(:file) { "<div foo  ='bar'>" }
+        it do
+          expect(subject).to eq [
+            build_offense(8..9, "Extra space detected where there should be no space.")
+          ]
+        end
+      end
+
+      context 'between attribute equal and value' do
+        let(:file) { "<div foo=  'bar'>" }
+        it do
+          expect(subject).to eq [
+            build_offense(9..10, "Extra space detected where there should be no space.")
+          ]
+        end
+      end
+    end
+
+    context 'when space is missing' do
+      context 'between attributes' do
+        let(:file) { "<div foo='foo'bar='bar'>" }
+        it do
+          expect(subject).to eq [
+            build_offense(14..13, "No space detected where there should be "\
+              "a single space.")
+          ]
+        end
+      end
+
+      context 'between last attribute and solidus' do
+        let(:file) { "<div foo='bar'/>" }
+        it do
+          expect(subject).to eq [
+            build_offense(14..13, "No space detected where there should be "\
+              "a single space.")
+          ]
+        end
+      end
+
+      context 'between name and solidus' do
+        let(:file) { "<div/>" }
+        it do
+          expect(subject).to eq [
+            build_offense(4..3, "No space detected where there should be "\
+              "a single space.")
+          ]
+        end
+      end
+    end
+
+    context 'when extra space is present' do
+      context 'between name and end of tag' do
+        let(:file) { "<div  >" }
+        it do
+          expect(subject).to eq [
+            build_offense(4..5, "Extra space detected where there should be no space.")
+          ]
+        end
+      end
+
+      context 'between name and first attribute' do
+        let(:file) { '<img   class="hide">' }
+        it do
+          expect(subject).to eq [
+            build_offense(4..6, "Extra space detected where there should be "\
+              "a single space.")
+          ]
+        end
+      end
+
+      context 'between name and end solidus' do
+        let(:file) { "<br   />" }
+        it do
+          expect(subject).to eq [
+            build_offense(3..5, "Extra space detected where there should be "\
+              "a single space.")
+          ]
+        end
+      end
+
+      context 'between last attribute and solidus' do
+        let(:file) { '<br class="hide"   />' }
+        it do
+          expect(subject).to eq [
+            build_offense(16..18, "Extra space detected where there should be "\
+              "a single space.")
+          ]
+        end
+      end
+
+      context 'between last attribute and end of tag' do
+        let(:file) { '<img class="hide"    >' }
+        it do
+          expect(subject).to eq [
+            build_offense(17..20, "Extra space detected where there should be "\
+              "no space.")
+          ]
+        end
+      end
+
+      context 'between attributes' do
+        let(:file) { "<div foo='foo'      bar='bar'>" }
+        it do
+          expect(subject).to eq [
+            build_offense(14..19, "Extra space detected where there should be "\
+              "a single space.")
+          ]
+        end
+      end
+
+      context 'extra newline between name and first attribute' do
+        let(:file) { <<~HTML }
+          <input
+
+            type="password" />
+        HTML
+        it do
+          expect(subject).to eq [
+            build_offense(6..9, "Extra space detected where there should be "\
+              "a single space or a single line break.")
+          ]
+        end
+      end
+
+      context 'extra newline between name and end of tag' do
+        let(:file) { <<~HTML }
+          <input
+
+            />
+        HTML
+        it do
+          expect(subject).to eq [
+            build_offense(6..9, "Extra space detected where there should be "\
+              "a single space.")
+          ]
+        end
+      end
+
+      context 'extra newline between attributes' do
+        let(:file) { <<~HTML }
+          <input
+            type="password"
+
+            class="foo" />
+        HTML
+        it do
+          expect(subject).to eq [
+            build_offense(24..27, "Extra space detected where there should be "\
+              "a single space or a single line break.")
+          ]
+        end
+      end
+
+      context 'end solidus is on newline' do
+        let(:file) { <<~HTML }
+          <input
+            type="password"
+            class="foo"
+            />
+        HTML
+        it do
+          expect(subject).to eq [
+            build_offense(38..40, "Extra space detected where there should be "\
+              "a single space.")
+          ]
+        end
+      end
+
+      context 'end of tag is on newline' do
+        let(:file) { <<~HTML }
+          <input
+            type="password"
+            class="foo"
+            >
+        HTML
+        it do
+          expect(subject).to eq [
+            build_offense(38..40, "Extra space detected where there should be "\
+              "no space.")
+          ]
+        end
+      end
+
+      context 'non-space detected between name and attribute' do
+        let(:file) { <<~HTML }
+          <input/class="hide" />
+        HTML
+        it do
+          expect(subject).to eq [
+            build_offense(6..6, 'Non-whitespace character(s) detected: "/".')
+          ]
+        end
+      end
+
+      context 'non-space detected between attribures' do
+        let(:file) { <<~HTML }
+          <input class="hide"/name="foo" />
+        HTML
+        it do
+          expect(subject).to eq [
+            build_offense(19..19, 'Non-whitespace character(s) detected: "/".')
+          ]
+        end
+      end
+    end
+  end
+
+  describe 'autocorrect' do
+    subject { corrected_content }
+
+    context 'when space is correct' do
+      context 'plain opening tag' do
+        let(:file) { "<div>" }
+        it { expect(subject).to eq file }
+      end
+
+      context 'self-closing tag without attributes' do
+        let(:file) { "<img />" }
+        it { expect(subject).to eq file }
+      end
+
+      context 'closing tag' do
+        let(:file) { "</div>" }
+        it { expect(subject).to eq file }
+      end
+
+      context 'tag with no name' do
+        let(:file) { "</>" }
+        it { expect(subject).to eq file }
+      end
+
+      context 'plain tag with attribute' do
+        let(:file) { '<div class="foo">' }
+        it { expect(subject).to eq file }
+      end
+
+      context 'self-closing tag with attribute' do
+        let(:file) { '<input class="foo" />' }
+        it { expect(subject).to eq file }
+      end
+
+      context 'between attributes' do
+        let(:file) { '<input class="foo" name="bar" />' }
+        it { expect(subject).to eq file }
+      end
+
+      context 'multi-line tag' do
+        let(:file) { <<~HTML }
+          <input
+            type="password"
+            class="foo" />
+        HTML
+        it { expect(subject).to eq file }
+      end
+    end
+
+    context 'when no space should be present' do
+      context 'after name' do
+        let(:file) { "<div   >" }
+        it { expect(subject).to eq "<div>" }
+      end
+
+      context 'before name' do
+        let(:file) { "<   div>" }
+        it { expect(subject).to eq "<div>" }
+      end
+
+      context 'before start solidus' do
+        let(:file) { "<   /div>" }
+        it { expect(subject).to eq "</div>" }
+      end
+
+      context 'after start solidus' do
+        let(:file) { "</   div>" }
+        it { expect(subject).to eq "</div>" }
+      end
+
+      context 'after end solidus' do
+        let(:file) { "<div/   >" }
+        it { expect(subject).to eq "<div />" }
+      end
+
+      context 'between attribute name and equal' do
+        let(:file) { "<div foo  ='bar'>" }
+        it { expect(subject).to eq "<div foo='bar'>" }
+      end
+
+      context 'between attribute equal and value' do
+        let(:file) { "<div foo=  'bar'>" }
+        it { expect(subject).to eq "<div foo='bar'>" }
+      end
+    end
+
+    context 'when space is missing' do
+      context 'between attributes' do
+        let(:file) { "<div foo='foo'bar='bar'>" }
+        it { expect(subject).to eq "<div foo='foo' bar='bar'>" }
+      end
+
+      context 'between last attribute and solidus' do
+        let(:file) { "<div foo='bar'/>" }
+        it { expect(subject).to eq "<div foo='bar' />" }
+      end
+
+      context 'between name and solidus' do
+        let(:file) { "<div/>" }
+        it { expect(subject).to eq "<div />" }
+      end
+    end
+
+    context 'when extra space is present' do
+      context 'between name and end of tag' do
+        let(:file) { "<div  >" }
+        it { expect(subject).to eq "<div>" }
+      end
+
+      context 'between name and first attribute' do
+        let(:file) { "<div  >" }
+        it { expect(subject).to eq "<div>" }
+      end
+
+      context 'between name and first attribute' do
+        let(:file) { '<img   class="hide">' }
+        it { expect(subject).to eq '<img class="hide">' }
+      end
+
+      context 'between name and end solidus' do
+        let(:file) { "<br   />" }
+        it { expect(subject).to eq "<br />" }
+      end
+
+      context 'between last attribute and solidus' do
+        let(:file) { '<br class="hide"   />' }
+        it { expect(subject).to eq '<br class="hide" />' }
+      end
+
+      context 'between last attribute and end of tag' do
+        let(:file) { '<img class="hide"    >' }
+        it { expect(subject).to eq '<img class="hide">' }
+      end
+
+      context 'between attributes' do
+        let(:file) { "<div foo='foo'      bar='bar'>" }
+        it { expect(subject).to eq "<div foo='foo' bar='bar'>" }
+      end
+
+      context 'extra newline between name and first attribute' do
+        let(:file) { <<~HTML }
+          <input
+
+            type="password" />
+        HTML
+        it { expect(subject).to eq <<~HTML }
+          <input
+            type="password" />
+        HTML
+      end
+
+      context 'extra newline between name and end of tag' do
+        let(:file) { <<~HTML }
+          <input
+
+            />
+        HTML
+        it { expect(subject).to eq <<~HTML }
+          <input />
+        HTML
+      end
+
+      context 'extra newline between attributes' do
+        let(:file) { <<~HTML }
+          <input
+            type="password"
+
+            class="foo" />
+        HTML
+        it { expect(subject).to eq <<~HTML }
+          <input
+            type="password"
+            class="foo" />
+        HTML
+      end
+
+      context 'end solidus is on newline' do
+        let(:file) { <<~HTML }
+          <input
+            type="password"
+            class="foo"
+            />
+        HTML
+        it { expect(subject).to eq <<~HTML }
+          <input
+            type="password"
+            class="foo" />
+        HTML
+      end
+
+      context 'end of tag is on newline' do
+        let(:file) { <<~HTML }
+          <input
+            type="password"
+            class="foo"
+            >
+        HTML
+        it { expect(subject).to eq <<~HTML }
+          <input
+            type="password"
+            class="foo">
+        HTML
+      end
+
+      context 'non-space detected between name and attribute' do
+        let(:file) { <<~HTML }
+          <input/class="hide" />
+        HTML
+        it { expect(subject).to eq <<~HTML }
+          <input class="hide" />
+        HTML
+      end
+
+      context 'non-space detected between attribures' do
+        let(:file) { <<~HTML }
+          <input class="hide"/name="foo" />
+        HTML
+        it { expect(subject).to eq <<~HTML }
+          <input class="hide" name="foo" />
+        HTML
+      end
+    end
+  end
+
+  private
+
+  def build_offense(range, message)
+    ERBLint::Offense.new(
+      linter,
+      processed_source.to_source_range(range.begin, range.end),
+      message
+    )
+  end
+end

--- a/spec/erb_lint/linters/space_in_html_tag_spec.rb
+++ b/spec/erb_lint/linters/space_in_html_tag_spec.rb
@@ -59,6 +59,23 @@ describe ERBLint::Linters::SpaceInHtmlTag do
         HTML
         it { expect(subject).to eq [] }
       end
+
+      context 'tag with erb' do
+        let(:file) { <<~HTML }
+          <input <%= attributes %> />
+        HTML
+        it { expect(subject).to eq [] }
+      end
+
+      context 'multi-line tag with erb' do
+        let(:file) { <<~HTML }
+          <input
+            type="password"
+            <%= attributes %>
+            class="foo" />
+        HTML
+        it { expect(subject).to eq [] }
+      end
     end
 
     context 'when no space should be present' do


### PR DESCRIPTION
Detects extra or missing whitespace in HTML tags and around attributes.

Depends on better_html v1.0.5 (https://github.com/Shopify/erb-lint/pull/64)