### PR TITLE
WIP: Add --output-format oneline options for easier editor integration

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -137,7 +137,7 @@ module ERBLint
         runner.offenses.each do |offense|
           puts "#{relative_filename(filename)}:" \
             "#{offense.line_range.begin}:" \
-            "#{offense.source_range.column_range.begin}:" \
+            "#{offense.source_range.column}:" \
             "#{offense.message}"
         end
       end

--- a/spec/erb_lint/cli_spec.rb
+++ b/spec/erb_lint/cli_spec.rb
@@ -138,6 +138,27 @@ describe ERBLint::CLI do
           end
         end
 
+        context 'with --outpuf-format oneline' do
+          let(:args) do
+            [
+              '--enable-linter', 'linter_with_errors,final_newline',
+              '--output-format', 'oneline',
+              linted_file
+            ]
+          end
+
+          it 'shows all error messages and line numbers' do
+            expect { subject }.to output(Regexp.new(Regexp.escape(<<~EOF))).to_stdout
+              /app/views/template.html.erb:1:1:fake message from a fake linter
+              /app/views/template.html.erb:1:19:Missing a trailing newline at the end of the file.
+            EOF
+          end
+
+          it 'is not successful' do
+            expect(subject).to be(false)
+          end
+        end
+
         context 'when no errors are found' do
           let(:args) { ['--enable-linter', 'linter_without_errors', linted_file] }
 


### PR DESCRIPTION
Editor integration for linters tend to work better with one line per
offense, unlike the more human-oriented default of two line + newline
per offense. In particular I'm thinking of the regexes used bye ALE for vim.

This adds an `--output-format oneline` command-line option for a more
compact and machine-parsable output format. Omitting the option ore using `--output-format multipline` uses the current "two lines + newline" output. The oneline output takes the form
of:

```
<filename>:<start-line>:<start-col>:<offense-message>
```

I'm marking this as a WIP because I'd like feedback as to my approach, and whether this is a feature the maintainers would be interested in. I'm also investigating a JSON output option, which should be a relatively straightforward extension of this approach once a schema is decided on. The schema used by Rubocop's JSON formatter might be a good starting point.