### PR TITLE
Allow setting custom linters directory in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Create a `.erb-lint.yml` file in your project, with the following structure:
 
 ```yaml
 ---
+custom_linters_directory: '.custom-erb-linters'
 linters:
   ErbSafety:
     enabled: true

--- a/lib/erb_lint/linter_registry.rb
+++ b/lib/erb_lint/linter_registry.rb
@@ -17,7 +17,8 @@ module ERBLint
         linters.detect { |linter| linter.simple_name == name }
       end
 
-      def load_custom_linters(directory = CUSTOM_LINTERS_DIR)
+      def load_custom_linters(directory)
+        directory ||= CUSTOM_LINTERS_DIR
         ruby_files = Dir.glob(File.expand_path(File.join(directory, '**', '*.rb')))
         ruby_files.each { |file| require file }
       end

--- a/lib/erb_lint/runner.rb
+++ b/lib/erb_lint/runner.rb
@@ -9,8 +9,7 @@ module ERBLint
       @file_loader = file_loader
       @config = config || RunnerConfig.default
       raise ArgumentError, 'expect `config` to be a RunnerConfig instance' unless @config.is_a?(RunnerConfig)
-
-      LinterRegistry.load_custom_linters
+      LinterRegistry.load_custom_linters(@config.to_hash['custom_linters_directory'])
       linter_classes = LinterRegistry.linters.select { |klass| @config.for_linter(klass).enabled? }
       @linters = linter_classes.map do |linter_class|
         linter_class.new(@file_loader, @config.for_linter(linter_class))

--- a/spec/erb_lint/runner_spec.rb
+++ b/spec/erb_lint/runner_spec.rb
@@ -24,6 +24,21 @@ describe ERBLint::Runner do
     end
   end
 
+  describe '#new' do
+    context 'with custom linters in custom directory' do
+      let(:custom_linters_directory) { File.expand_path('../fixtures/linters', __FILE__) }
+      let(:config) { ERBLint::RunnerConfig.new({
+        custom_linters_directory: custom_linters_directory
+      })}
+
+      it 'loads custom linters' do
+        expect(ERBLint::LinterRegistry).to receive(:require)
+          .with(File.join(custom_linters_directory, 'custom_linter.rb')).once
+        described_class.new(file_loader, config)
+      end
+    end
+  end
+
   describe '#run' do
     let(:file) { 'DummyFileContent' }
     let(:filename) { 'somefolder/otherfolder/dummyfile.html.erb' }


### PR DESCRIPTION
`#load_custom_linters` is already taking an argument for specs, this extends it so a directory can be read from the config. This allows users to organize their linters, instead of enforcing the linters to live in a top level directory.