### PR TITLE
Enhance SelfCloseTag rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,43 @@ Linter-Specific Option | Description
 -----------------------|---------------------------------------------------------
 `correction_style`     | When configured with `cdata`, adds CDATA markers. When configured with `plain`, don't add makers. Defaults to `cdata`.
 
+### SelfClosingTag
+
+This linter enforces self closing tag styles for void elements.
+
+The void elements are `area`, `base`, `br`, `col`, `embed`, `hr`, `img`, `input`, `keygen`, `link`, `menuitem`, `meta`, `param`, `source`, `track`, and `wbr`.
+
+If `enforced_style` is set to `always` (XHTML style):
+
+```erb
+Bad ❌
+<link rel="stylesheet" type="text/css" href="styles.css">
+Good ✅
+<img src="someimage.png" alt="Some Image" />
+```
+
+If `enforced_style` is set to `never` (HTML5 style):
+```erb
+Bad ❌
+<hr />
+Good ✅
+<meta charset="UTF-8">
+```
+
+Example configuration:
+
+```yaml
+---
+linters:
+  SelfClosingTag:
+    enabled: true
+    enforced_style: 'always'
+```
+
+Linter-Specific Option | Description
+-----------------------|---------------------------------------------------------
+`enforced_style`       |  If we should `always` or `never` expect self closing tags for void elements. Defaults to `never`.
+
 ### AllowedScriptType
 
 This linter prevent the addition of `<script>` tags that have `type` attributes that are not in a white-list of allowed values.
@@ -382,7 +419,7 @@ linters:
   CustomLinter:
     enabled: true
     custom_message: We suggest you change this file.
-```
+**```**
 
 Test your linter by running `erblint`'s command-line interface:
 

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ linters:
   CustomLinter:
     enabled: true
     custom_message: We suggest you change this file.
-**```**
+```
 
 Test your linter by running `erblint`'s command-line interface:
 

--- a/spec/erb_lint/linters/self_closing_tag_spec.rb
+++ b/spec/erb_lint/linters/self_closing_tag_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe ERBLint::Linters::SelfClosingTag do
-  let(:linter_config) { described_class.config_schema.new }
+  let(:linter_config) { described_class.config_schema.new(enforced_style: enforced_style) }
 
   let(:file_loader) { ERBLint::FileLoader.new('.') }
   let(:linter) { described_class.new(file_loader, linter_config) }
@@ -16,41 +16,87 @@ describe ERBLint::Linters::SelfClosingTag do
   describe 'offenses' do
     subject { offenses }
 
-    context 'when an element is not self-closing' do
-      let(:file) { "<a></a/>" }
-      it { expect(subject).to eq [] }
-    end
+    context 'when enforced_style is always' do
+      let(:enforced_style) { 'always' }
 
-    context 'when an element is self-closed correctly' do
-      let(:file) { "<br/>" }
-      it { expect(subject).to eq [] }
-    end
+      context 'when an element is not a void element' do
+        let(:file) { "<a></a/>" }
+        it { expect(subject).to eq [] }
+      end
 
-    context 'when an element is not #self_closing?' do
-      let(:file) { "<br>" }
-      it do
-        expect(subject).to eq [
-          build_offense(3..2, "Tag `br` is self-closing, it must end with `/>`."),
-        ]
+      context 'when a void element is #self-closed' do
+        let(:file) { "<br/>" }
+        it { expect(subject).to eq [] }
+      end
+
+      context 'when a void element is not #self_closing?' do
+        let(:file) { "<br>" }
+        it do
+          expect(subject).to eq [
+            build_offense(3..2, "Tag `br` is self-closing, it must end with `/>`."),
+          ]
+        end
+      end
+
+      context 'when a void element is #closing? and #self_closing?' do
+        let(:file) { "</br/>" }
+        it do
+          expect(subject).to eq [
+            build_offense(1..1, "Tag `br` is a void element, it must not start with `</`."),
+          ]
+        end
+      end
+
+      context 'when an element is #closing?' do
+        let(:file) { "</br>" }
+        it do
+          expect(subject).to eq [
+            build_offense(1..1, "Tag `br` is a void element, it must not start with `</`."),
+            build_offense(4..3, "Tag `br` is self-closing, it must end with `/>`."),
+          ]
+        end
       end
     end
 
