### PR TITLE
Support passing dirs as arguments

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -37,7 +37,9 @@ module ERBLint
 
       load_config
 
-      if lint_files.empty?
+      if !@files.empty? && lint_files.empty?
+        success!("no files found...\n")
+      elsif lint_files.empty?
         success!("no files given...\n#{option_parser}")
       end
 
@@ -166,6 +168,7 @@ module ERBLint
         Dir[pattern].select { |filename| !excluded?(filename) }
       else
         @files
+          .map { |f| Dir.exist?(f) ? Dir[File.join(f, DEFAULT_LINT_ALL_GLOB)] : f }
           .map { |f| f.include?('*') ? Dir[f] : f }
           .flatten
           .map { |f| File.expand_path(f, Dir.pwd) }

--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -147,7 +147,7 @@ module ERBLint
       def base_configs(inherit_from)
         regex = URI::DEFAULT_PARSER.make_regexp(%w(http https))
         configs = Array(inherit_from).compact.map do |base_name|
-          if base_name =~ /\A#{regex}\z/
+          if base_name.match?(/\A#{regex}\z/)
             RuboCop::ConfigLoader.load_file(RuboCop::RemoteConfig.new(base_name, Dir.pwd))
           else
             config_from_hash(@file_loader.yaml(base_name))


### PR DESCRIPTION
Dirs are joined with the `DEFAULT_LINT_ALL_GLOB`. Displays the
error _"no files found"_ if only a single dir is provided and it
contains no files that match the lint glob.

Fixes #99 