### PR TITLE
Fix multiple corrections on same offense

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -63,8 +63,9 @@ module ERBLint
       end
 
       if @stats.corrected > 0
-        if @stats.found > 0
-          warn "#{@stats.corrected} error(s) corrected and #{@stats.found} error(s) remaining in ERB files".red
+        corrected_found_diff = @stats.found - @stats.corrected
+        if corrected_found_diff > 0
+          warn "#{@stats.corrected} error(s) corrected and #{corrected_found_diff} error(s) remaining in ERB files".red
         else
           puts "#{@stats.corrected} error(s) corrected in ERB files".green
         end
@@ -99,6 +100,7 @@ module ERBLint
 
       7.times do
         processed_source = ERBLint::ProcessedSource.new(filename, file_content)
+        previous_offenses = runner.offenses
         runner.run(processed_source)
         break unless autocorrect? && runner.offenses.any?
 
@@ -113,6 +115,7 @@ module ERBLint
         end
 
         file_content = corrector.corrected_content
+        break if previous_offenses.eql?(runner.offenses)
       end
 
       @stats.found += runner.offenses.size

--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -100,7 +100,6 @@ module ERBLint
 
       7.times do
         processed_source = ERBLint::ProcessedSource.new(filename, file_content)
-        previous_offenses = runner.offenses
         runner.run(processed_source)
         break unless autocorrect? && runner.offenses.any?
 
@@ -115,7 +114,7 @@ module ERBLint
         end
 
         file_content = corrector.corrected_content
-        break if previous_offenses.eql?(runner.offenses)
+        runner.clear_offenses
       end
 
       @stats.found += runner.offenses.size

--- a/lib/erb_lint/linter.rb
+++ b/lib/erb_lint/linter.rb
@@ -55,5 +55,9 @@ module ERBLint
     def add_offense(source_range, message, context = nil)
       @offenses << Offense.new(self, source_range, message, context)
     end
+
+    def clear_offenses
+      @offenses = []
+    end
   end
 end

--- a/lib/erb_lint/runner.rb
+++ b/lib/erb_lint/runner.rb
@@ -26,5 +26,10 @@ module ERBLint
         @offenses.concat(linter.offenses)
       end
     end
+
+    def clear_offenses
+      @offenses = []
+      @linters.each(&:clear_offenses)
+    end
   end
 end

--- a/spec/erb_lint/linter_spec.rb
+++ b/spec/erb_lint/linter_spec.rb
@@ -13,8 +13,7 @@ describe ERBLint::Linter do
     module ERBLint
       module Linters
         class Fake < ERBLint::Linter
-          def offenses(_processed_source)
-          end
+          attr_accessor :offenses
         end
       end
     end
@@ -22,6 +21,14 @@ describe ERBLint::Linter do
     describe '.simple_name' do
       it 'returns the name of the class with the ERBLint::Linter prefix removed' do
         expect(subject.class.simple_name).to eq 'Fake'
+      end
+    end
+
+    describe '.clear_offenses' do
+      it 'clears all offenses from the offenses ivar' do
+        linter.offenses = ["someoffense"]
+        linter.clear_offenses
+        expect(linter.offenses).to eq []
       end
     end
   end

--- a/spec/erb_lint/runner_spec.rb
+++ b/spec/erb_lint/runner_spec.rb
@@ -114,5 +114,21 @@ describe ERBLint::Runner do
         expect(subject[0].message).to eq("Missing a trailing newline at the end of the file.")
       end
     end
+
+    context 'clear_offenses clears offenses' do
+      let(:config) do
+        ERBLint::RunnerConfig.new(
+          linters: {
+            'FakeLinter1' => { 'enabled' => true },
+            'FakeLinter2' => { 'enabled' => true }
+          }
+        )
+      end
+
+      it 'clears all offenses from the offenses ivar' do
+        runner.clear_offenses
+        expect(subject).to eq []
+      end
+    end
   end
 end


### PR DESCRIPTION
https://github.com/Shopify/erb-lint/pull/69 introduced stored offenses in an instance variable `@offenses`.

However this makes it so the break condition of the lopp: https://github.com/Shopify/erb-lint/blob/8b7863485fd9d9cdb36f83af8cc87cb0fc50b683/lib/erb_lint/cli.rb#L102-L103

Will only break if no offenses are detected on the first pass, if an offense is detected the first time, the loop will not break because the offences are now stored in the ivar `@offense` of the runner.

To circumvent this, I am comparing what the previous offenses were and breaking if there are no changes at the end of the iteration.

----
This PR also fixes a few misleading messages on offense 