### PR TITLE
[#104] Update README to document installing better_html for linting only

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ gem install erb_lint
 gem 'erb_lint'
 ```
 
+_Note:_ if you only want to use `better_html` for linting, and not as a replacecment for Erb as your template parser, also add the following to your `Gemfile`:
+
+```ruby
+gem 'better_html', require: false
+```
+
 ## Configuration
 
 Create a `.erb-lint.yml` file in your project, with the following structure:


### PR DESCRIPTION
_Note:_ I verified that this configuration (not requiring BetterHTML by default) works, but I was not able to reproduce @dvandersluis's original problem, so I'm relying on his follow-up assertion that it is an adequate workaround for that scenario.