### PR TITLE
WIP: Introduce formatter objects and add a JSON format.

### DIFF
--- a/lib/erb_lint.rb
+++ b/lib/erb_lint.rb
@@ -3,6 +3,7 @@
 require 'erb_lint/corrector'
 require 'erb_lint/file_loader'
 require 'erb_lint/formatters/default_formatter'
+require 'erb_lint/formatters/json_formatter'
 require 'erb_lint/linter_config'
 require 'erb_lint/linter_registry'
 require 'erb_lint/linter'

--- a/lib/erb_lint.rb
+++ b/lib/erb_lint.rb
@@ -2,6 +2,7 @@
 
 require 'erb_lint/corrector'
 require 'erb_lint/file_loader'
+require 'erb_lint/formatters/default_formatter'
 require 'erb_lint/linter_config'
 require 'erb_lint/linter_registry'
 require 'erb_lint/linter'

--- a/lib/erb_lint/formatters/default_formatter.rb
+++ b/lib/erb_lint/formatters/default_formatter.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'erb_lint'
+require 'rainbow'
+
+module ERBLint
+  module Formatters
+    class DefaultFormatter
+      def initialize
+        @results = {}
+      end
+
+      def file_completed(filename, runner)
+        @results[filename] = runner
+      end
+
+      def report(stats, options, io = STDOUT)
+        @results.each do |filename, runner|
+          runner.offenses.each do |offense|
+            io.puts <<~EOF
+              #{offense.message}#{Rainbow(' (not autocorrected)').red if options[:autocorrect]}
+              In file: #{relative_filename(filename)}:#{offense.line_range.begin}
+
+            EOF
+          end
+        end
+
+        if stats.corrected > 0
+          corrected_found_diff = stats.found - stats.corrected
+          if corrected_found_diff > 0
+            warn Rainbow(
+              "#{stats.corrected} error(s) corrected and #{corrected_found_diff} error(s) remaining in ERB files"
+            ).red
+          else
+            io.puts Rainbow("#{stats.corrected} error(s) corrected in ERB files").green
+          end
+        elsif stats.found > 0
+          warn Rainbow("#{stats.found} error(s) were found in ERB files").red
+        else
+          io.puts Rainbow("No errors were found in ERB files").green
+        end
+      end
+
+      private
+
+      def relative_filename(filename)
+        filename.sub("#{File.expand_path('.', Dir.pwd)}/", '')
+      end
+    end
+  end
+end

--- a/lib/erb_lint/formatters/default_formatter.rb
+++ b/lib/erb_lint/formatters/default_formatter.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'erb_lint'
-require 'rainbow'
-
 module ERBLint
   module Formatters
     class DefaultFormatter
@@ -10,16 +7,16 @@ module ERBLint
         @results = {}
       end
 
-      def file_completed(filename, runner)
-        @results[filename] = runner
+      def file_completed(relative_filename, runner)
+        @results[relative_filename] = runner
       end
 
-      def report(stats, options, io = STDOUT)
-        @results.each do |filename, runner|
+      def report(stats, options, io)
+        @results.each do |relative_filename, runner|
           runner.offenses.each do |offense|
             io.puts <<~EOF
               #{offense.message}#{Rainbow(' (not autocorrected)').red if options[:autocorrect]}
-              In file: #{relative_filename(filename)}:#{offense.line_range.begin}
+              In file: #{relative_filename}:#{offense.line_range.begin}
 
             EOF
           end
@@ -28,23 +25,17 @@ module ERBLint
         if stats.corrected > 0
           corrected_found_diff = stats.found - stats.corrected
           if corrected_found_diff > 0
-            warn Rainbow(
+            io.puts Rainbow(
               "#{stats.corrected} error(s) corrected and #{corrected_found_diff} error(s) remaining in ERB files"
             ).red
           else
             io.puts Rainbow("#{stats.corrected} error(s) corrected in ERB files").green
           end
         elsif stats.found > 0
-          warn Rainbow("#{stats.found} error(s) were found in ERB files").red
+          io.puts Rainbow("#{stats.found} error(s) were found in ERB files").red
         else
           io.puts Rainbow("No errors were found in ERB files").green
         end
-      end
-
-      private
-
-      def relative_filename(filename)
-        filename.sub("#{File.expand_path('.', Dir.pwd)}/", '')
       end
     end
   end

--- a/lib/erb_lint/formatters/json_formatter.rb
+++ b/lib/erb_lint/formatters/json_formatter.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module ERBLint
+  module Formatters
+    class JSONFormatter
+      RUBOCOP_MESSAGE_PATTERN = /\A(?<linter>\S+): (?<message>.+)\z/.freeze
+
+      def initialize
+        @result = {
+          metadata: metadata_hash,
+          files: [],
+          summary: {offense_count: 0, inspected_file_count: 0}
+        }
+      end
+
+      def file_completed(relative_filename, runner)
+        @result[:summary][:offense_count] += runner.offenses.count
+        @result[:summary][:inspected_file_count] += 1
+        @result[:files] = hash_for_file(relative_filename, runner)
+      end
+
+      def report(stats, options, io)
+        io.puts JSON.pretty_generate(@result)
+      end
+
+      private
+
+      def metadata_hash
+        {
+          erb_lint_version: ERBLint::VERSION,
+          ruby_engine: RUBY_ENGINE,
+          ruby_version: RUBY_VERSION,
+          ruby_patchlevel: RUBY_PATCHLEVEL.to_s,
+          ruby_platform: RUBY_PLATFORM
+        }
+      end
+
+      def hash_for_file(relative_filename, runner)
+        {
+          path: relative_filename,
+          offenses: runner.offenses.map { |o| hash_for_offense(o) }
+        }
+      end
+
+      def hash_for_offense(offense)
+        linter, message = linter_and_message(offense)
+        {
+          message: message,
+          linter: linter,
+          corrected: offense_corrected?(offense),
+          location: hash_for_location(offense)
+        }
+      end
+
+      def linter_and_message(offense)
+        if offense.linter.is_a?(ERBLint::Linters::Rubocop)
+          rubocop_linter_and_message offense.message
+        else
+          [offense.linter.class.simple_name, offense.message]
+        end
+      end
+
+      def offense_corrected?(offense)
+        offense.context.is_a?(Hash) && offense.context.key?(:rubocop_correction)
+      end
+
+      def rubocop_linter_and_message(message)
+        match = message.match(RUBOCOP_MESSAGE_PATTERN)
+        [match[:linter], match[:message]]
+      end
+
+      def hash_for_location(offense)
+        {
+          start_line: offense.source_range.start_line,
+          start_column: offense.source_range.start_column,
+          last_line: offense.source_range.last_line,
+          length: offense.source_range.length
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
I took a shot at introducing formatters as suggested in #84 because I'd like this cool gem to become available in [syntastic](https://github.com/vim-syntastic/syntastic/issues/2226). The one-line-format for #84 could easily be added as another formatter.

Before I go on and add tests I would like to know what you think of this and whether there are suggestions to add/change things.

The JSON format is gratefully adopted from [rubocop](https://docs.rubocop.org/en/latest/formatters/#json-formatter) (without the `:severity` key and `:linter` instead of `:cop_name` in the offense hashes).