### PR TITLE
Upgrade to version 0.0.28

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    erb_lint (0.0.27)
+    erb_lint (0.0.28)
       activesupport
       better_html (~> 1.0.7)
       html_tokenizer

--- a/lib/erb_lint/version.rb
+++ b/lib/erb_lint/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ERBLint
-  VERSION = '0.0.27'
+  VERSION = '0.0.28'
 end


### PR DESCRIPTION
Increment the gem version.

The changes that are in queue for this deploy:
Add require: false by default in Gemspec for erb_lint https://github.com/shopify/erb-lint/commit/77dbf734bb17bf88f2c4406253f13a0e0edddaae
Update gemspec's homepage URL https://github.com/Shopify/erb-lint/pull/109
Fix integration bug with shopify cop https://github.com/Shopify/erb-lint/pull/111