### PR TITLE
Do not fall back when config has parsing error.

### DIFF
--- a/lib/erb_lint/file_loader.rb
+++ b/lib/erb_lint/file_loader.rb
@@ -11,8 +11,6 @@ module ERBLint
 
     def yaml(filename)
       YAML.safe_load(read_content(filename), [Regexp], [], false, filename) || {}
-    rescue Psych::SyntaxError
-      {}
     end
 
     private

--- a/spec/erb_lint/linter_spec.rb
+++ b/spec/erb_lint/linter_spec.rb
@@ -26,7 +26,7 @@ describe ERBLint::Linter do
 
     describe '.clear_offenses' do
       it 'clears all offenses from the offenses ivar' do
-        linter.offenses = ["someoffense"]
+        linter.offenses = %w(someoffense)
         linter.clear_offenses
         expect(linter.offenses).to eq []
       end

--- a/spec/erb_lint/linters/erb_safety_spec.rb
+++ b/spec/erb_lint/linters/erb_safety_spec.rb
@@ -7,7 +7,7 @@ describe ERBLint::Linters::ErbSafety do
   let(:linter_config) { described_class.config_schema.new }
   let(:better_html_config) do
     {
-      javascript_safe_methods: ['to_json'],
+      javascript_safe_methods: %w(to_json),
     }
   end
   let(:file_loader) { MockFileLoader.new(better_html_config) }
@@ -146,12 +146,12 @@ describe ERBLint::Linters::ErbSafety do
     end
 
     context 'with non-default config' do
-      let(:better_html_config) { { javascript_safe_methods: ['foobar'] } }
+      let(:better_html_config) { { javascript_safe_methods: %w(foobar) } }
       it { expect(subject).to eq [] }
     end
 
     context 'with string keys in config' do
-      let(:better_html_config) { { 'javascript_safe_methods' => ['foobar'] } }
+      let(:better_html_config) { { 'javascript_safe_methods' => %w(foobar) } }
       it { expect(subject).to eq [] }
     end
   end

--- a/spec/erb_lint/linters/rubocop_spec.rb
+++ b/spec/erb_lint/linters/rubocop_spec.rb
@@ -31,7 +31,7 @@ describe ERBLint::Linters::Rubocop do
 
   context 'config is valid when rubocop_config is not explicitly provided' do
     let(:linter_config) do
-      described_class.config_schema.new(only: ['NotALinter'])
+      described_class.config_schema.new(only: %w(NotALinter))
     end
     let(:file) { <<~FILE }
       <% not_banned_method %>

--- a/spec/file_loader_spec.rb
+++ b/spec/file_loader_spec.rb
@@ -36,10 +36,5 @@ describe ERBLint::FileLoader do
       YAML
       it { expect { subject }.to raise_exception(Psych::DisallowedClass) }
     end
-
-    context "gracefully falls back when syntax is wrong" do
-      let(:yaml_content) { "---\n- foo\nbar:" }
-      it { expect(subject).to eq({}) }
-    end
   end
 end


### PR DESCRIPTION
# Expected:
- YAML is invalid it raises regular YAML parsing errors

# Actual:
- YAML is invalid, it disregards your configuration and uses the default

Took me a while to figure out that my YAML was invalid because the error is swallowed but linting continued, it just didn't have the settings from my config anymore.