### PR TITLE
Disable offense when string contains a single char:

### DIFF
--- a/lib/erb_lint/linters/hard_coded_string.rb
+++ b/lib/erb_lint/linters/hard_coded_string.rb
@@ -29,7 +29,7 @@ module ERBLint
           offended_strings = text_node.to_a.select { |node| relevant_node(node) }
           offended_strings.each do |offended_string|
             offended_string.split("\n").each do |str|
-              to_check << [text_node, str] unless str.empty?
+              to_check << [text_node, str] if str.length > 1
             end
           end
         end
@@ -101,11 +101,7 @@ module ERBLint
       def message(string)
         stripped_string = string.strip
 
-        if stripped_string.length > 1
-          "String not translated: #{stripped_string}"
-        else
-          "Consider using Rails helpers to move out the single character `#{stripped_string}` from the html."
-        end
+        "String not translated: #{stripped_string}"
       end
     end
   end

--- a/spec/erb_lint/linters/hard_coded_string_spec.rb
+++ b/spec/erb_lint/linters/hard_coded_string_spec.rb
@@ -89,12 +89,8 @@ describe ERBLint::Linters::HardCodedString do
       </span>
     FILE
 
-    it 'add offense' do
-      expected = untranslated_string_error(
-        26..26,
-        "Consider using Rails helpers to move out the single character \`%\` from the html."
-      )
-      expect(subject).to eq [expected]
+    it 'does not add offense' do
+      expect(subject).to eq []
     end
   end
 


### PR DESCRIPTION
- With the auto-correction feature in place, this message doesn't make sense anymore
- After the auto-correction is processed, a second pass is done and relints the file, the problem is that we have a lot of strings that could look like this
  ```html.erb
    My name is <%= name %>.
  ```
  The autocorrection will transform it to
  ```html.erb
    <%= t('translation.key') %> <%= name %>.
  ```
  After the second pass, the final `.` will be linted
- The best solution would be to move the `<%= name %>` in the translation, but we are not ready for that and it requires way more work