### PR TITLE
Reorder default config and add SelfClosingTag

### DIFF
--- a/lib/erb_lint/runner_config.rb
+++ b/lib/erb_lint/runner_config.rb
@@ -42,16 +42,17 @@ module ERBLint
       def default
         new(
           linters: {
+            AllowedScriptType: { enabled: true },
+            ClosingErbTagIndent: { enabled: true },
+            ExtraNewline: { enabled: true },
             FinalNewline: { enabled: true },
+            NoJavascriptTagHelper: { enabled: true },
             ParserErrors: { enabled: true },
             RightTrim: { enabled: true },
+            SelfClosingTag: { enabled: true },
             SpaceAroundErbTag: { enabled: true },
-            NoJavascriptTagHelper: { enabled: true },
-            AllowedScriptType: { enabled: true },
-            ExtraNewline: { enabled: true },
-            ClosingErbTagIndent: { enabled: true },
-            TrailingWhitespace: { enabled: true },
             SpaceIndentation: { enabled: true },
+            TrailingWhitespace: { enabled: true },
           },
         )
       end


### PR DESCRIPTION
I forgot to enable ` SelfClosingTag` in the default config, and I also took this opportunity to reorder the list alphabetically.