### PR TITLE
Bump `better_html` and rescue syntax error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gem 'activesupport', '~> 5.1'
 gem 'rake'
+gem 'better_html', git: 'git@github.com:Shopify/better-html', branch: 'erb-escape-fix'
 
 group 'test' do
   gem 'fakefs'

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 
 gem 'activesupport', '~> 5.1'
 gem 'rake'
-gem 'better_html', git: 'git@github.com:Shopify/better-html', branch: 'erb-escape-fix'
 
 group 'test' do
   gem 'fakefs'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,17 @@
+GIT
+  remote: git@github.com:Shopify/better-html
+  revision: aa670a13c4bb7fa6383b7c8b9264fe23eb2cf3fb
+  branch: erb-escape-fix
+  specs:
+    better_html (1.0.6)
+      actionview (>= 4.0)
+      activesupport (>= 4.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      html_tokenizer (~> 0.0.6)
+      parser (>= 2.4)
+      smart_properties
+
 PATH
   remote: .
   specs:
@@ -12,37 +26,29 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    actionview (5.1.4)
-      activesupport (= 5.1.4)
+    actionview (5.1.6)
+      activesupport (= 5.1.6)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    activesupport (5.1.4)
+    activesupport (5.1.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     ast (2.4.0)
-    better_html (1.0.6)
-      actionview (>= 4.0)
-      activesupport (>= 4.0)
-      ast (~> 2.0)
-      erubi (~> 1.4)
-      html_tokenizer (~> 0.0.6)
-      parser (>= 2.4)
-      smart_properties
     builder (3.2.3)
     colorize (0.8.1)
     concurrent-ruby (1.0.5)
     crass (1.0.3)
     diff-lcs (1.3)
-    erubi (1.7.0)
+    erubi (1.7.1)
     fakefs (0.11.3)
     html_tokenizer (0.0.6)
-    i18n (0.9.3)
+    i18n (1.0.0)
       concurrent-ruby (~> 1.0)
-    loofah (2.1.1)
+    loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mini_portile2 (2.3.0)
@@ -56,8 +62,8 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.0.3)
-      loofah (~> 2.0)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     rainbow (3.0.0)
     rake (12.3.0)
     rspec (3.7.0)
@@ -92,6 +98,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 5.1)
+  better_html!
   erb_lint!
   fakefs
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,3 @@
-GIT
-  remote: git@github.com:Shopify/better-html
-  revision: aa670a13c4bb7fa6383b7c8b9264fe23eb2cf3fb
-  branch: erb-escape-fix
-  specs:
-    better_html (1.0.6)
-      actionview (>= 4.0)
-      activesupport (>= 4.0)
-      ast (~> 2.0)
-      erubi (~> 1.4)
-      html_tokenizer (~> 0.0.6)
-      parser (>= 2.4)
-      smart_properties
-
 PATH
   remote: .
   specs:
@@ -38,6 +24,14 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     ast (2.4.0)
+    better_html (1.0.7)
+      actionview (>= 4.0)
+      activesupport (>= 4.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      html_tokenizer (~> 0.0.6)
+      parser (>= 2.4)
+      smart_properties
     builder (3.2.3)
     colorize (0.8.1)
     concurrent-ruby (1.0.5)
@@ -98,7 +92,6 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 5.1)
-  better_html!
   erb_lint!
   fakefs
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     erb_lint (0.0.22)
       activesupport
-      better_html (~> 1.0.6)
+      better_html (~> 1.0.7)
       colorize
       html_tokenizer
       rubocop (~> 0.51)

--- a/erb_lint.gemspec
+++ b/erb_lint.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.bindir = 'exe'
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
-  s.add_dependency 'better_html', '~> 1.0.6'
+  s.add_dependency 'better_html', '~> 1.0.7'
   s.add_dependency 'html_tokenizer'
   s.add_dependency 'rubocop', '~> 0.51'
   s.add_dependency 'activesupport'

--- a/lib/erb_lint/linters/no_javascript_tag_helper.rb
+++ b/lib/erb_lint/linters/no_javascript_tag_helper.rb
@@ -23,7 +23,12 @@ module ERBLint
           next if indicator == '#'
           source = code_node.loc.source
 
-          next unless (ruby_node = BetterHtml::TestHelper::RubyNode.parse(source))
+          ruby_node = begin
+            BetterHtml::TestHelper::RubyNode.parse(source)
+          rescue ::Parser::SyntaxError
+            nil
+          end
+          next unless ruby_node
           send_node = ruby_node.descendants(:send).first
           next unless send_node&.method_name?(:javascript_tag)
 

--- a/spec/erb_lint/linters/no_javascript_tag_helper_spec.rb
+++ b/spec/erb_lint/linters/no_javascript_tag_helper_spec.rb
@@ -27,10 +27,10 @@ describe ERBLint::Linters::NoJavascriptTagHelper do
 
     context 'regression with <%%= syntax does not raise an exception' do
       let(:file) { <<~FILE }
-<%%= ma_tile do |tile| %>
-  <%%= tile.image 'styleguide/toronto-stunning-sunset' %>
-<%% end %>
-<% end %>
+        <%%= ma_tile do |tile| %>
+          <%%= tile.image 'styleguide/toronto-stunning-sunset' %>
+        <%% end %>
+        <% end %>
       FILE
 
       it { expect(subject).to eq [] }

--- a/spec/erb_lint/linters/no_javascript_tag_helper_spec.rb
+++ b/spec/erb_lint/linters/no_javascript_tag_helper_spec.rb
@@ -25,6 +25,17 @@ describe ERBLint::Linters::NoJavascriptTagHelper do
       it { expect(subject).to eq [build_offense(7..30)] }
     end
 
+    context 'regression with <%%= syntax does not raise an exception' do
+      let(:file) { <<~FILE }
+<%%= ma_tile do |tile| %>
+  <%%= tile.image 'styleguide/toronto-stunning-sunset' %>
+<%% end %>
+<% end %>
+      FILE
+
+      it { expect(subject).to eq [] }
+    end
+
     context 'no method calls in erb tag' do
       let(:file) { <<~FILE }
         <%= true %>

--- a/spec/erb_lint/linters/parser_error_spec.rb
+++ b/spec/erb_lint/linters/parser_error_spec.rb
@@ -29,6 +29,16 @@ describe ERBLint::Linters::ParserErrors do
         ]
       end
     end
+
+    context 'malformed html' do
+      let(:file) { "<%%= erb %>" }
+      it do
+        expect(subject).to eq [
+          build_offense(9...10, "expected '/', '>', \", ' or '=' after attribute name (at %)"),
+          build_offense(9...10, "expected whitespace, '>', attribute name or value (at %)")
+        ]
+      end
+    end
   end
 
   private

--- a/spec/erb_lint/linters/parser_error_spec.rb
+++ b/spec/erb_lint/linters/parser_error_spec.rb
@@ -35,7 +35,7 @@ describe ERBLint::Linters::ParserErrors do
       it do
         expect(subject).to eq [
           build_offense(9...10, "expected '/', '>', \", ' or '=' after attribute name (at %)"),
-          build_offense(9...10, "expected whitespace, '>', attribute name or value (at %)")
+          build_offense(9...10, "expected whitespace, '>', attribute name or value (at %)"),
         ]
       end
     end


### PR DESCRIPTION
Rescue syntax errors from `BetterHtml::TestHelper::RubyNode` and ignore them in `no_javascript_tag_helper.rb`. The `<%%=` syntax was causing the syntax error exception to be raised for an unrelated reason so this fixes both issues.