### PR TITLE
Only enforce spaces around code and statement tags

### DIFF
--- a/lib/erb_lint/linters/space_around_erb_tag.rb
+++ b/lib/erb_lint/linters/space_around_erb_tag.rb
@@ -13,14 +13,16 @@ module ERBLint
 
       def run(processed_source)
         processed_source.ast.descendants(:erb).each do |erb_node|
-          indicator, ltrim, code_node, rtrim = *erb_node
+          indicator_node, ltrim, code_node, rtrim = *erb_node
+          indicator = indicator_node&.loc&.source
+          next if indicator == '#' || indicator == '%'
           code = code_node.children.first
 
           start_spaces = code.match(START_SPACES)&.captures&.first || ""
           if start_spaces.size != 1 && !start_spaces.include?("\n")
             add_offense(
               code_node.loc.resize(start_spaces.size),
-              "Use 1 space after `<%#{indicator&.loc&.source}#{ltrim&.loc&.source}` "\
+              "Use 1 space after `<%#{indicator}#{ltrim&.loc&.source}` "\
               "instead of #{start_spaces.size} space#{'s' if start_spaces.size > 1}.",
               ' '
             )

--- a/spec/erb_lint/linters/space_around_erb_tag_spec.rb
+++ b/spec/erb_lint/linters/space_around_erb_tag_spec.rb
@@ -21,6 +21,16 @@ describe ERBLint::Linters::SpaceAroundErbTag do
       it { expect(subject).to eq [] }
     end
 
+    context 'for escaped erb tag' do
+      let(:file) { "this is text <%%=text %> not erb\n" }
+      it { expect(subject).to eq [] }
+    end
+
+    context 'for erb comment' do
+      let(:file) { "this is text <%#comment %> not erb\n" }
+      it { expect(subject).to eq [] }
+    end
+
     context 'when tag starts with a newline' do
       let(:file) { <<~ERB }
         <%


### PR DESCRIPTION
Ignore spaces around comment and escaped erb tags.