### PR TITLE
Relax lint_all glob

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -11,7 +11,7 @@ require 'colorize'
 module ERBLint
   class CLI
     DEFAULT_CONFIG_FILENAME = '.erb-lint.yml'
-    DEFAULT_LINT_ALL_GLOB = "**/*.html{+*,}.erb"
+    DEFAULT_LINT_ALL_GLOB = "**/*.erb"
 
     class ExitWithFailure < RuntimeError; end
     class ExitWithSuccess < RuntimeError; end


### PR DESCRIPTION
A priori, I think we want _any_ *.erb file linted, not only html.erb
files. For example, https://github.com/trailblazer/cells uses *.erb
files that does not have the .html part.