-    context 'when an element is #closing? and #self_closing?' do
-      let(:file) { "</br/>" }
-      it do
-        expect(subject).to eq [
-          build_offense(1..1, "Tag `br` is self-closing, it must not start with `</`."),
-        ]
-      end
-    end
+    context 'when enforced_style is never' do
+      let(:enforced_style) { 'never' }
 
-    context 'when an element is #closing?' do
-      let(:file) { "</br>" }
-      it do
-        expect(subject).to eq [
-          build_offense(1..1, "Tag `br` is self-closing, it must not start with `</`."),
-          build_offense(4..3, "Tag `br` is self-closing, it must end with `/>`."),
-        ]
+      context 'when an element is not a void element' do
+        let(:file) { "<a></a/>" }
+        it { expect(subject).to eq [] }
+      end
+
+      context 'when a void element is #self-closed' do
+        let(:file) { "<br/>" }
+        it do
+          expect(subject).to eq [
+            build_offense(3..3, "Tag `br` is a void element, it must end with `>` and not `/>`."),
+          ]
+        end
+      end
+
+      context 'when a void element is not #self_closing?' do
+        let(:file) { "<br>" }
+        it { expect(subject).to eq [] }
+      end
+
+      context 'when a void element is #closing? and #self_closing?' do
+        let(:file) { "</br/>" }
+        it do
+          expect(subject).to eq [
+            build_offense(1..1, "Tag `br` is a void element, it must not start with `</`."),
+            build_offense(4..4, "Tag `br` is a void element, it must end with `>` and not `/>`."),
+          ]
+        end
+      end
+
+      context 'when an element is #closing?' do
+        let(:file) { "</br>" }
+        it do
+          expect(subject).to eq [
+            build_offense(1..1, "Tag `br` is a void element, it must not start with `</`."),
+          ]
+        end
       end
     end
   end
@@ -58,29 +104,62 @@ describe ERBLint::Linters::SelfClosingTag do
   describe 'autocorrect' do
     subject { corrected_content }
 
-    context 'when an element is not self-closing' do
-      let(:file) { "<a></a/>" }
-      it { expect(subject).to eq file }
+    context 'when enforced_style is always' do
+      let(:enforced_style) { 'always' }
+
+      context 'when an element is not self-closing' do
+        let(:file) { "<a></a/>" }
+        it { expect(subject).to eq file }
+      end
+
+      context 'when an element is self-closed' do
+        let(:file) { "<br/>" }
+        it { expect(subject).to eq file }
+      end
+
+      context 'when an element is not #self_closing?' do
+        let(:file) { "<br>" }
+        it { expect(subject).to eq "<br/>" }
+      end
+
+      context 'when an element is #closing? and #self_closing?' do
+        let(:file) { "</br/>" }
+        it { expect(subject).to eq "<br/>" }
+      end
+
+      context 'when an element is #closing?' do
+        let(:file) { "</br>" }
+        it { expect(subject).to eq "<br/>" }
+      end
     end
 
-    context 'when an element is self-closed correctly' do
-      let(:file) { "<br/>" }
-      it { expect(subject).to eq file }
-    end
+    context 'when enforced_style is never' do
+      let(:enforced_style) { 'never' }
 
-    context 'when an element is not #self_closing?' do
-      let(:file) { "<br>" }
-      it { expect(subject).to eq "<br/>" }
-    end
+      context 'when an element is not self-closing' do
+        let(:file) { "<a></a/>" }
+        it { expect(subject).to eq file }
+      end
 
-    context 'when an element is #closing? and #self_closing?' do
-      let(:file) { "</br/>" }
-      it { expect(subject).to eq "<br/>" }
-    end
+      context 'when an element is self-closed' do
+        let(:file) { "<br/>" }
+        it { expect(subject).to eq "<br>" }
+      end
 
-    context 'when an element is #closing?' do
-      let(:file) { "</br>" }
-      it { expect(subject).to eq "<br/>" }
+      context 'when an element is not #self_closing?' do
+        let(:file) { "<br>" }
+        it { expect(subject).to eq file }
+      end
+
+      context 'when an element is #closing? and #self_closing?' do
+        let(:file) { "</br/>" }
+        it { expect(subject).to eq "<br>" }
+      end
+
+      context 'when an element is #closing?' do
+        let(:file) { "</br>" }
+        it { expect(subject).to eq "<br>" }
+      end
     end
   end
 


### PR DESCRIPTION
Based on suggestions in #89.

Added a `always` and `never` config option to allow us to support HTML5 or XHTML environments.