### PR TITLE
Allow symbols in YAML files

### DIFF
--- a/lib/erb_lint/file_loader.rb
+++ b/lib/erb_lint/file_loader.rb
@@ -10,7 +10,7 @@ module ERBLint
     end
 
     def yaml(filename)
-      YAML.safe_load(read_content(filename), [Regexp], [], false, filename) || {}
+      YAML.safe_load(read_content(filename), [Regexp, Symbol], [], false, filename) || {}
     rescue Psych::SyntaxError
       {}
     end

--- a/spec/file_loader_spec.rb
+++ b/spec/file_loader_spec.rb
@@ -27,6 +27,14 @@ describe ERBLint::FileLoader do
       it { expect(subject).to eq('some_config' => [/\Afoo/i]) }
     end
 
+    context "it allows symbol to be loaded" do
+      let(:yaml_content) { <<~YAML }
+        ---
+        :some_config: :symbol
+      YAML
+      it { expect(subject).to eq(some_config: :symbol) }
+    end
+
     context "it does not allow other objects to be loaded" do
       let(:yaml_content) { <<~YAML }
         ---


### PR DESCRIPTION
Some of RuboCop's config requires the use of symbols in the yaml files.

For example, the `Style/InverseMethods` cop has an `InverseMethods` config option which is a hash which requires both the keys and values be symbols. From RuboCop's `default.yml`:

```yaml
Style/InverseMethods:
  # `InverseMethods` are methods that can be inverted by a not (`not` or `!`)
  # The relationship of inverse methods only needs to be defined in one direction.
  # Keys and values both need to be defined as symbols.
  InverseMethods:
    :any?: :none?
    :even?: :odd?
    :==: :!=
    :=~: :!~
    :<: :>=
    :>: :<=
```