### PR TITLE
Fixed #119

### DIFF
--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -147,7 +147,7 @@ module ERBLint
       def base_configs(inherit_from)
         regex = URI::DEFAULT_PARSER.make_regexp(%w(http https))
         configs = Array(inherit_from).compact.map do |base_name|
-          if base_name.match?(/\A#{regex}\z/)
+          if base_name =~ /\A#{regex}\z/
             RuboCop::ConfigLoader.load_file(RuboCop::RemoteConfig.new(base_name, Dir.pwd))
           else
             config_from_hash(@file_loader.yaml(base_name))


### PR DESCRIPTION
String#match? and Regexp#match? are available from Ruby 2.4 and later only, the min required Ruby version to run the gem is 2.3.0+. We use (string =~ regexp) for compatibility with older Rubies considering a little performance impact, https://github.com/JuanitoFatas/fast-ruby#regexp-vs-stringmatch-vs-string-vs-stringmatch-code-