### PR TITLE
Allow the hardcodedString linter to delegate the autocorrection logic to a external class

### DIFF
--- a/spec/erb_lint/linters/hard_coded_string_spec.rb
+++ b/spec/erb_lint/linters/hard_coded_string_spec.rb
@@ -16,7 +16,7 @@ describe ERBLint::Linters::HardCodedString do
       <span> Hello </span>
     FILE
 
-    it { expect(subject).to eq [untranslated_string_error(6..12, 'String not translated: Hello')] }
+    it { expect(subject).to eq [untranslated_string_error(7..11, 'String not translated: Hello')] }
   end
 
   context 'when file contains nested hard coded string' do
@@ -28,7 +28,7 @@ describe ERBLint::Linters::HardCodedString do
       </span>
     FILE
 
-    it { expect(subject).to eq [untranslated_string_error(60..68, 'String not translated: Example')] }
+    it { expect(subject).to eq [untranslated_string_error(61..67, 'String not translated: Example')] }
   end
 
   context 'when file contains a mix of hard coded string and erb' do
@@ -36,7 +36,7 @@ describe ERBLint::Linters::HardCodedString do
       <span><%= foo %> Example </span>
     FILE
 
-    it { expect(subject).to eq [untranslated_string_error(6..24, 'String not translated: Example')] }
+    it { expect(subject).to eq [untranslated_string_error(17..23, 'String not translated: Example')] }
   end
 
   context 'when file contains hard coded string nested inside erb' do
@@ -48,7 +48,7 @@ describe ERBLint::Linters::HardCodedString do
       </span>
     FILE
 
-    it { expect(subject).to eq [untranslated_string_error(32..40, 'String not translated: Example')] }
+    it { expect(subject).to eq [untranslated_string_error(33..39, 'String not translated: Example')] }
   end
 
   context 'when file contains multiple hard coded string' do
@@ -60,9 +60,9 @@ describe ERBLint::Linters::HardCodedString do
 
     it 'find all offenses' do
       expect(subject).to eq [
-        untranslated_string_error(6..14, 'String not translated: Example'),
-        untranslated_string_error(29..33, 'String not translated: Foo'),
-        untranslated_string_error(48..53, 'String not translated: Test')
+        untranslated_string_error(7..13, 'String not translated: Example'),
+        untranslated_string_error(30..32, 'String not translated: Foo'),
+        untranslated_string_error(49..52, 'String not translated: Test')
       ]
     end
   end
@@ -90,7 +90,7 @@ describe ERBLint::Linters::HardCodedString do
 
     it 'add offense' do
       expected = untranslated_string_error(
-        22..47,
+        26..26,
         "Consider using Rails helpers to move out the single character \`%\` from the html."
       )
       expect(subject).to eq [expected]
@@ -121,7 +121,47 @@ describe ERBLint::Linters::HardCodedString do
       Example
     FILE
 
-    it { expect(subject).to eq [untranslated_string_error(157..165, "String not translated: Example")] }
+    it { expect(subject).to eq [untranslated_string_error(158..164, "String not translated: Example")] }
+  end
+
+  context 'when file contains multiple chunks of hardcoded strings' do
+    let(:file) { <<~FILE }
+      <div>
+        Foo <%= bar %> Foo2 <% bar %> Foo3
+      </div>
+    FILE
+
+    it do
+      expected = [
+        untranslated_string_error(8..10, "String not translated: Foo"),
+        untranslated_string_error(23..26, "String not translated: Foo2"),
+        untranslated_string_error(38..41, "String not translated: Foo3")
+      ]
+
+      expect(subject).to eq expected
+    end
+  end
+
+  context 'when file contains multiple hardcoded strings that spans on multiple lines' do
+    let(:file) { <<~FILE }
+      <div>
+        Foo
+        John
+        Albert
+        Smith
+      </div>
+    FILE
+
+    it 'creates a new offense for each' do
+      expected = [
+        untranslated_string_error(8..10, "String not translated: Foo"),
+        untranslated_string_error(14..17, "String not translated: John"),
+        untranslated_string_error(21..26, "String not translated: Albert"),
+        untranslated_string_error(30..34, "String not translated: Smith")
+      ]
+
+      expect(subject).to eq expected
+    end
   end
 
   private

