### PR TITLE
False positive on blank:

### DIFF
--- a/lib/erb_lint/linters/hard_coded_string.rb
+++ b/lib/erb_lint/linters/hard_coded_string.rb
@@ -29,7 +29,7 @@ module ERBLint
           offended_strings = text_node.to_a.select { |node| relevant_node(node) }
           offended_strings.each do |offended_string|
             offended_string.split("\n").each do |str|
-              to_check << [text_node, str] if str.length > 1
+              to_check << [text_node, str] if str.gsub(/\s*/, '').length > 1
             end
           end
         end

--- a/spec/erb_lint/linters/hard_coded_string_spec.rb
+++ b/spec/erb_lint/linters/hard_coded_string_spec.rb
@@ -147,6 +147,7 @@ describe ERBLint::Linters::HardCodedString do
         John
         Albert
         Smith
+        <%= test %>
       </div>
     FILE
 


### PR DESCRIPTION
- When a string spans on multiple lines, the last line would point an offense to the blank
i.e.
```.html.erb
<div>
  Hello
  <%= world %>
</div>
```
erb-lint generates a text node that looks like this 
```
  Hello\n  (Github editor doesn't show it, but there is 2 spaces before the Hello, and 2 spaces after the \n
```

 (it takes all characters until it finds a non text node)
- This PR ensure no offense would be added on the extra blank on the next line