### PR TITLE
Ignore html spaces for hardcoded extraction

### DIFF
--- a/lib/erb_lint/linters/hard_coded_string.rb
+++ b/lib/erb_lint/linters/hard_coded_string.rb
@@ -29,7 +29,7 @@ module ERBLint
           offended_strings = text_node.to_a.select { |node| relevant_node(node) }
           offended_strings.each do |offended_string|
             offended_string.split("\n").each do |str|
-              to_check << [text_node, str] if str.gsub(/\s*/, '').length > 1
+              to_check << [text_node, str] if check_string?(str)
             end
           end
         end
@@ -67,6 +67,11 @@ module ERBLint
       end
 
       private
+
+      def check_string?(str)
+        string = str.gsub(/\s*/, '')
+        string.length > 1 && !%w(&nbsp;).include?(string)
+      end
 
       def load_corrector
         corrector_name = @config['corrector'].fetch('name') { raise MissingCorrector }

--- a/spec/erb_lint/linters/hard_coded_string_spec.rb
+++ b/spec/erb_lint/linters/hard_coded_string_spec.rb
@@ -81,6 +81,14 @@ describe ERBLint::Linters::HardCodedString do
     it { expect(subject).to eq [] }
   end
 
+  context 'when file contains blacklisted extraction' do
+    let(:file) { <<~FILE }
+      &nbsp;
+    FILE
+
+    it { expect(subject).to eq [] }
+  end
+
   context 'when file contains irrelevant hard coded string' do
     let(:file) { <<~FILE }
       <span class="example">


### PR DESCRIPTION
This PR adds a list of blacklisted strings that shouldn't be extracted which is only `&nbsp;` for now.

Ex of why this is needed: https://policial.shopify.io/Shopify/shopify/builds/438899