--- a/spec/erb_lint/linters/hard_coded_string_spec.rb
+++ b/spec/erb_lint/linters/hard_coded_string_spec.rb
@@ -169,7 +169,7 @@ describe ERBLint::Linters::HardCodedString do
     let(:tempfile) do
       @tempfile = Tempfile.new(['my_class', '.rb']).tap do |f|
         f.write(<<~EOM)
-          class MySuperCorrector
+          class I18nCorrector
             attr_reader :node
 
             def initialize(filename, range)
@@ -192,7 +192,7 @@ describe ERBLint::Linters::HardCodedString do
     end
 
     let(:linter_options) do
-      { corrector: { path: tempfile.path, name: 'MySuperCorrector' } }
+      { corrector: { path: tempfile.path, name: 'I18nCorrector' } }
     end
 
     let(:file) { <<~FILE }
@@ -203,7 +203,7 @@ describe ERBLint::Linters::HardCodedString do
       offense = untranslated_string_error(7..11, 'String not translated: Hello')
       linter.autocorrect(processed_source, offense)
 
-      expect(defined?(MySuperCorrector)).to eq('constant')
+      expect(defined?(I18nCorrector)).to eq('constant')
     end
 
     it 'calls the autocorrect method and pass a rubocop node' do
@@ -228,10 +228,11 @@ describe ERBLint::Linters::HardCodedString do
         { corrector: { path: tempfile.path, name: 'UnknownClass' } }
       end
 
-      it 'does not continue the auto correction' do
+      it 'does not continue the auto correction when the class passed is not whitelisted' do
         offense = untranslated_string_error(7..11, 'String not translated: Hello')
 
-        expect(linter.autocorrect(processed_source, offense)).to eq(nil)
+        error = ERBLint::Linters::HardCodedString::ForbiddenCorrector
+        expect { linter.autocorrect(processed_source, offense) }.to raise_error(error)
       end
     end
   end


### PR DESCRIPTION
Multiple things was wrong with the HardCodedString linter:

- The linter was not properly pointing the offense on the hardcoded string but instead on the entire text node
  - If we had a line like `<div> Foo <%= bar %>`, we want the offense to be pointed on the string `Foo`
- If a line had multiple hardcoded string separated by erb tags, then only the first string would generate an offense
- When a block of text that contains muliple lines, we want to split each line and treat them individually, otherwise the whole block would be treated as an offense
  - The main reason for this change is to make the autocorrecting feature easier
  - If we have a block of text like this
  ```html.erb
    <div>
      My name is John <%= last_name %>.
      I leave in <%= country %>
    <div>
  ```
  then we will add an offense on `My name is John` and `I leave in`. Without this change, the offense will be trated as `My name is John` and `.\n    I leave in`


-----------------------------------

Added a way to pass a `corrector` to the HardCodedString linter:

- Hardcoded string inside html should be treated the same way as hardcoded string inside ruby or erb, it goes the same way for autocorrection
- We already have a bunch of logic in order to autocorrect hardcoded string inside those, (extract the string, create a translation file, generate a key, find the good scope ...). Because the logic it's exactly the same for this linter, I opted to not reinvent the wheel
- My solution is to pass a path to your corrector file, and his name. Our linter will take care of requiring it and instantiate the class
- The linter expects from the Autocorrector class to:
  - Accept 2 arguments in its constructor. The file path and the source range of the offense will be passed
  - Response to the `autocorrect` method which should have a signature as follow
  ```ruby
    def autocorrect(node, tag_start: tag_end:)
    end
  ```
  - The autocorrect method needs to returns  a proc which will be given an instance of RuboCop::Cop::Corrector
- In order to have as much compatibility from a rubocop node, the Autocorrector#autocorrect method will be give an instance of `RuboCop::AST::StrNode` which we manually create inside the linter. There is one caveat, a node should be able to respond to `loc`, but I was unable to make it work. The main reason is because when a Node is created, propery can be assigned to this node, one of them being the `location` which needs to be an instance of `Parser::SourceMap`, trying to generate this with non ruby code is too tricky


cc/ @Shopify/i18n 