### PR TITLE
Autocorrect offenses for rubocop 0.72

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gem 'activesupport', '~> 5.1'
 gem 'rake'
+gem 'smart_properties', '~> 1.13.1'
 
 group 'test' do
   gem 'fakefs'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
     html_tokenizer (0.0.6)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.3)
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -48,10 +49,9 @@ GEM
     minitest (5.11.3)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
-    parallel (1.12.1)
-    parser (2.5.1.0)
+    parallel (1.17.0)
+    parser (2.6.3.0)
       ast (~> 2.4.0)
-    powerpack (0.1.1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -72,19 +72,19 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
-    rubocop (0.54.0)
+    rubocop (0.72.0)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.5)
-      powerpack (~> 0.1)
+      parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.9.0)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    ruby-progressbar (1.10.1)
     smart_properties (1.13.1)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    unicode-display_width (1.3.0)
+    unicode-display_width (1.6.0)
 
 PLATFORMS
   ruby
@@ -98,4 +98,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ DEPENDENCIES
   rake
   rspec
   rubocop
+  smart_properties (~> 1.13.1)
 
 BUNDLED WITH
    1.17.3

--- a/Rakefile
+++ b/Rakefile
@@ -26,4 +26,4 @@ Rake::TestTask.new(:test) do |t|
   t.verbose = false
 end
 
-task default: :test
+task(default: :test)

--- a/erb_lint.gemspec
+++ b/erb_lint.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.push File.expand_path("../lib", __FILE__)
+$LOAD_PATH.push(File.expand_path("../lib", __FILE__))
 
 require 'erb_lint/version'
 
@@ -20,13 +20,13 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.3.0'
 
-  s.add_dependency 'better_html', '~> 1.0.7'
-  s.add_dependency 'html_tokenizer'
-  s.add_dependency 'rubocop', '~> 0.51'
-  s.add_dependency 'activesupport'
-  s.add_dependency 'smart_properties'
-  s.add_dependency 'rainbow'
+  s.add_dependency('better_html', '~> 1.0.7')
+  s.add_dependency('html_tokenizer')
+  s.add_dependency('rubocop', '~> 0.51')
+  s.add_dependency('activesupport')
+  s.add_dependency('smart_properties')
+  s.add_dependency('rainbow')
 
-  s.add_development_dependency 'rspec'
-  s.add_development_dependency 'rubocop'
+  s.add_development_dependency('rspec')
+  s.add_development_dependency('rubocop')
 end

--- a/exe/erblint
+++ b/exe/erblint
@@ -6,4 +6,4 @@ $LOAD_PATH.unshift("#{__dir__}/../lib")
 require 'erb_lint/cli'
 
 cli = ERBLint::CLI.new
-exit cli.run
+exit(cli.run)

--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -67,27 +67,27 @@ module ERBLint
       if @stats.corrected > 0
         corrected_found_diff = @stats.found - @stats.corrected
         if corrected_found_diff > 0
-          warn Rainbow(
+          warn(Rainbow(
             "#{@stats.corrected} error(s) corrected and #{corrected_found_diff} error(s) remaining in ERB files"
-          ).red
+          ).red)
         else
           puts Rainbow("#{@stats.corrected} error(s) corrected in ERB files").green
         end
       elsif @stats.found > 0
-        warn Rainbow("#{@stats.found} error(s) were found in ERB files").red
+        warn(Rainbow("#{@stats.found} error(s) were found in ERB files").red)
       else
         puts Rainbow("No errors were found in ERB files").green
       end
 
       @stats.found == 0
     rescue OptionParser::InvalidOption, OptionParser::InvalidArgument, ExitWithFailure => e
-      warn Rainbow(e.message).red
+      warn(Rainbow(e.message).red)
       false
     rescue ExitWithSuccess => e
       puts e.message
       true
     rescue => e
-      warn Rainbow("#{e.class}: #{e.message}\n#{e.backtrace.join("\n")}").red
+      warn(Rainbow("#{e.class}: #{e.message}\n#{e.backtrace.join("\n")}").red)
       false
     end
 
@@ -146,7 +146,7 @@ module ERBLint
         config = RunnerConfig.new(file_loader.yaml(config_filename), file_loader)
         @config = RunnerConfig.default.merge(config)
       else
-        warn Rainbow("#{config_filename} not found: using default config").yellow
+        warn(Rainbow("#{config_filename} not found: using default config").yellow)
         @config = RunnerConfig.default
       end
       @config.merge!(runner_config_override)

--- a/lib/erb_lint/linters/hard_coded_string.rb
+++ b/lib/erb_lint/linters/hard_coded_string.rb
@@ -61,7 +61,7 @@ module ERBLint
 
       def autocorrect(processed_source, offense)
         string = offense.source_range.source
-        return unless klass = load_corrector
+        return unless (klass = load_corrector)
         return unless string.strip.length > 1
         node = RuboCop::AST::StrNode.new(:str, [string])
         corrector = klass.new(node, processed_source.filename, corrector_i18n_load_path, offense.source_range)

--- a/lib/erb_lint/runner_config_resolver.rb
+++ b/lib/erb_lint/runner_config_resolver.rb
@@ -41,7 +41,7 @@ module ERBLint
         hash['inherit_from'] = Array(hash['inherit_from'])
         Array(config_path).reverse_each do |path|
           # Put gem configuration first so local configuration overrides it.
-          hash['inherit_from'].unshift gem_config_path(gem_name, path)
+          hash['inherit_from'].unshift(gem_config_path(gem_name, path))
         end
       end
     end

--- a/spec/erb_lint/block_map_spec.rb
+++ b/spec/erb_lint/block_map_spec.rb
@@ -18,9 +18,9 @@ describe ERBLint::Utils::BlockMap do
       ERB
 
       it do
-        expect(subject.size).to eq(1)
-        expect(subject[0].type).to eq(:block)
-        expect(subject[0].nodes.map(&:loc).map(&:source)).to eq(["<%= javascript_tag do %>", "<% end %>"])
+        expect(subject.size).to(eq(1))
+        expect(subject[0].type).to(eq(:block))
+        expect(subject[0].nodes.map(&:loc).map(&:source)).to(eq(["<%= javascript_tag do %>", "<% end %>"]))
       end
     end
 
@@ -30,9 +30,9 @@ describe ERBLint::Utils::BlockMap do
       ERB
 
       it do
-        expect(subject.size).to eq(1)
-        expect(subject[0].type).to eq(:block)
-        expect(subject[0].nodes.map(&:loc).map(&:source)).to eq(["<%= javascript_tag do foo; end %>"])
+        expect(subject.size).to(eq(1))
+        expect(subject[0].type).to(eq(:block))
+        expect(subject[0].nodes.map(&:loc).map(&:source)).to(eq(["<%= javascript_tag do foo; end %>"]))
       end
     end
 
@@ -44,9 +44,9 @@ describe ERBLint::Utils::BlockMap do
       ERB
 
       it do
-        expect(subject.size).to eq(1)
-        expect(subject[0].type).to eq(:if)
-        expect(subject[0].nodes.map(&:loc).map(&:source)).to eq(["<% if foo %>", "<% end %>"])
+        expect(subject.size).to(eq(1))
+        expect(subject[0].type).to(eq(:if))
+        expect(subject[0].nodes.map(&:loc).map(&:source)).to(eq(["<% if foo %>", "<% end %>"]))
       end
     end
 
@@ -60,9 +60,9 @@ describe ERBLint::Utils::BlockMap do
       ERB
 
       it do
-        expect(subject.size).to eq(1)
-        expect(subject[0].type).to eq(:if)
-        expect(subject[0].nodes.map(&:loc).map(&:source)).to eq(["<% if foo %>", "<% else %>", "<% end %>"])
+        expect(subject.size).to(eq(1))
+        expect(subject[0].type).to(eq(:if))
+        expect(subject[0].nodes.map(&:loc).map(&:source)).to(eq(["<% if foo %>", "<% else %>", "<% end %>"]))
       end
     end
 
@@ -80,15 +80,15 @@ describe ERBLint::Utils::BlockMap do
       ERB
 
       it do
-        expect(subject.size).to eq(1)
-        expect(subject[0].type).to eq(:if)
-        expect(subject[0].nodes.map(&:loc).map(&:source)).to eq([
+        expect(subject.size).to(eq(1))
+        expect(subject[0].type).to(eq(:if))
+        expect(subject[0].nodes.map(&:loc).map(&:source)).to(eq([
           "<% if foo %>",
           "<% elsif bar %>",
           "<% elsif baz %>",
           "<% elsif qux %>",
           "<% end %>",
-        ])
+        ]))
       end
     end
 
@@ -102,13 +102,13 @@ describe ERBLint::Utils::BlockMap do
       ERB
 
       it do
-        expect(subject.size).to eq(2)
-        expect(subject[0].type).to eq(:block)
-        expect(subject[0].nodes.map(&:loc).map(&:source)).to eq(["<% foo do %>", "<% end %>"])
-        expect(subject[0].nodes.map(&:loc).map(&:range)).to eq([0...12, 48...57])
-        expect(subject[1].type).to eq(:if)
-        expect(subject[1].nodes.map(&:loc).map(&:source)).to eq(["<% if bar %>", "<% end %>"])
-        expect(subject[1].nodes.map(&:loc).map(&:range)).to eq([15...27, 38...47])
+        expect(subject.size).to(eq(2))
+        expect(subject[0].type).to(eq(:block))
+        expect(subject[0].nodes.map(&:loc).map(&:source)).to(eq(["<% foo do %>", "<% end %>"]))
+        expect(subject[0].nodes.map(&:loc).map(&:range)).to(eq([0...12, 48...57]))
+        expect(subject[1].type).to(eq(:if))
+        expect(subject[1].nodes.map(&:loc).map(&:source)).to(eq(["<% if bar %>", "<% end %>"]))
+        expect(subject[1].nodes.map(&:loc).map(&:range)).to(eq([15...27, 38...47]))
       end
     end
 
@@ -122,10 +122,10 @@ describe ERBLint::Utils::BlockMap do
       ERB
 
       it do
-        expect(subject.size).to eq(1)
-        expect(subject[0].type).to eq(:block)
-        expect(subject[0].nodes.map(&:loc).map(&:source)).to eq(["<% foo do\n  if bar %>", "<% end %>", "<% end %>"])
-        expect(subject[0].nodes.map(&:loc).map(&:range)).to eq([0...21, 32...41, 42...51])
+        expect(subject.size).to(eq(1))
+        expect(subject[0].type).to(eq(:block))
+        expect(subject[0].nodes.map(&:loc).map(&:source)).to(eq(["<% foo do\n  if bar %>", "<% end %>", "<% end %>"]))
+        expect(subject[0].nodes.map(&:loc).map(&:range)).to(eq([0...21, 32...41, 42...51]))
       end
     end
 
@@ -137,9 +137,9 @@ describe ERBLint::Utils::BlockMap do
       ERB
 
       it do
-        expect(subject.size).to eq(1)
-        expect(subject[0].type).to eq(:begin)
-        expect(subject[0].nodes.map(&:loc).map(&:source)).to eq(["<% begin %>", "<% end %>"])
+        expect(subject.size).to(eq(1))
+        expect(subject[0].type).to(eq(:begin))
+        expect(subject[0].nodes.map(&:loc).map(&:source)).to(eq(["<% begin %>", "<% end %>"]))
       end
     end
 
@@ -155,14 +155,14 @@ describe ERBLint::Utils::BlockMap do
       ERB
 
       it do
-        expect(subject.size).to eq(1)
-        expect(subject[0].type).to eq(:begin)
-        expect(subject[0].nodes.map(&:loc).map(&:source)).to eq([
+        expect(subject.size).to(eq(1))
+        expect(subject[0].type).to(eq(:begin))
+        expect(subject[0].nodes.map(&:loc).map(&:source)).to(eq([
           "<% begin %>",
           "<% rescue Error1 => e %>",
           "<% rescue Error2 => e %>",
           "<% end %>",
-        ])
+        ]))
       end
     end
 
@@ -179,15 +179,15 @@ describe ERBLint::Utils::BlockMap do
       ERB
 
       it do
-        expect(subject.size).to eq(1)
-        expect(subject[0].type).to eq(:case)
-        expect(subject[0].nodes.map(&:loc).map(&:source)).to eq([
+        expect(subject.size).to(eq(1))
+        expect(subject[0].type).to(eq(:case))
+        expect(subject[0].nodes.map(&:loc).map(&:source)).to(eq([
           "<% case foo %>",
           "<% when :bar %>",
           "<% when :baz %>",
           "<% else %>",
           "<% end %>",
-        ])
+        ]))
       end
     end
   end

--- a/spec/erb_lint/cli_spec.rb
+++ b/spec/erb_lint/cli_spec.rb
@@ -19,10 +19,10 @@ describe ERBLint::CLI do
   end
 
   before do
-    allow(ERBLint::LinterRegistry).to receive(:linters)
+    allow(ERBLint::LinterRegistry).to(receive(:linters)
       .and_return([ERBLint::Linters::LinterWithErrors,
                    ERBLint::Linters::LinterWithoutErrors,
-                   ERBLint::Linters::FinalNewline])
+                   ERBLint::Linters::FinalNewline]))
   end
 
   module ERBLint
@@ -48,33 +48,33 @@ describe ERBLint::CLI do
 
     context 'with no arguments' do
       it 'shows usage' do
-        expect { subject }.to output(/erblint \[options\] \[file1, file2, ...\]/).to_stdout
+        expect { subject }.to(output(/erblint \[options\] \[file1, file2, ...\]/).to_stdout)
       end
 
       it 'shows all known linters' do
-        expect { subject }.to output(
+        expect { subject }.to(output(
           /Known linters are: linter_with_errors, linter_without_errors, final_newline/
-        ).to_stdout
+        ).to_stdout)
       end
 
       it 'is successful' do
-        expect(subject).to be(true)
+        expect(subject).to(be(true))
       end
     end
 
     context 'with --version' do
       let(:args) { ['--version'] }
-      it { expect { subject }.to output("#{ERBLint::VERSION}\n").to_stdout }
+      it { expect { subject }.to(output("#{ERBLint::VERSION}\n").to_stdout) }
     end
 
     context 'with --help' do
       let(:args) { ['--help'] }
 
       it 'shows usage' do
-        expect { subject }.to output(/erblint \[options\] \[file1, file2, ...\]/).to_stdout
+        expect { subject }.to(output(/erblint \[options\] \[file1, file2, ...\]/).to_stdout)
       end
       it 'is successful' do
-        expect(subject).to be(true)
+        expect(subject).to(be(true))
       end
     end
 
@@ -82,9 +82,9 @@ describe ERBLint::CLI do
       context 'when file does not exist' do
         let(:args) { ['--config', '.somefile.yml'] }
 
-        it { expect { subject }.to output(/.somefile.yml: does not exist/).to_stderr }
+        it { expect { subject }.to(output(/.somefile.yml: does not exist/).to_stderr) }
         it 'is not successful' do
-          expect(subject).to be(false)
+          expect(subject).to(be(false))
         end
       end
     end
@@ -94,8 +94,8 @@ describe ERBLint::CLI do
         let(:linted_file) { '/path/to/myfile.html.erb' }
         let(:args) { [linted_file] }
 
-        it { expect { subject }.to output(/#{Regexp.escape(linted_file)}: does not exist/).to_stderr }
-        it { expect(subject).to be(false) }
+        it { expect { subject }.to(output(/#{Regexp.escape(linted_file)}: does not exist/).to_stderr) }
+        it { expect(subject).to(be(false)) }
       end
 
       context 'when file exists' do
@@ -110,17 +110,17 @@ describe ERBLint::CLI do
 
         context 'without --config' do
           context 'when default config does not exist' do
-            it { expect { subject }.to output(/\.erb-lint\.yml not found: using default config/).to_stderr }
+            it { expect { subject }.to(output(/\.erb-lint\.yml not found: using default config/).to_stderr) }
           end
         end
 
         it 'shows how many files and linters are used' do
-          expect { subject }.to output(/Linting 1 files with 2 linters/).to_stdout
+          expect { subject }.to(output(/Linting 1 files with 2 linters/).to_stdout)
         end
 
         context 'when errors are found' do
           it 'shows all error messages and line numbers' do
-            expect { subject }.to output(Regexp.new(Regexp.escape(<<~EOF))).to_stdout
+            expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stdout)
               fake message from a fake linter
               In file: /app/views/template.html.erb:1
 
@@ -130,11 +130,11 @@ describe ERBLint::CLI do
           end
 
           it 'prints that errors were found to stdout' do
-            expect { subject }.to output(/2 error\(s\) were found in ERB files/).to_stderr
+            expect { subject }.to(output(/2 error\(s\) were found in ERB files/).to_stderr)
           end
 
           it 'is not successful' do
-            expect(subject).to be(false)
+            expect(subject).to(be(false))
           end
         end
 
@@ -142,11 +142,11 @@ describe ERBLint::CLI do
           let(:args) { ['--enable-linter', 'linter_without_errors', linted_file] }
 
           it 'shows no that errors were found to stderr' do
-            expect { subject }.to output(/No errors were found in ERB files/).to_stdout
+            expect { subject }.to(output(/No errors were found in ERB files/).to_stdout)
           end
 
           it 'is successful' do
-            expect(subject).to be(true)
+            expect(subject).to(be(true))
           end
         end
       end
@@ -157,8 +157,8 @@ describe ERBLint::CLI do
         let(:linted_dir) { '/path/to' }
         let(:args) { [linted_dir] }
 
-        it { expect { subject }.to output(/#{Regexp.escape(linted_dir)}: does not exist/).to_stderr }
-        it { expect(subject).to be(false) }
+        it { expect { subject }.to(output(/#{Regexp.escape(linted_dir)}: does not exist/).to_stderr) }
+        it { expect(subject).to(be(false)) }
       end
 
       context 'when dir exists' do
@@ -171,7 +171,7 @@ describe ERBLint::CLI do
             FileUtils.mkdir_p(linted_dir)
           end
 
-          it { expect { subject }.to output(/no files found/).to_stdout }
+          it { expect { subject }.to(output(/no files found/).to_stdout) }
         end
 
         context 'with descendant files that match default glob' do
@@ -186,17 +186,17 @@ describe ERBLint::CLI do
 
           context 'without --config' do
             context 'when default config does not exist' do
-              it { expect { subject }.to output(/\.erb-lint\.yml not found: using default config/).to_stderr }
+              it { expect { subject }.to(output(/\.erb-lint\.yml not found: using default config/).to_stderr) }
             end
           end
 
           it 'shows how many files and linters are used' do
-            expect { subject }.to output(/Linting 1 files with 2 linters/).to_stdout
+            expect { subject }.to(output(/Linting 1 files with 2 linters/).to_stdout)
           end
 
           context 'when errors are found' do
             it 'shows all error messages and line numbers' do
-              expect { subject }.to output(Regexp.new(Regexp.escape(<<~EOF))).to_stdout
+              expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stdout)
                 fake message from a fake linter
                 In file: /app/views/template.html.erb:1
 
@@ -206,11 +206,11 @@ describe ERBLint::CLI do
             end
 
             it 'prints that errors were found to stdout' do
-              expect { subject }.to output(/2 error\(s\) were found in ERB files/).to_stderr
+              expect { subject }.to(output(/2 error\(s\) were found in ERB files/).to_stderr)
             end
 
             it 'is not successful' do
-              expect(subject).to be(false)
+              expect(subject).to(be(false))
             end
           end
 
@@ -218,11 +218,11 @@ describe ERBLint::CLI do
             let(:args) { ['--enable-linter', 'linter_without_errors', linted_dir] }
 
             it 'shows no that errors were found to stderr' do
-              expect { subject }.to output(/No errors were found in ERB files/).to_stdout
+              expect { subject }.to(output(/No errors were found in ERB files/).to_stdout)
             end
 
             it 'is successful' do
-              expect(subject).to be(true)
+              expect(subject).to(be(true))
             end
           end
         end
@@ -232,10 +232,10 @@ describe ERBLint::CLI do
     context 'with unknown argument' do
       let(:args) { ['--foo'] }
 
-      it { expect { subject }.to output(/invalid option: --foo/).to_stderr }
+      it { expect { subject }.to(output(/invalid option: --foo/).to_stderr) }
 
       it 'is not successful' do
-        expect(subject).to be(false)
+        expect(subject).to(be(false))
       end
     end
 
@@ -243,13 +243,13 @@ describe ERBLint::CLI do
       let(:args) { ['--enable-linter', 'foo'] }
 
       it do
-        expect { subject }.to output(
+        expect { subject }.to(output(
           /foo: not a valid linter name \(linter_with_errors, linter_without_errors, final_newline\)/
-        ).to_stderr
+        ).to_stderr)
       end
 
       it 'is not successful' do
-        expect(subject).to be(false)
+        expect(subject).to(be(false))
       end
     end
   end

--- a/spec/erb_lint/linter_config_spec.rb
+++ b/spec/erb_lint/linter_config_spec.rb
@@ -13,14 +13,14 @@ describe ERBLint::LinterConfig do
         let(:config_hash) { {} }
 
         it 'returns default config' do
-          expect(subject).to eq("enabled" => false, "exclude" => [])
+          expect(subject).to(eq("enabled" => false, "exclude" => []))
         end
       end
 
       context 'with custom data' do
         let(:config_hash) { { foo: true } }
 
-        it { expect { subject }.to raise_error(described_class::Error, "Given key is not allowed: foo") }
+        it { expect { subject }.to(raise_error(described_class::Error, "Given key is not allowed: foo")) }
       end
     end
 
@@ -36,28 +36,28 @@ describe ERBLint::LinterConfig do
         let(:config_hash) { {} }
         let(:key) { 'foo' }
 
-        it { expect(subject).to eq(nil) }
+        it { expect(subject).to(eq(nil)) }
       end
 
       context 'with custom data' do
         let(:config_hash) { { foo: 'custom value' } }
         let(:key) { 'foo' }
 
-        it { expect(subject).to eq('custom value') }
+        it { expect(subject).to(eq('custom value')) }
       end
 
       context 'with string data and symbol key' do
         let(:config_hash) { { 'foo' => 'custom value' } }
         let(:key) { :foo }
 
-        it { expect(subject).to eq('custom value') }
+        it { expect(subject).to(eq('custom value')) }
       end
 
       context 'with unknown key' do
         let(:config_hash) { {} }
         let(:key) { 'bogus' }
 
-        it { expect { subject }.to raise_error(described_class::Error, "No such property: bogus") }
+        it { expect { subject }.to(raise_error(described_class::Error, "No such property: bogus")) }
       end
     end
 
@@ -66,33 +66,34 @@ describe ERBLint::LinterConfig do
 
       context 'when enabled is true' do
         let(:config_hash) { { enabled: true } }
-        it { expect(subject).to eq(true) }
+        it { expect(subject).to(eq(true)) }
       end
 
       context 'when enabled is false' do
         let(:config_hash) { { enabled: false } }
-        it { expect(subject).to eq(false) }
+        it { expect(subject).to(eq(false)) }
       end
 
       context 'when enabled key is missing' do
         let(:config_hash) { {} }
-        it { expect(subject).to eq(false) }
+        it { expect(subject).to(eq(false)) }
       end
 
       context 'when enabled key is not true or false' do
         let(:config_hash) { { enabled: 42 } }
         it do
-          expect { subject }.to \
+          expect { subject }.to(\
             raise_error(
               described_class::Error,
               "ERBLint::LinterConfig does not accept 42 as value for the property enabled. Only accepts: [true, false]"
             )
+          )
         end
       end
 
       context 'when enabled key is nil' do
         let(:config_hash) { { enabled: nil } }
-        it { expect(subject).to eq(nil) }
+        it { expect(subject).to(eq(nil)) }
       end
     end
 
@@ -100,13 +101,13 @@ describe ERBLint::LinterConfig do
       context 'when glob matches' do
         let(:config_hash) { { exclude: ['vendor/**/*'] } }
         subject { linter_config.excludes_file?('vendor/gem/foo.rb') }
-        it { expect(subject).to eq(true) }
+        it { expect(subject).to(eq(true)) }
       end
 
       context 'when glob does not match' do
         let(:config_hash) { { exclude: ['vendor/**/*'] } }
         subject { linter_config.excludes_file?('app/foo.rb') }
-        it { expect(subject).to eq(false) }
+        it { expect(subject).to(eq(false)) }
       end
     end
   end

--- a/spec/erb_lint/linter_registry_spec.rb
+++ b/spec/erb_lint/linter_registry_spec.rb
@@ -13,7 +13,7 @@ describe ERBLint::LinterRegistry do
         class FakeLinter < ERBLint::Linter
           include ERBLint::LinterRegistry
         end
-      end.to change { described_class.linters.count }.by(1)
+      end.to(change { described_class.linters.count }.by(1))
     end
   end
 
@@ -21,8 +21,8 @@ describe ERBLint::LinterRegistry do
     let(:custom_directory) { File.expand_path('../fixtures/linters', __FILE__) }
 
     it 'adds the custom linter to the set of registered linters' do
-      expect(described_class).to receive(:require)
-        .with(File.join(custom_directory, 'custom_linter.rb')).once
+      expect(described_class).to(receive(:require)
+        .with(File.join(custom_directory, 'custom_linter.rb')).once)
       described_class.load_custom_linters(custom_directory)
     end
   end

--- a/spec/erb_lint/linter_spec.rb
+++ b/spec/erb_lint/linter_spec.rb
@@ -20,7 +20,7 @@ describe ERBLint::Linter do
 
     describe '.simple_name' do
       it 'returns the name of the class with the ERBLint::Linter prefix removed' do
-        expect(subject.class.simple_name).to eq 'Fake'
+        expect(subject.class.simple_name).to(eq('Fake'))
       end
     end
 
@@ -28,7 +28,7 @@ describe ERBLint::Linter do
       it 'clears all offenses from the offenses ivar' do
         linter.offenses = %w(someoffense)
         linter.clear_offenses
-        expect(linter.offenses).to eq []
+        expect(linter.offenses).to(eq([]))
       end
     end
   end

--- a/spec/erb_lint/linters/allowed_script_type_spec.rb
+++ b/spec/erb_lint/linters/allowed_script_type_spec.rb
@@ -18,17 +18,17 @@ describe ERBLint::Linters::AllowedScriptType do
 
     context 'when type is correct' do
       let(:file) { '<script type="text/javascript">' }
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
 
     context 'when type is incorrect' do
       let(:file) { '<script type="text/yavascript">' }
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(8..29,
             "Avoid using \"text/yavascript\" as type for `<script>` tag. "\
             "Must be one of: text/javascript (or no type attribute)."),
-        ]
+        ]))
       end
     end
 
@@ -38,11 +38,11 @@ describe ERBLint::Linters::AllowedScriptType do
       context 'with any script tag' do
         let(:file) { '<script>' }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(1..6,
               "Avoid using inline `<script>` tags altogether. "\
               "Instead, move javascript code into a static file."),
-          ]
+          ]))
         end
       end
     end
@@ -52,21 +52,21 @@ describe ERBLint::Linters::AllowedScriptType do
 
       context 'when type is absent' do
         let(:file) { '<script>' }
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
 
       context 'when type value is missing' do
         let(:file) { '<script type>' }
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
 
       context 'when type value is present but blank' do
         let(:file) { '<script type="">' }
         it 'is not valid' do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(8..14,
               "Avoid using \"\" as type for `<script>` tag. Must be one of: text/javascript (or no type attribute)."),
-          ]
+          ]))
         end
       end
     end
@@ -77,20 +77,20 @@ describe ERBLint::Linters::AllowedScriptType do
       context 'when type is blank' do
         let(:file) { '<script>' }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(1..6,
               "Missing a `type=\"text/javascript\"` attribute to `<script>` tag."),
-          ]
+          ]))
         end
       end
 
       context 'when type is empty' do
         let(:file) { '<script type>' }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(1..6,
               "Missing a `type=\"text/javascript\"` attribute to `<script>` tag."),
-          ]
+          ]))
         end
       end
     end
@@ -102,12 +102,12 @@ describe ERBLint::Linters::AllowedScriptType do
     context 'file remains the same' do
       context 'when type is correct' do
         let(:file) { '<script type="text/javascript">' }
-        it { expect(subject).to eq file }
+        it { expect(subject).to(eq(file)) }
       end
 
       context 'when type is incorrect' do
         let(:file) { '<script type="text/yavascript">' }
-        it { expect(subject).to eq file }
+        it { expect(subject).to(eq(file)) }
       end
 
       context 'when allow_blank=true' do
@@ -115,12 +115,12 @@ describe ERBLint::Linters::AllowedScriptType do
 
         context 'when type is blank' do
           let(:file) { '<script>' }
-          it { expect(subject).to eq file }
+          it { expect(subject).to(eq(file)) }
         end
 
         context 'when type is empty' do
           let(:file) { '<script type>' }
-          it { expect(subject).to eq file }
+          it { expect(subject).to(eq(file)) }
         end
       end
     end
@@ -131,12 +131,12 @@ describe ERBLint::Linters::AllowedScriptType do
 
         context 'when type is blank' do
           let(:file) { '<script>' }
-          it { expect(subject).to eq '<script type="text/javascript">' }
+          it { expect(subject).to(eq('<script type="text/javascript">')) }
         end
 
         context 'when type is empty' do
           let(:file) { '<script type>' }
-          it { expect(subject).to eq '<script type="text/javascript">' }
+          it { expect(subject).to(eq('<script type="text/javascript">')) }
         end
       end
     end

--- a/spec/erb_lint/linters/closing_erb_tag_indent_spec.rb
+++ b/spec/erb_lint/linters/closing_erb_tag_indent_spec.rb
@@ -18,7 +18,7 @@ describe ERBLint::Linters::ClosingErbTagIndent do
 
     context 'when tag is correct' do
       let(:file) { "<% foo %>" }
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
 
     context 'when tag starts and ends with a newline' do
@@ -27,7 +27,7 @@ describe ERBLint::Linters::ClosingErbTagIndent do
           foo
         %>
       ERB
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
 
     context 'when tag start and end are misaligned' do
@@ -37,9 +37,9 @@ describe ERBLint::Linters::ClosingErbTagIndent do
             %>
       ERB
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(9..12, "Indent `%>` on column 0 to match start of tag."),
-        ]
+        ]))
       end
     end
 
@@ -52,9 +52,9 @@ describe ERBLint::Linters::ClosingErbTagIndent do
             %>
       ERB
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(13..16, "Indent `%>` on column 2 to match start of tag."),
-        ]
+        ]))
       end
     end
 
@@ -64,9 +64,9 @@ describe ERBLint::Linters::ClosingErbTagIndent do
           foo %>
       ERB
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(8..8, "Insert newline before `%>` to match start of tag."),
-        ]
+        ]))
       end
     end
 
@@ -76,9 +76,9 @@ describe ERBLint::Linters::ClosingErbTagIndent do
         %>
       ERB
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(6..6, "Remove newline before `%>` to match start of tag."),
-        ]
+        ]))
       end
     end
   end
@@ -88,7 +88,7 @@ describe ERBLint::Linters::ClosingErbTagIndent do
 
     context 'when tag is correct' do
       let(:file) { "<% foo %>" }
-      it { expect(subject).to eq file }
+      it { expect(subject).to(eq(file)) }
     end
 
     context 'when tag starts and ends with a newline' do
@@ -97,7 +97,7 @@ describe ERBLint::Linters::ClosingErbTagIndent do
           foo
         %>
       ERB
-      it { expect(subject).to eq file }
+      it { expect(subject).to(eq(file)) }
     end
 
     context 'when tag start and end are misaligned' do
@@ -106,7 +106,7 @@ describe ERBLint::Linters::ClosingErbTagIndent do
           foo
             %>
       ERB
-      it { expect(subject).to eq <<~ERB }
+      it { expect(subject).to(eq(<<~ERB)) }
         <%
           foo
         %>
@@ -120,7 +120,7 @@ describe ERBLint::Linters::ClosingErbTagIndent do
 
                 %>
       ERB
-      it { expect(subject).to eq <<~ERB }
+      it { expect(subject).to(eq(<<~ERB)) }
         <div><%
           foo
 
@@ -133,7 +133,7 @@ describe ERBLint::Linters::ClosingErbTagIndent do
         <%
           foo %>
       ERB
-      it { expect(subject).to eq <<~ERB }
+      it { expect(subject).to(eq(<<~ERB)) }
         <%
           foo
         %>
@@ -145,7 +145,7 @@ describe ERBLint::Linters::ClosingErbTagIndent do
         <% foo
         %>
       ERB
-      it { expect(subject).to eq <<~ERB }
+      it { expect(subject).to(eq(<<~ERB)) }
         <% foo %>
       ERB
     end

--- a/spec/erb_lint/linters/deprecated_classes_spec.rb
+++ b/spec/erb_lint/linters/deprecated_classes_spec.rb
@@ -22,7 +22,7 @@ describe ERBLint::Linters::DeprecatedClasses do
       let(:file) { '' }
 
       it 'does not report any offense' do
-        expect(subject).to eq []
+        expect(subject).to(eq([]))
       end
     end
 
@@ -34,7 +34,7 @@ describe ERBLint::Linters::DeprecatedClasses do
       FILE
 
       it 'does not report any offenses' do
-        expect(subject).to eq []
+        expect(subject).to(eq([]))
       end
     end
   end
@@ -62,7 +62,7 @@ describe ERBLint::Linters::DeprecatedClasses do
       let(:file) { '' }
 
       it 'does not report any offenses' do
-        expect(subject).to eq []
+        expect(subject).to(eq([]))
       end
     end
 
@@ -74,7 +74,7 @@ describe ERBLint::Linters::DeprecatedClasses do
       FILE
 
       it 'does not report any offenses' do
-        expect(subject).to eq []
+        expect(subject).to(eq([]))
       end
     end
 
@@ -86,11 +86,11 @@ describe ERBLint::Linters::DeprecatedClasses do
       FILE
 
       it 'reports 1 offense' do
-        expect(subject.size).to eq 1
+        expect(subject.size).to(eq(1))
       end
 
       it 'reports an offense with message containing suggestion 1' do
-        expect(subject.first.message).to include suggestion_1
+        expect(subject.first.message).to(include(suggestion_1))
       end
     end
 
@@ -104,17 +104,17 @@ describe ERBLint::Linters::DeprecatedClasses do
       FILE
 
       it 'reports 1 offense' do
-        expect(subject.size).to eq 1
+        expect(subject.size).to(eq(1))
       end
 
       it 'reports an offense with message containing suggestion 1' do
-        expect(subject.first.message).to include suggestion_1
+        expect(subject.first.message).to(include(suggestion_1))
       end
 
       it 'reports an offense with position range that is adjusted in the nested context' do
-        expect(subject.first.source_range.begin_pos).to eq 28
-        expect(subject.first.source_range.end_pos).to eq 45
-        expect(subject.first.source_range.source).to eq "<div class=\"abc\">"
+        expect(subject.first.source_range.begin_pos).to(eq(28))
+        expect(subject.first.source_range.end_pos).to(eq(45))
+        expect(subject.first.source_range.source).to(eq("<div class=\"abc\">"))
       end
     end
 
@@ -127,12 +127,12 @@ describe ERBLint::Linters::DeprecatedClasses do
         FILE
 
         it 'reports 2 offenses' do
-          expect(subject.size).to eq 2
+          expect(subject.size).to(eq(2))
         end
 
         it 'reports offenses with messages containing suggestion 1' do
-          expect(subject[0].message).to include suggestion_1
-          expect(subject[1].message).to include suggestion_1
+          expect(subject[0].message).to(include(suggestion_1))
+          expect(subject[1].message).to(include(suggestion_1))
         end
       end
 
@@ -144,12 +144,12 @@ describe ERBLint::Linters::DeprecatedClasses do
         FILE
 
         it 'reports 2 offenses' do
-          expect(subject.size).to eq 2
+          expect(subject.size).to(eq(2))
         end
 
         it 'reports offenses with messages containing suggestion 1' do
-          expect(subject[0].message).to include suggestion_1
-          expect(subject[1].message).to include suggestion_1
+          expect(subject[0].message).to(include(suggestion_1))
+          expect(subject[1].message).to(include(suggestion_1))
         end
       end
     end
@@ -162,12 +162,12 @@ describe ERBLint::Linters::DeprecatedClasses do
       FILE
 
       it 'reports 2 offenses' do
-        expect(subject.size).to eq 2
+        expect(subject.size).to(eq(2))
       end
 
       it 'reports offenses with messages containing suggestion 2' do
-        expect(subject[0].message).to include suggestion_2
-        expect(subject[1].message).to include suggestion_2
+        expect(subject[0].message).to(include(suggestion_2))
+        expect(subject[1].message).to(include(suggestion_2))
       end
     end
 
@@ -184,7 +184,7 @@ describe ERBLint::Linters::DeprecatedClasses do
         let(:file) { '' }
 
         it 'does not report any offenses' do
-          expect(subject).to eq []
+          expect(subject).to(eq([]))
         end
       end
 
@@ -196,11 +196,11 @@ describe ERBLint::Linters::DeprecatedClasses do
         FILE
 
         it 'reports 1 offense' do
-          expect(subject.size).to eq 1
+          expect(subject.size).to(eq(1))
         end
 
         it 'reports an offense with its message ending with the addendum' do
-          expect(subject.first.message).to end_with addendum
+          expect(subject.first.message).to(end_with(addendum))
         end
       end
     end
@@ -216,7 +216,7 @@ describe ERBLint::Linters::DeprecatedClasses do
         let(:file) { '' }
 
         it 'does not report any offenses' do
-          expect(subject).to eq []
+          expect(subject).to(eq([]))
         end
       end
 
@@ -228,11 +228,11 @@ describe ERBLint::Linters::DeprecatedClasses do
         FILE
 
         it 'reports 1 offense' do
-          expect(subject.size).to eq 1
+          expect(subject.size).to(eq(1))
         end
 
         it 'reports an offense with its message ending with the suggestion' do
-          expect(subject.first.message).to end_with suggestion_1
+          expect(subject.first.message).to(end_with(suggestion_1))
         end
       end
     end
@@ -243,7 +243,7 @@ describe ERBLint::Linters::DeprecatedClasses do
       FILE
 
       it 'does not report any offenses' do
-        expect(subject).to eq []
+        expect(subject).to(eq([]))
       end
     end
   end

--- a/spec/erb_lint/linters/erb_safety_spec.rb
+++ b/spec/erb_lint/linters/erb_safety_spec.rb
@@ -31,7 +31,7 @@ describe ERBLint::Linters::ErbSafety do
       <a onclick="alert('<%= foo %>')">
     FILE
 
-    it { expect(subject).to eq [unsafe_interpolate(23..25)] }
+    it { expect(subject).to(eq([unsafe_interpolate(23..25)])) }
   end
 
   context 'interpolate a variable in js attribute calling safe method' do
@@ -39,7 +39,7 @@ describe ERBLint::Linters::ErbSafety do
       <a onclick="alert(<%= foo.to_json %>)">
     FILE
 
-    it { expect(subject).to eq [] }
+    it { expect(subject).to(eq([])) }
   end
 
   context 'interpolate a variable in js attribute calling safe method inside string interpolation' do
@@ -47,7 +47,7 @@ describe ERBLint::Linters::ErbSafety do
       <a onclick="alert(<%= "hello \#{foo.to_json}" %>)">
     FILE
 
-    it { expect(subject).to eq [] }
+    it { expect(subject).to(eq([])) }
   end
 
   context 'html_safe in any attribute is unsafe' do
@@ -55,7 +55,7 @@ describe ERBLint::Linters::ErbSafety do
       <div title="<%= foo.html_safe %>">
     FILE
 
-    it { expect(subject).to eq [unsafe_html_safe(16..28)] }
+    it { expect(subject).to(eq([unsafe_html_safe(16..28)])) }
   end
 
   context 'html_safe in any attribute is unsafe despite having to_json' do
@@ -63,7 +63,7 @@ describe ERBLint::Linters::ErbSafety do
       <a onclick="<%= foo.to_json.html_safe %>">
     FILE
 
-    it { expect(subject).to eq [unsafe_html_safe(16..36), unsafe_interpolate(16..36)] }
+    it { expect(subject).to(eq([unsafe_html_safe(16..36), unsafe_interpolate(16..36)])) }
   end
 
   context '<== in any attribute is unsafe' do
@@ -71,7 +71,7 @@ describe ERBLint::Linters::ErbSafety do
       <div title="<%== foo %>">
     FILE
 
-    it { expect(subject).to eq [unsafe_erb_interpolate(12..22)] }
+    it { expect(subject).to(eq([unsafe_erb_interpolate(12..22)])) }
   end
 
   context '<== in any attribute is unsafe despite having to_json' do
@@ -79,7 +79,7 @@ describe ERBLint::Linters::ErbSafety do
       <div title="<%== foo.to_json %>">
     FILE
 
-    it { expect(subject).to eq [unsafe_erb_interpolate(12..30)] }
+    it { expect(subject).to(eq([unsafe_erb_interpolate(12..30)])) }
   end
 
   context 'raw in any attribute is unsafe' do
@@ -87,7 +87,7 @@ describe ERBLint::Linters::ErbSafety do
       <div title="<%= raw foo %>">
     FILE
 
-    it { expect(subject).to eq [unsafe_raw(16..22)] }
+    it { expect(subject).to(eq([unsafe_raw(16..22)])) }
   end
 
   context 'raw in any attribute is unsafe despite having to_json' do
@@ -95,7 +95,7 @@ describe ERBLint::Linters::ErbSafety do
       <div title="<%= raw foo.to_json %>">
     FILE
 
-    it { expect(subject).to eq [unsafe_raw(16..30)] }
+    it { expect(subject).to(eq([unsafe_raw(16..30)])) }
   end
 
   context 'unsafe erb in <script>' do
@@ -103,7 +103,7 @@ describe ERBLint::Linters::ErbSafety do
       <script>var foo = <%= unsafe %>;</script>
     FILE
 
-    it { expect(subject).to eq [unsafe_javascript_tag_interpolate(18..30)] }
+    it { expect(subject).to(eq([unsafe_javascript_tag_interpolate(18..30)])) }
   end
 
   context 'safe erb in <script>' do
@@ -111,7 +111,7 @@ describe ERBLint::Linters::ErbSafety do
       <script>var foo = <%= unsafe.to_json %>;</script>
     FILE
 
-    it { expect(subject).to eq [] }
+    it { expect(subject).to(eq([])) }
   end
 
   context 'safe erb in <script> when raw is present' do
@@ -119,7 +119,7 @@ describe ERBLint::Linters::ErbSafety do
       <script>var foo = <%= raw unsafe.to_json %>;</script>
     FILE
 
-    it { expect(subject).to eq [] }
+    it { expect(subject).to(eq([])) }
   end
 
   context 'statements not allowed in <script> tags' do
@@ -127,7 +127,7 @@ describe ERBLint::Linters::ErbSafety do
       <script><% if foo? %>var foo = 1;<% end %></script>
     FILE
 
-    it { expect(subject).to eq [erb_statements_not_allowed(8..20)] }
+    it { expect(subject).to(eq([erb_statements_not_allowed(8..20)])) }
   end
 
   context 'changing better-html config file works' do
@@ -142,17 +142,17 @@ describe ERBLint::Linters::ErbSafety do
 
     context 'with default config' do
       let(:better_html_config) { {} }
-      it { expect(subject).to eq [unsafe_javascript_tag_interpolate(8..20)] }
+      it { expect(subject).to(eq([unsafe_javascript_tag_interpolate(8..20)])) }
     end
 
     context 'with non-default config' do
       let(:better_html_config) { { javascript_safe_methods: %w(foobar) } }
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
 
     context 'with string keys in config' do
       let(:better_html_config) { { 'javascript_safe_methods' => %w(foobar) } }
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
   end
 

--- a/spec/erb_lint/linters/extra_newline_spec.rb
+++ b/spec/erb_lint/linters/extra_newline_spec.rb
@@ -18,7 +18,7 @@ describe ERBLint::Linters::ExtraNewline do
 
     context 'when no new line is present' do
       let(:file) { "this is a line" }
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
 
     context 'when no blank lines are present' do
@@ -27,7 +27,7 @@ describe ERBLint::Linters::ExtraNewline do
         line 2
         line 3
       FILE
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
 
     context 'when a single blank line is present' do
@@ -36,7 +36,7 @@ describe ERBLint::Linters::ExtraNewline do
 
         line 3
       FILE
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
 
     context 'when two blank lines follow each other' do
@@ -47,9 +47,9 @@ describe ERBLint::Linters::ExtraNewline do
         line 3
       FILE
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(8..8, "Extra blank line detected."),
-        ]
+        ]))
       end
     end
 
@@ -63,9 +63,9 @@ describe ERBLint::Linters::ExtraNewline do
         line 3
       FILE
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(8..10, "Extra blank line detected."),
-        ]
+        ]))
       end
     end
   end
@@ -75,17 +75,17 @@ describe ERBLint::Linters::ExtraNewline do
 
     context 'when no new line is present' do
       let(:file) { "this is a line" }
-      it { expect(subject).to eq file }
+      it { expect(subject).to(eq(file)) }
     end
 
     context 'when single blank line present at end of file' do
       let(:file) { "this is a line\n\n" }
-      it { expect(subject).to eq file }
+      it { expect(subject).to(eq(file)) }
     end
 
     context 'when multiple blank lines present at end of file' do
       let(:file) { "this is a line\n\n\n\n" }
-      it { expect(subject).to eq "this is a line\n\n" }
+      it { expect(subject).to(eq("this is a line\n\n")) }
     end
 
     context 'when no blank lines are present' do
@@ -94,7 +94,7 @@ describe ERBLint::Linters::ExtraNewline do
         line 2
         line 3
       FILE
-      it { expect(subject).to eq file }
+      it { expect(subject).to(eq(file)) }
     end
 
     context 'when a single blank line is present' do
@@ -103,7 +103,7 @@ describe ERBLint::Linters::ExtraNewline do
 
         line 3
       FILE
-      it { expect(subject).to eq file }
+      it { expect(subject).to(eq(file)) }
     end
 
     context 'when two blank lines follow each other' do
@@ -114,7 +114,7 @@ describe ERBLint::Linters::ExtraNewline do
         line 3
       FILE
       it do
-        expect(subject).to eq <<~FILE
+        expect(subject).to(eq(<<~FILE))
           line 1
 
           line 3
@@ -132,7 +132,7 @@ describe ERBLint::Linters::ExtraNewline do
         line 3
       FILE
       it do
-        expect(subject).to eq <<~FILE
+        expect(subject).to(eq(<<~FILE))
           line 1
 
           line 3

--- a/spec/erb_lint/linters/final_newline_spec.rb
+++ b/spec/erb_lint/linters/final_newline_spec.rb
@@ -21,7 +21,7 @@ describe ERBLint::Linters::FinalNewline do
       let(:file) { '' }
 
       it 'does not report any offenses' do
-        expect(subject).to eq []
+        expect(subject).to(eq([]))
       end
     end
 
@@ -29,7 +29,7 @@ describe ERBLint::Linters::FinalNewline do
       let(:file) { "<div id=\"a\">\nContent\n</div>\n" }
 
       it 'does not report any errors' do
-        expect(subject).to eq []
+        expect(subject).to(eq([]))
       end
     end
 
@@ -37,19 +37,20 @@ describe ERBLint::Linters::FinalNewline do
       let(:file) { "<div id=\"a\">\nContent\n</div>\n\n\n" }
 
       it 'reports 1 offense' do
-        expect(subject.size).to eq 1
+        expect(subject.size).to(eq(1))
       end
 
       it 'the offense range is set to an empty range after the last character of the file' do
-        expect(subject.first.source_range.begin_pos).to eq 28
-        expect(subject.first.source_range.end_pos).to eq 30
-        expect(subject.first.source_range.source).to eq "\n\n"
-        expect(subject.first.message).to eq \
+        expect(subject.first.source_range.begin_pos).to(eq(28))
+        expect(subject.first.source_range.end_pos).to(eq(30))
+        expect(subject.first.source_range.source).to(eq("\n\n"))
+        expect(subject.first.message).to(eq(\
           "Remove multiple trailing newline at the end of the file."
+        ))
       end
 
       it 'autocorrects' do
-        expect(corrected_content).to eq "<div id=\"a\">\nContent\n</div>\n"
+        expect(corrected_content).to(eq("<div id=\"a\">\nContent\n</div>\n"))
       end
     end
 
@@ -57,21 +58,21 @@ describe ERBLint::Linters::FinalNewline do
       let(:file) { "<div id=\"a\">\nContent\n</div>" }
 
       it 'reports 1 offense' do
-        expect(subject.size).to eq 1
+        expect(subject.size).to(eq(1))
       end
 
       it 'reports an offense on the last line' do
-        expect(subject.first.line_range).to eq 3..3
+        expect(subject.first.line_range).to(eq(3..3))
       end
 
       it 'the offense range is set to an empty range after the last character of the file' do
-        expect(subject.first.source_range.begin_pos).to eq 27
-        expect(subject.first.source_range.end_pos).to eq 27
-        expect(subject.first.source_range.source).to eq ""
+        expect(subject.first.source_range.begin_pos).to(eq(27))
+        expect(subject.first.source_range.end_pos).to(eq(27))
+        expect(subject.first.source_range.source).to(eq(""))
       end
 
       it 'autocorrects' do
-        expect(corrected_content).to eq "<div id=\"a\">\nContent\n</div>\n"
+        expect(corrected_content).to(eq("<div id=\"a\">\nContent\n</div>\n"))
       end
     end
   end
@@ -83,7 +84,7 @@ describe ERBLint::Linters::FinalNewline do
       let(:file) { '' }
 
       it 'does not report any offenses' do
-        expect(subject).to eq []
+        expect(subject).to(eq([]))
       end
     end
 
@@ -91,25 +92,25 @@ describe ERBLint::Linters::FinalNewline do
       let(:file) { "<div id=\"a\">\nContent\n</div>\n" }
 
       it 'reports 1 offense' do
-        expect(subject.size).to eq 1
+        expect(subject.size).to(eq(1))
       end
 
       it 'reports meaningful message' do
-        expect(subject.first.message).to eq 'Remove 1 trailing newline at the end of the file.'
+        expect(subject.first.message).to(eq('Remove 1 trailing newline at the end of the file.'))
       end
 
       it 'reports an offense on the last line' do
-        expect(subject.first.line_range).to eq 3..4
+        expect(subject.first.line_range).to(eq(3..4))
       end
 
       it 'the offense range is set to the newline character' do
-        expect(subject.first.source_range.begin_pos).to eq 27
-        expect(subject.first.source_range.end_pos).to eq 28
-        expect(subject.first.source_range.source).to eq "\n"
+        expect(subject.first.source_range.begin_pos).to(eq(27))
+        expect(subject.first.source_range.end_pos).to(eq(28))
+        expect(subject.first.source_range.source).to(eq("\n"))
       end
 
       it 'autocorrects' do
-        expect(corrected_content).to eq "<div id=\"a\">\nContent\n</div>"
+        expect(corrected_content).to(eq("<div id=\"a\">\nContent\n</div>"))
       end
     end
 
@@ -117,17 +118,17 @@ describe ERBLint::Linters::FinalNewline do
       let(:file) { "foo\n\n\n\n" }
 
       it 'the offense range includes all newline characters' do
-        expect(subject.first.source_range.begin_pos).to eq 3
-        expect(subject.first.source_range.end_pos).to eq 7
-        expect(subject.first.source_range.source).to eq "\n\n\n\n"
+        expect(subject.first.source_range.begin_pos).to(eq(3))
+        expect(subject.first.source_range.end_pos).to(eq(7))
+        expect(subject.first.source_range.source).to(eq("\n\n\n\n"))
       end
 
       it 'reports meaningful message' do
-        expect(subject.first.message).to eq 'Remove 4 trailing newline at the end of the file.'
+        expect(subject.first.message).to(eq('Remove 4 trailing newline at the end of the file.'))
       end
 
       it 'autocorrects' do
-        expect(corrected_content).to eq "foo"
+        expect(corrected_content).to(eq("foo"))
       end
     end
 
@@ -135,7 +136,7 @@ describe ERBLint::Linters::FinalNewline do
       let(:file) { "<div id=\"a\">\nContent\n</div>" }
 
       it 'does not report any offenses' do
-        expect(subject).to eq []
+        expect(subject).to(eq([]))
       end
     end
   end
@@ -147,7 +148,7 @@ describe ERBLint::Linters::FinalNewline do
       let(:file) { '' }
 
       it 'does not report any offenses' do
-        expect(subject).to eq []
+        expect(subject).to(eq([]))
       end
     end
 
@@ -155,7 +156,7 @@ describe ERBLint::Linters::FinalNewline do
       let(:file) { "<div id=\"a\">\nContent\n</div>\n" }
 
       it 'does not report any offenses' do
-        expect(subject).to eq []
+        expect(subject).to(eq([]))
       end
     end
 
@@ -163,11 +164,11 @@ describe ERBLint::Linters::FinalNewline do
       let(:file) { "<div id=\"a\">\nContent\n</div>" }
 
       it 'reports 1 offense' do
-        expect(subject.size).to eq 1
+        expect(subject.size).to(eq(1))
       end
 
       it 'reports an offense on the last line' do
-        expect(subject.first.line_range).to eq 3..3
+        expect(subject.first.line_range).to(eq(3..3))
       end
     end
   end

--- a/spec/erb_lint/linters/hard_coded_string_spec.rb
+++ b/spec/erb_lint/linters/hard_coded_string_spec.rb
@@ -18,7 +18,7 @@ describe ERBLint::Linters::HardCodedString do
       <span> Hello </span>
     FILE
 
-    it { expect(subject).to eq [untranslated_string_error(7..11, 'String not translated: Hello')] }
+    it { expect(subject).to(eq([untranslated_string_error(7..11, 'String not translated: Hello')])) }
   end
 
   context 'when file contains nested hard coded string' do
@@ -30,7 +30,7 @@ describe ERBLint::Linters::HardCodedString do
       </span>
     FILE
 
-    it { expect(subject).to eq [untranslated_string_error(61..67, 'String not translated: Example')] }
+    it { expect(subject).to(eq([untranslated_string_error(61..67, 'String not translated: Example')])) }
   end
 
   context 'when file contains a mix of hard coded string and erb' do
@@ -38,7 +38,7 @@ describe ERBLint::Linters::HardCodedString do
       <span><%= foo %> Example </span>
     FILE
 
-    it { expect(subject).to eq [untranslated_string_error(17..23, 'String not translated: Example')] }
+    it { expect(subject).to(eq([untranslated_string_error(17..23, 'String not translated: Example')])) }
   end
 
   context 'when file contains hard coded string nested inside erb' do
@@ -50,7 +50,7 @@ describe ERBLint::Linters::HardCodedString do
       </span>
     FILE
 
-    it { expect(subject).to eq [untranslated_string_error(33..39, 'String not translated: Example')] }
+    it { expect(subject).to(eq([untranslated_string_error(33..39, 'String not translated: Example')])) }
   end
 
   context 'when file contains multiple hard coded string' do
@@ -61,11 +61,11 @@ describe ERBLint::Linters::HardCodedString do
     FILE
 
     it 'find all offenses' do
-      expect(subject).to eq [
+      expect(subject).to(eq([
         untranslated_string_error(7..13, 'String not translated: Example'),
         untranslated_string_error(30..32, 'String not translated: Foo'),
         untranslated_string_error(49..52, 'String not translated: Test'),
-      ]
+      ]))
     end
   end
 
@@ -78,7 +78,7 @@ describe ERBLint::Linters::HardCodedString do
       </span>
     FILE
 
-    it { expect(subject).to eq [] }
+    it { expect(subject).to(eq([])) }
   end
 
   context 'when file contains blacklisted extraction' do
@@ -86,7 +86,7 @@ describe ERBLint::Linters::HardCodedString do
       &nbsp;
     FILE
 
-    it { expect(subject).to eq [] }
+    it { expect(subject).to(eq([])) }
   end
 
   context 'when file contains irrelevant hard coded string' do
@@ -99,7 +99,7 @@ describe ERBLint::Linters::HardCodedString do
     FILE
 
     it 'does not add offense' do
-      expect(subject).to eq []
+      expect(subject).to(eq([]))
     end
   end
 
@@ -113,7 +113,7 @@ describe ERBLint::Linters::HardCodedString do
       </script>
     FILE
 
-    it { expect(subject).to eq [] }
+    it { expect(subject).to(eq([])) }
   end
 
   context 'when file contains hard coded string inside style' do
@@ -125,7 +125,7 @@ describe ERBLint::Linters::HardCodedString do
       </style>
     FILE
 
-    it { expect(subject).to eq [] }
+    it { expect(subject).to(eq([])) }
   end
 
   %w(xmp iframe noembed noframes listing).each do |tag|
@@ -136,7 +136,7 @@ describe ERBLint::Linters::HardCodedString do
         </#{tag}>
       FILE
 
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
   end
 
@@ -151,7 +151,7 @@ describe ERBLint::Linters::HardCodedString do
       Example
     FILE
 
-    it { expect(subject).to eq [untranslated_string_error(158..164, "String not translated: Example")] }
+    it { expect(subject).to(eq([untranslated_string_error(158..164, "String not translated: Example")])) }
   end
 
   context 'when file contains multiple chunks of hardcoded strings' do
@@ -168,7 +168,7 @@ describe ERBLint::Linters::HardCodedString do
         untranslated_string_error(38..41, "String not translated: Foo3"),
       ]
 
-      expect(subject).to eq expected
+      expect(subject).to(eq(expected))
     end
   end
 
@@ -191,7 +191,7 @@ describe ERBLint::Linters::HardCodedString do
         untranslated_string_error(30..34, "String not translated: Smith"),
       ]
 
-      expect(subject).to eq expected
+      expect(subject).to(eq(expected))
     end
   end
 
@@ -244,7 +244,7 @@ describe ERBLint::Linters::HardCodedString do
       offense = untranslated_string_error(7..11, 'String not translated: Hello')
       linter.autocorrect(processed_source, offense)
 
-      expect(defined?(I18nCorrector)).to eq('constant')
+      expect(defined?(I18nCorrector)).to(eq('constant'))
     end
 
     context 'without i18n load path' do
@@ -255,7 +255,7 @@ describe ERBLint::Linters::HardCodedString do
       it 'rescues the MissingI18nLoadPath error when no load path options is passed' do
         offense = untranslated_string_error(7..11, 'String not translated: Hello')
 
-        expect(linter.autocorrect(processed_source, offense)).to eq(nil)
+        expect(linter.autocorrect(processed_source, offense)).to(eq(nil))
       end
     end
 
@@ -265,7 +265,7 @@ describe ERBLint::Linters::HardCodedString do
       it 'rescue the MissingCorrector error when no corrector option is passed' do
         offense = untranslated_string_error(7..11, 'String not translated: Hello')
 
-        expect(linter.autocorrect(processed_source, offense)).to eq(nil)
+        expect(linter.autocorrect(processed_source, offense)).to(eq(nil))
       end
     end
 
@@ -278,7 +278,7 @@ describe ERBLint::Linters::HardCodedString do
         offense = untranslated_string_error(7..11, 'String not translated: Hello')
 
         error = ERBLint::Linters::HardCodedString::ForbiddenCorrector
-        expect { linter.autocorrect(processed_source, offense) }.to raise_error(error)
+        expect { linter.autocorrect(processed_source, offense) }.to(raise_error(error))
       end
     end
   end

--- a/spec/erb_lint/linters/no_javascript_tag_helper_spec.rb
+++ b/spec/erb_lint/linters/no_javascript_tag_helper_spec.rb
@@ -22,7 +22,7 @@ describe ERBLint::Linters::NoJavascriptTagHelper do
         <%= javascript_tag do %>
       FILE
 
-      it { expect(subject).to eq [build_offense(7..30)] }
+      it { expect(subject).to(eq([build_offense(7..30)])) }
     end
 
     context 'regression with <%%= syntax does not raise an exception' do
@@ -33,7 +33,7 @@ describe ERBLint::Linters::NoJavascriptTagHelper do
         <% end %>
       FILE
 
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
 
     context 'no method calls in erb tag' do
@@ -41,7 +41,7 @@ describe ERBLint::Linters::NoJavascriptTagHelper do
         <%= true %>
       FILE
 
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
   end
 
@@ -53,7 +53,7 @@ describe ERBLint::Linters::NoJavascriptTagHelper do
         <%= javascript_tag("var myData = 1;") %>
       HTML
 
-      it { expect(subject).to eq <<~HTML }
+      it { expect(subject).to(eq(<<~HTML)) }
         <script>
         //<![CDATA[
         var myData = 1;
@@ -68,7 +68,7 @@ describe ERBLint::Linters::NoJavascriptTagHelper do
         <%= javascript_tag("var myData = 1;") %>
       HTML
 
-      it { expect(subject).to eq <<~HTML }
+      it { expect(subject).to(eq(<<~HTML)) }
         <script>var myData = 1;</script>
       HTML
     end
@@ -78,7 +78,7 @@ describe ERBLint::Linters::NoJavascriptTagHelper do
         <%= javascript_tag('var myData = 1;', defer: true) %>
       HTML
 
-      it { expect(subject).to eq <<~HTML }
+      it { expect(subject).to(eq(<<~HTML)) }
         <script defer="true">
         //<![CDATA[
         var myData = 1;
@@ -92,7 +92,7 @@ describe ERBLint::Linters::NoJavascriptTagHelper do
         <%= javascript_tag("var myData = \#{myData.to_json};", custom_attribute: "foo-\#{my_attribute}") %>
       HTML
 
-      it { expect(subject).to eq <<~HTML }
+      it { expect(subject).to(eq(<<~HTML)) }
         <script custom-attribute="foo-<%= my_attribute %>">
         //<![CDATA[
         var myData = <%== myData.to_json %>;
@@ -106,7 +106,7 @@ describe ERBLint::Linters::NoJavascriptTagHelper do
         <%= javascript_tag(data) %>
       HTML
 
-      it { expect(subject).to eq <<~HTML }
+      it { expect(subject).to(eq(<<~HTML)) }
         <script>
         //<![CDATA[
         <%== data %>
@@ -122,7 +122,7 @@ describe ERBLint::Linters::NoJavascriptTagHelper do
         <% end %>
       HTML
 
-      it { expect(subject).to eq <<~HTML }
+      it { expect(subject).to(eq(<<~HTML)) }
         <script>
         //<![CDATA[
 
@@ -141,7 +141,7 @@ describe ERBLint::Linters::NoJavascriptTagHelper do
         <% end %>
       HTML
 
-      it { expect(subject).to eq <<~HTML }
+      it { expect(subject).to(eq(<<~HTML)) }
         <script>
           foo
         </script>
@@ -155,7 +155,7 @@ describe ERBLint::Linters::NoJavascriptTagHelper do
         <% end %>
       HTML
 
-      it { expect(subject).to eq <<~HTML }
+      it { expect(subject).to(eq(<<~HTML)) }
         <script defer="true" async="true">
         //<![CDATA[
 
@@ -173,7 +173,7 @@ describe ERBLint::Linters::NoJavascriptTagHelper do
         <% end %>
       HTML
 
-      it { expect(subject).to eq <<~HTML }
+      it { expect(subject).to(eq(<<~HTML)) }
         <script defer="true" async="true">
         //<![CDATA[
 

--- a/spec/erb_lint/linters/parser_error_spec.rb
+++ b/spec/erb_lint/linters/parser_error_spec.rb
@@ -18,22 +18,22 @@ describe ERBLint::Linters::ParserErrors do
 
     context 'when file is valid' do
       let(:file) { "<a>" }
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
 
     context 'when file is invalid' do
       let(:file) { "<>" }
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(1..1, "expected '/' or tag name (at >)"),
-        ]
+        ]))
       end
     end
 
     context 'escaped erb is ignored' do
       let(:file) { "<%%= erb %>" }
       it do
-        expect(subject).to eq []
+        expect(subject).to(eq([]))
       end
     end
   end

--- a/spec/erb_lint/linters/right_trim_spec.rb
+++ b/spec/erb_lint/linters/right_trim_spec.rb
@@ -21,26 +21,26 @@ describe ERBLint::Linters::RightTrim do
 
       context 'when trim is correct' do
         let(:file) { "<% foo -%>" }
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
 
       context 'when trim is incorrect' do
         let(:file) { "<% foo =%>" }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(7..7, "Prefer -%> instead of =%> for trimming on the right."),
-          ]
+          ]))
         end
       end
 
       context 'when no trim is present' do
         let(:file) { "<% foo %>" }
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
 
       context 'when a call argument is present that is not a trim' do
         let(:file) { "<% foo 1%>" }
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
     end
 
@@ -49,26 +49,26 @@ describe ERBLint::Linters::RightTrim do
 
       context 'when trim is correct' do
         let(:file) { "<% foo =%>" }
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
 
       context 'when trim is incorrect' do
         let(:file) { "<% foo -%>" }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(7..7, "Prefer =%> instead of -%> for trimming on the right."),
-          ]
+          ]))
         end
       end
 
       context 'when no trim is present' do
         let(:file) { "<% foo %>" }
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
 
       context 'when a call argument is present that is not a trim' do
         let(:file) { "<% foo 1%>" }
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
     end
   end
@@ -81,22 +81,22 @@ describe ERBLint::Linters::RightTrim do
 
       context 'when trim is correct' do
         let(:file) { "<% foo -%>" }
-        it { expect(subject).to eq file }
+        it { expect(subject).to(eq(file)) }
       end
 
       context 'when trim is incorrect' do
         let(:file) { "<% foo =%>" }
-        it { expect(subject).to eq "<% foo -%>" }
+        it { expect(subject).to(eq("<% foo -%>")) }
       end
 
       context 'when no trim is present' do
         let(:file) { "<% foo %>" }
-        it { expect(subject).to eq file }
+        it { expect(subject).to(eq(file)) }
       end
 
       context 'when a call argument is present that is not a trim' do
         let(:file) { "<% foo 1%>" }
-        it { expect(subject).to eq file }
+        it { expect(subject).to(eq(file)) }
       end
     end
 
@@ -105,22 +105,22 @@ describe ERBLint::Linters::RightTrim do
 
       context 'when trim is correct' do
         let(:file) { "<% foo =%>" }
-        it { expect(subject).to eq file }
+        it { expect(subject).to(eq(file)) }
       end
 
       context 'when trim is incorrect' do
         let(:file) { "<% foo -%>" }
-        it { expect(subject).to eq "<% foo =%>" }
+        it { expect(subject).to(eq("<% foo =%>")) }
       end
 
       context 'when no trim is present' do
         let(:file) { "<% foo %>" }
-        it { expect(subject).to eq file }
+        it { expect(subject).to(eq(file)) }
       end
 
       context 'when a call argument is present that is not a trim' do
         let(:file) { "<% foo 1%>" }
-        it { expect(subject).to eq file }
+        it { expect(subject).to(eq(file)) }
       end
     end
   end

--- a/spec/erb_lint/linters/rubocop_spec.rb
+++ b/spec/erb_lint/linters/rubocop_spec.rb
@@ -207,12 +207,12 @@ describe ERBLint::Linters::Rubocop do
   context 'code is aligned to the column matching start of ruby code' do
     let(:linter_config) do
       described_class.config_schema.new(
-        only: ['Layout/AlignParameters'],
+        only: ['Layout/AlignArguments'],
         rubocop_config: {
           AllCops: {
             TargetRubyVersion: '2.4',
           },
-          'Layout/AlignParameters': {
+          'Layout/AlignArguments': {
             Enabled: true,
             EnforcedStyle: 'with_fixed_indentation',
             SupportedStyles: %w(with_first_parameter with_fixed_indentation),
@@ -244,8 +244,8 @@ describe ERBLint::Linters::Rubocop do
         expect(subject[0].source_range.source).to(eq("checked: true"))
         expect(subject[0].line_range).to(eq(2..2))
         expect(subject[0].message).to(\
-          eq("Layout/AlignParameters: Use one level of indentation for "\
-             "parameters following the first line of a multi-line method call.")
+          eq("Layout/AlignArguments: Use one level of indentation for "\
+             "arguments following the first line of a multi-line method call.")
         )
       end
     end

--- a/spec/erb_lint/linters/rubocop_spec.rb
+++ b/spec/erb_lint/linters/rubocop_spec.rb
@@ -25,7 +25,7 @@ describe ERBLint::Linters::Rubocop do
   let(:inherit_from_filename) { 'custom_rubocop.yml' }
   subject { offenses }
   before do
-    allow(file_loader).to receive(:yaml).with(inherit_from_filename).and_return(nested_config)
+    allow(file_loader).to(receive(:yaml).with(inherit_from_filename).and_return(nested_config))
   end
   before { linter.run(processed_source) }
 
@@ -36,7 +36,7 @@ describe ERBLint::Linters::Rubocop do
     let(:file) { <<~FILE }
       <% not_banned_method %>
     FILE
-    it { expect(subject).to eq [] }
+    it { expect(subject).to(eq([])) }
   end
 
   context 'when rubocop finds no offenses' do
@@ -44,7 +44,7 @@ describe ERBLint::Linters::Rubocop do
       <% not_banned_method %>
     FILE
 
-    it { expect(subject).to eq [] }
+    it { expect(subject).to(eq([])) }
   end
 
   context 'when rubocop encounters a erb comment' do
@@ -54,7 +54,7 @@ describe ERBLint::Linters::Rubocop do
       %>
     FILE
 
-    it { expect(subject).to eq [] }
+    it { expect(subject).to(eq([])) }
   end
 
   context 'when rubocop encounters a ruby comment' do
@@ -65,8 +65,8 @@ describe ERBLint::Linters::Rubocop do
       %>
     FILE
 
-    it { expect(subject).to eq [arbitrary_error_message(37..51)] }
-    it { expect(subject.first.source_range.source).to eq "auto_correct_me" }
+    it { expect(subject).to(eq([arbitrary_error_message(37..51)])) }
+    it { expect(subject.first.source_range.source).to(eq("auto_correct_me")) }
   end
 
   context 'when rubocop finds offenses in ruby statements' do
@@ -74,13 +74,13 @@ describe ERBLint::Linters::Rubocop do
       <% auto_correct_me %>
     FILE
 
-    it { expect(subject).to eq [arbitrary_error_message(3..17)] }
-    it { expect(subject.first.source_range.source).to eq "auto_correct_me" }
+    it { expect(subject).to(eq([arbitrary_error_message(3..17)])) }
+    it { expect(subject.first.source_range.source).to(eq("auto_correct_me")) }
 
     context 'when autocorrecting' do
       subject { corrected_content }
 
-      it { expect(subject).to eq "<% safe_method %>\n" }
+      it { expect(subject).to(eq("<% safe_method %>\n")) }
     end
   end
 
@@ -89,12 +89,12 @@ describe ERBLint::Linters::Rubocop do
       <%= auto_correct_me %>
     FILE
 
-    it { expect(subject).to eq [arbitrary_error_message(4..18)] }
+    it { expect(subject).to(eq([arbitrary_error_message(4..18)])) }
 
     context 'when autocorrecting' do
       subject { corrected_content }
 
-      it { expect(subject).to eq "<%= safe_method %>\n" }
+      it { expect(subject).to(eq("<%= safe_method %>\n")) }
     end
   end
 
@@ -108,18 +108,18 @@ describe ERBLint::Linters::Rubocop do
     FILE
 
     it 'finds offenses' do
-      expect(subject).to eq [
+      expect(subject).to(eq([
         arbitrary_error_message(3..17),
         arbitrary_error_message(25..39),
         arbitrary_error_message(47..61),
-      ]
+      ]))
     end
 
     context 'can autocorrect individual offenses' do
       let(:corrector) { ERBLint::Corrector.new(processed_source, [offenses.first]) }
       subject { corrected_content }
 
-      it { expect(subject).to eq <<~FILE }
+      it { expect(subject).to(eq(<<~FILE)) }
         <%
         safe_method(:foo)
         auto_correct_me(:bar)
@@ -136,7 +136,7 @@ describe ERBLint::Linters::Rubocop do
       <% end %>
     FILE
 
-    it { expect(subject).to eq [] }
+    it { expect(subject).to(eq([])) }
   end
 
   context 'statements with partial block expression is processed' do
@@ -146,12 +146,12 @@ describe ERBLint::Linters::Rubocop do
       <% end %>
     FILE
 
-    it { expect(subject).to eq [arbitrary_error_message(3..17)] }
+    it { expect(subject).to(eq([arbitrary_error_message(3..17)])) }
 
     context 'when autocorrecting' do
       subject { corrected_content }
 
-      it { expect(subject).to eq <<~FILE }
+      it { expect(subject).to(eq(<<~FILE)) }
         <% safe_method.each do %>
           foo
         <% end %>
@@ -170,8 +170,8 @@ describe ERBLint::Linters::Rubocop do
       </div>
     FILE
 
-    it { expect(subject).to eq [arbitrary_error_message(29..43)] }
-    it { expect(subject.first.source_range.source).to eq "auto_correct_me" }
+    it { expect(subject).to(eq([arbitrary_error_message(29..43)])) }
+    it { expect(subject.first.source_range.source).to(eq("auto_correct_me")) }
   end
 
   context 'supports loading nested config' do
@@ -200,7 +200,7 @@ describe ERBLint::Linters::Rubocop do
         <% auto_correct_me %>
       FILE
 
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
   end
 
@@ -228,7 +228,7 @@ describe ERBLint::Linters::Rubocop do
              checked: true %>
       FILE
 
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
 
     context 'when alignment is incorrect' do
@@ -238,14 +238,15 @@ describe ERBLint::Linters::Rubocop do
       FILE
 
       it do
-        expect(subject.size).to eq(1)
-        expect(subject[0].source_range.begin_pos).to eq 25
-        expect(subject[0].source_range.end_pos).to eq 38
-        expect(subject[0].source_range.source).to eq "checked: true"
-        expect(subject[0].line_range).to eq 2..2
-        expect(subject[0].message).to \
-          eq "Layout/AlignParameters: Use one level of indentation for "\
-             "parameters following the first line of a multi-line method call."
+        expect(subject.size).to(eq(1))
+        expect(subject[0].source_range.begin_pos).to(eq(25))
+        expect(subject[0].source_range.end_pos).to(eq(38))
+        expect(subject[0].source_range.source).to(eq("checked: true"))
+        expect(subject[0].line_range).to(eq(2..2))
+        expect(subject[0].message).to(\
+          eq("Layout/AlignParameters: Use one level of indentation for "\
+             "parameters following the first line of a multi-line method call.")
+        )
       end
     end
 
@@ -255,7 +256,7 @@ describe ERBLint::Linters::Rubocop do
                          checked: true %>
       FILE
 
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
   end
 
@@ -264,7 +265,7 @@ describe ERBLint::Linters::Rubocop do
       <% dont_auto_correct_me(auto_correct_me(dont_auto_correct_me)) %>
     FILE
 
-    it { expect(corrected_content).to eq "<% dont_auto_correct_me(safe_method(dont_auto_correct_me)) %>\n" }
+    it { expect(corrected_content).to(eq("<% dont_auto_correct_me(safe_method(dont_auto_correct_me)) %>\n")) }
   end
 
   private

--- a/spec/erb_lint/linters/rubocop_text_spec.rb
+++ b/spec/erb_lint/linters/rubocop_text_spec.rb
@@ -27,7 +27,7 @@ describe ERBLint::Linters::RubocopText do
       <span class="<%= auto_correct_me %>"></span>
     FILE
 
-    it { expect(subject).to eq [] }
+    it { expect(subject).to(eq([])) }
   end
 
   context 'when rubocop find offenses inside erb text node' do
@@ -35,7 +35,7 @@ describe ERBLint::Linters::RubocopText do
       <span> <%= auto_correct_me %> </span>
     FILE
 
-    it { expect(subject).to eq [arbitrary_error_message(11..25)] }
+    it { expect(subject).to(eq([arbitrary_error_message(11..25)])) }
   end
 
   context 'when rubocop does not find offenses inside erb text node' do
@@ -43,7 +43,7 @@ describe ERBLint::Linters::RubocopText do
       <span> <%= not_banned_method %> </span>
     FILE
 
-    it { expect(subject).to eq [] }
+    it { expect(subject).to(eq([])) }
   end
 
   private

--- a/spec/erb_lint/linters/self_closing_tag_spec.rb
+++ b/spec/erb_lint/linters/self_closing_tag_spec.rb
@@ -21,39 +21,39 @@ describe ERBLint::Linters::SelfClosingTag do
 
       context 'when an element is not a void element' do
         let(:file) { "<a></a/>" }
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
 
       context 'when a void element is #self-closed' do
         let(:file) { "<br/>" }
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
 
       context 'when a void element is not #self_closing?' do
         let(:file) { "<br>" }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(3..2, "Tag `br` is self-closing, it must end with `/>`."),
-          ]
+          ]))
         end
       end
 
       context 'when a void element is #closing? and #self_closing?' do
         let(:file) { "</br/>" }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(1..1, "Tag `br` is a void element, it must not start with `</`."),
-          ]
+          ]))
         end
       end
 
       context 'when an element is #closing?' do
         let(:file) { "</br>" }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(1..1, "Tag `br` is a void element, it must not start with `</`."),
             build_offense(4..3, "Tag `br` is self-closing, it must end with `/>`."),
-          ]
+          ]))
         end
       end
     end
@@ -63,39 +63,39 @@ describe ERBLint::Linters::SelfClosingTag do
 
       context 'when an element is not a void element' do
         let(:file) { "<a></a/>" }
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
 
       context 'when a void element is #self-closed' do
         let(:file) { "<br/>" }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(3..3, "Tag `br` is a void element, it must end with `>` and not `/>`."),
-          ]
+          ]))
         end
       end
 
       context 'when a void element is not #self_closing?' do
         let(:file) { "<br>" }
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
 
       context 'when a void element is #closing? and #self_closing?' do
         let(:file) { "</br/>" }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(1..1, "Tag `br` is a void element, it must not start with `</`."),
             build_offense(4..4, "Tag `br` is a void element, it must end with `>` and not `/>`."),
-          ]
+          ]))
         end
       end
 
       context 'when an element is #closing?' do
         let(:file) { "</br>" }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(1..1, "Tag `br` is a void element, it must not start with `</`."),
-          ]
+          ]))
         end
       end
     end
@@ -109,27 +109,27 @@ describe ERBLint::Linters::SelfClosingTag do
 
       context 'when an element is not self-closing' do
         let(:file) { "<a></a/>" }
-        it { expect(subject).to eq file }
+        it { expect(subject).to(eq(file)) }
       end
 
       context 'when an element is self-closed' do
         let(:file) { "<br/>" }
-        it { expect(subject).to eq file }
+        it { expect(subject).to(eq(file)) }
       end
 
       context 'when an element is not #self_closing?' do
         let(:file) { "<br>" }
-        it { expect(subject).to eq "<br/>" }
+        it { expect(subject).to(eq("<br/>")) }
       end
 
       context 'when an element is #closing? and #self_closing?' do
         let(:file) { "</br/>" }
-        it { expect(subject).to eq "<br/>" }
+        it { expect(subject).to(eq("<br/>")) }
       end
 
       context 'when an element is #closing?' do
         let(:file) { "</br>" }
-        it { expect(subject).to eq "<br/>" }
+        it { expect(subject).to(eq("<br/>")) }
       end
     end
 
@@ -138,27 +138,27 @@ describe ERBLint::Linters::SelfClosingTag do
 
       context 'when an element is not self-closing' do
         let(:file) { "<a></a/>" }
-        it { expect(subject).to eq file }
+        it { expect(subject).to(eq(file)) }
       end
 
       context 'when an element is self-closed' do
         let(:file) { "<br/>" }
-        it { expect(subject).to eq "<br>" }
+        it { expect(subject).to(eq("<br>")) }
       end
 
       context 'when an element is not #self_closing?' do
         let(:file) { "<br>" }
-        it { expect(subject).to eq file }
+        it { expect(subject).to(eq(file)) }
       end
 
       context 'when an element is #closing? and #self_closing?' do
         let(:file) { "</br/>" }
-        it { expect(subject).to eq "<br>" }
+        it { expect(subject).to(eq("<br>")) }
       end
 
       context 'when an element is #closing?' do
         let(:file) { "</br>" }
-        it { expect(subject).to eq "<br>" }
+        it { expect(subject).to(eq("<br>")) }
       end
     end
   end

--- a/spec/erb_lint/linters/space_around_erb_tag_spec.rb
+++ b/spec/erb_lint/linters/space_around_erb_tag_spec.rb
@@ -18,17 +18,17 @@ describe ERBLint::Linters::SpaceAroundErbTag do
 
     context 'when space is correct' do
       let(:file) { "<% foo %>" }
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
 
     context 'for escaped erb tag' do
       let(:file) { "this is text <%%=text %> not erb\n" }
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
 
     context 'for erb comment' do
       let(:file) { "this is text <%#comment %> not erb\n" }
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
 
     context 'when tag starts with a newline' do
@@ -37,84 +37,84 @@ describe ERBLint::Linters::SpaceAroundErbTag do
           foo
         %>
       ERB
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
 
     context 'when tag contains extra spaces and newlines' do
       let(:file) { "<%  \n  foo  \n %>" }
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
 
     context 'when tag contains extra spaces and multiple newlines' do
       let(:file) { "<%  \n\n\n  foo  \n\n\n %>" }
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(2..8, "Use 1 newline after `<%` instead of 3."),
           build_offense(12..17, "Use 1 newline before `%>` instead of 3."),
-        ]
+        ]))
       end
     end
 
     context 'when space is missing on the left of statement' do
       let(:file) { "<%foo %>" }
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(2..1, "Use 1 space after `<%` instead of 0 space."),
-        ]
+        ]))
       end
     end
 
     context 'when space is missing on the left of expression' do
       let(:file) { "<%=foo %>" }
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(3..2, "Use 1 space after `<%=` instead of 0 space."),
-        ]
+        ]))
       end
     end
 
     context 'when space is missing on the left of statement with trim' do
       let(:file) { "<%-foo %>" }
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(3..2, "Use 1 space after `<%-` instead of 0 space."),
-        ]
+        ]))
       end
     end
 
     context 'when more than 1 space on the left' do
       let(:file) { "<%  foo %>" }
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(2..3, "Use 1 space after `<%` instead of 2 spaces."),
-        ]
+        ]))
       end
     end
 
     context 'when space is missing on the right' do
       let(:file) { "<% foo%>" }
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(6..5, "Use 1 space before `%>` instead of 0 space."),
-        ]
+        ]))
       end
     end
 
     context 'when space is missing on the right with trim' do
       let(:file) { "<% foo-%>" }
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(6..5, "Use 1 space before `-%>` instead of 0 space."),
-        ]
+        ]))
       end
     end
 
     context 'when more than 1 space on the right' do
       let(:file) { "<% foo   %>" }
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(6..8, "Use 1 space before `%>` instead of 3 space."),
-        ]
+        ]))
       end
     end
   end
@@ -124,7 +124,7 @@ describe ERBLint::Linters::SpaceAroundErbTag do
 
     context 'when space is correct' do
       let(:file) { "<% foo %>" }
-      it { expect(subject).to eq file }
+      it { expect(subject).to(eq(file)) }
     end
 
     context 'when tag starts with a newline' do
@@ -133,52 +133,52 @@ describe ERBLint::Linters::SpaceAroundErbTag do
           foo
         %>
       ERB
-      it { expect(subject).to eq file }
+      it { expect(subject).to(eq(file)) }
     end
 
     context 'when tag contains extra spaces and newlines' do
       let(:file) { "<%  \n  foo  \n %>" }
-      it { expect(subject).to eq file }
+      it { expect(subject).to(eq(file)) }
     end
 
     context 'when tag contains extra spaces and multiple newlines' do
       let(:file) { "<%  \n\n\n  foo  \n\n\n %>" }
-      it { expect(subject).to eq "<%  \n  foo  \n %>" }
+      it { expect(subject).to(eq("<%  \n  foo  \n %>")) }
     end
 
     context 'when space is missing on the left of statement' do
       let(:file) { "<%foo %>" }
-      it { expect(subject).to eq "<% foo %>" }
+      it { expect(subject).to(eq("<% foo %>")) }
     end
 
     context 'when space is missing on the left of expression' do
       let(:file) { "<%=foo %>" }
-      it { expect(subject).to eq "<%= foo %>" }
+      it { expect(subject).to(eq("<%= foo %>")) }
     end
 
     context 'when space is missing on the left of statement with trim' do
       let(:file) { "<%-foo %>" }
-      it { expect(subject).to eq "<%- foo %>" }
+      it { expect(subject).to(eq("<%- foo %>")) }
     end
 
     context 'when more than 1 space on the left' do
       let(:file) { "<%  foo %>" }
-      it { expect(subject).to eq "<% foo %>" }
+      it { expect(subject).to(eq("<% foo %>")) }
     end
 
     context 'when space is missing on the right' do
       let(:file) { "<% foo%>" }
-      it { expect(subject).to eq "<% foo %>" }
+      it { expect(subject).to(eq("<% foo %>")) }
     end
 
     context 'when space is missing on the right with trim' do
       let(:file) { "<% foo-%>" }
-      it { expect(subject).to eq "<% foo -%>" }
+      it { expect(subject).to(eq("<% foo -%>")) }
     end
 
     context 'when more than 1 space on the right' do
       let(:file) { "<% foo   %>" }
-      it { expect(subject).to eq "<% foo %>" }
+      it { expect(subject).to(eq("<% foo %>")) }
     end
   end
 

--- a/spec/erb_lint/linters/space_in_html_tag_spec.rb
+++ b/spec/erb_lint/linters/space_in_html_tag_spec.rb
@@ -19,42 +19,42 @@ describe ERBLint::Linters::SpaceInHtmlTag do
     context 'when space is correct' do
       context 'plain opening tag' do
         let(:file) { "<div>" }
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
 
       context 'self-closing tag without attributes' do
         let(:file) { "<img />" }
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
 
       context 'closing tag' do
         let(:file) { "</div>" }
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
 
       context 'tag with no name' do
         let(:file) { "</>" }
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
 
       context 'empty tag' do
         let(:file) { "<>" }
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
 
       context 'plain tag with attribute' do
         let(:file) { '<div class="foo">' }
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
 
       context 'self-closing tag with attribute' do
         let(:file) { '<input class="foo" />' }
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
 
       context 'between attributes' do
         let(:file) { '<input class="foo" name="bar" />' }
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
 
       context 'multi-line tag' do
@@ -63,14 +63,14 @@ describe ERBLint::Linters::SpaceInHtmlTag do
             type="password"
             class="foo" />
         HTML
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
 
       context 'tag with erb' do
         let(:file) { <<~HTML }
           <input <%= attributes %> />
         HTML
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
 
       context 'multi-line tag with erb' do
@@ -80,7 +80,7 @@ describe ERBLint::Linters::SpaceInHtmlTag do
             <%= attributes %>
             class="foo" />
         HTML
-        it { expect(subject).to eq [] }
+        it { expect(subject).to(eq([])) }
       end
     end
 
@@ -88,63 +88,63 @@ describe ERBLint::Linters::SpaceInHtmlTag do
       context 'after name' do
         let(:file) { "<div   >" }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(4..6, "Extra space detected where there should be no space."),
-          ]
+          ]))
         end
       end
 
       context 'before name' do
         let(:file) { "<   div>" }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(1..3, "Extra space detected where there should be no space."),
-          ]
+          ]))
         end
       end
 
       context 'before start solidus' do
         let(:file) { "<   /div>" }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(1..3, "Extra space detected where there should be no space."),
-          ]
+          ]))
         end
       end
 
       context 'after start solidus' do
         let(:file) { "</   div>" }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(2..4, "Extra space detected where there should be no space."),
-          ]
+          ]))
         end
       end
 
       context 'after end solidus' do
         let(:file) { "<div /   >" }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(6..8, "Extra space detected where there should be no space."),
-          ]
+          ]))
         end
       end
 
       context 'between attribute name and equal' do
         let(:file) { "<div foo  ='bar'>" }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(8..9, "Extra space detected where there should be no space."),
-          ]
+          ]))
         end
       end
 
       context 'between attribute equal and value' do
         let(:file) { "<div foo=  'bar'>" }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(9..10, "Extra space detected where there should be no space."),
-          ]
+          ]))
         end
       end
     end
@@ -153,30 +153,30 @@ describe ERBLint::Linters::SpaceInHtmlTag do
       context 'between attributes' do
         let(:file) { "<div foo='foo'bar='bar'>" }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(14..13, "No space detected where there should be "\
               "a single space."),
-          ]
+          ]))
         end
       end
 
       context 'between last attribute and solidus' do
         let(:file) { "<div foo='bar'/>" }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(14..13, "No space detected where there should be "\
               "a single space."),
-          ]
+          ]))
         end
       end
 
       context 'between name and solidus' do
         let(:file) { "<div/>" }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(4..3, "No space detected where there should be "\
               "a single space."),
-          ]
+          ]))
         end
       end
     end
@@ -185,59 +185,59 @@ describe ERBLint::Linters::SpaceInHtmlTag do
       context 'between name and end of tag' do
         let(:file) { "<div  >" }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(4..5, "Extra space detected where there should be no space."),
-          ]
+          ]))
         end
       end
 
       context 'between name and first attribute' do
         let(:file) { '<img   class="hide">' }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(4..6, "Extra space detected where there should be "\
               "a single space."),
-          ]
+          ]))
         end
       end
 
       context 'between name and end solidus' do
         let(:file) { "<br   />" }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(3..5, "Extra space detected where there should be "\
               "a single space."),
-          ]
+          ]))
         end
       end
 
       context 'between last attribute and solidus' do
         let(:file) { '<br class="hide"   />' }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(16..18, "Extra space detected where there should be "\
               "a single space."),
-          ]
+          ]))
         end
       end
 
       context 'between last attribute and end of tag' do
         let(:file) { '<img class="hide"    >' }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(17..20, "Extra space detected where there should be "\
               "no space."),
-          ]
+          ]))
         end
       end
 
       context 'between attributes' do
         let(:file) { "<div foo='foo'      bar='bar'>" }
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(14..19, "Extra space detected where there should be "\
               "a single space."),
-          ]
+          ]))
         end
       end
 
@@ -248,10 +248,10 @@ describe ERBLint::Linters::SpaceInHtmlTag do
             type="password" />
         HTML
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(6..9, "Extra space detected where there should be "\
               "a single space or a single line break."),
-          ]
+          ]))
         end
       end
 
@@ -262,10 +262,10 @@ describe ERBLint::Linters::SpaceInHtmlTag do
             />
         HTML
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(6..9, "Extra space detected where there should be "\
               "a single space."),
-          ]
+          ]))
         end
       end
 
@@ -277,10 +277,10 @@ describe ERBLint::Linters::SpaceInHtmlTag do
             class="foo" />
         HTML
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(24..27, "Extra space detected where there should be "\
               "a single space or a single line break."),
-          ]
+          ]))
         end
       end
 
@@ -292,10 +292,10 @@ describe ERBLint::Linters::SpaceInHtmlTag do
             />
         HTML
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(38..40, "Extra space detected where there should be "\
               "a single space."),
-          ]
+          ]))
         end
       end
 
@@ -307,10 +307,10 @@ describe ERBLint::Linters::SpaceInHtmlTag do
             >
         HTML
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(38..40, "Extra space detected where there should be "\
               "no space."),
-          ]
+          ]))
         end
       end
 
@@ -319,9 +319,9 @@ describe ERBLint::Linters::SpaceInHtmlTag do
           <input/class="hide" />
         HTML
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(6..6, 'Non-whitespace character(s) detected: "/".'),
-          ]
+          ]))
         end
       end
 
@@ -330,9 +330,9 @@ describe ERBLint::Linters::SpaceInHtmlTag do
           <input class="hide"/name="foo" />
         HTML
         it do
-          expect(subject).to eq [
+          expect(subject).to(eq([
             build_offense(19..19, 'Non-whitespace character(s) detected: "/".'),
-          ]
+          ]))
         end
       end
     end
@@ -344,37 +344,37 @@ describe ERBLint::Linters::SpaceInHtmlTag do
     context 'when space is correct' do
       context 'plain opening tag' do
         let(:file) { "<div>" }
-        it { expect(subject).to eq file }
+        it { expect(subject).to(eq(file)) }
       end
 
       context 'self-closing tag without attributes' do
         let(:file) { "<img />" }
-        it { expect(subject).to eq file }
+        it { expect(subject).to(eq(file)) }
       end
 
       context 'closing tag' do
         let(:file) { "</div>" }
-        it { expect(subject).to eq file }
+        it { expect(subject).to(eq(file)) }
       end
 
       context 'tag with no name' do
         let(:file) { "</>" }
-        it { expect(subject).to eq file }
+        it { expect(subject).to(eq(file)) }
       end
 
       context 'plain tag with attribute' do
         let(:file) { '<div class="foo">' }
-        it { expect(subject).to eq file }
+        it { expect(subject).to(eq(file)) }
       end
 
       context 'self-closing tag with attribute' do
         let(:file) { '<input class="foo" />' }
-        it { expect(subject).to eq file }
+        it { expect(subject).to(eq(file)) }
       end
 
       context 'between attributes' do
         let(:file) { '<input class="foo" name="bar" />' }
-        it { expect(subject).to eq file }
+        it { expect(subject).to(eq(file)) }
       end
 
       context 'multi-line tag' do
@@ -383,7 +383,7 @@ describe ERBLint::Linters::SpaceInHtmlTag do
             type="password"
             class="foo" />
         HTML
-        it { expect(subject).to eq file }
+        it { expect(subject).to(eq(file)) }
       end
 
       context 'escaped <%%= tag' do
@@ -392,98 +392,98 @@ describe ERBLint::Linters::SpaceInHtmlTag do
             <%%= content_for :application_stylesheets, stylesheet_link_tag('application') %>
           <%- end -%>
         ERB
-        it { expect(subject).to eq file }
+        it { expect(subject).to(eq(file)) }
       end
     end
 
     context 'when no space should be present' do
       context 'after name' do
         let(:file) { "<div   >" }
-        it { expect(subject).to eq "<div>" }
+        it { expect(subject).to(eq("<div>")) }
       end
 
       context 'before name' do
         let(:file) { "<   div>" }
-        it { expect(subject).to eq "<div>" }
+        it { expect(subject).to(eq("<div>")) }
       end
 
       context 'before start solidus' do
         let(:file) { "<   /div>" }
-        it { expect(subject).to eq "</div>" }
+        it { expect(subject).to(eq("</div>")) }
       end
 
       context 'after start solidus' do
         let(:file) { "</   div>" }
-        it { expect(subject).to eq "</div>" }
+        it { expect(subject).to(eq("</div>")) }
       end
 
       context 'after end solidus' do
         let(:file) { "<div/   >" }
-        it { expect(subject).to eq "<div />" }
+        it { expect(subject).to(eq("<div />")) }
       end
 
       context 'between attribute name and equal' do
         let(:file) { "<div foo  ='bar'>" }
-        it { expect(subject).to eq "<div foo='bar'>" }
+        it { expect(subject).to(eq("<div foo='bar'>")) }
       end
 
       context 'between attribute equal and value' do
         let(:file) { "<div foo=  'bar'>" }
-        it { expect(subject).to eq "<div foo='bar'>" }
+        it { expect(subject).to(eq("<div foo='bar'>")) }
       end
     end
 
     context 'when space is missing' do
       context 'between attributes' do
         let(:file) { "<div foo='foo'bar='bar'>" }
-        it { expect(subject).to eq "<div foo='foo' bar='bar'>" }
+        it { expect(subject).to(eq("<div foo='foo' bar='bar'>")) }
       end
 
       context 'between last attribute and solidus' do
         let(:file) { "<div foo='bar'/>" }
-        it { expect(subject).to eq "<div foo='bar' />" }
+        it { expect(subject).to(eq("<div foo='bar' />")) }
       end
 
       context 'between name and solidus' do
         let(:file) { "<div/>" }
-        it { expect(subject).to eq "<div />" }
+        it { expect(subject).to(eq("<div />")) }
       end
     end
 
     context 'when extra space is present' do
       context 'between name and end of tag' do
         let(:file) { "<div  >" }
-        it { expect(subject).to eq "<div>" }
+        it { expect(subject).to(eq("<div>")) }
       end
 
       context 'between name and first attribute' do
         let(:file) { "<div  >" }
-        it { expect(subject).to eq "<div>" }
+        it { expect(subject).to(eq("<div>")) }
       end
 
       context 'between name and first attribute' do
         let(:file) { '<img   class="hide">' }
-        it { expect(subject).to eq '<img class="hide">' }
+        it { expect(subject).to(eq('<img class="hide">')) }
       end
 
       context 'between name and end solidus' do
         let(:file) { "<br   />" }
-        it { expect(subject).to eq "<br />" }
+        it { expect(subject).to(eq("<br />")) }
       end
 
       context 'between last attribute and solidus' do
         let(:file) { '<br class="hide"   />' }
-        it { expect(subject).to eq '<br class="hide" />' }
+        it { expect(subject).to(eq('<br class="hide" />')) }
       end
 
       context 'between last attribute and end of tag' do
         let(:file) { '<img class="hide"    >' }
-        it { expect(subject).to eq '<img class="hide">' }
+        it { expect(subject).to(eq('<img class="hide">')) }
       end
 
       context 'between attributes' do
         let(:file) { "<div foo='foo'      bar='bar'>" }
-        it { expect(subject).to eq "<div foo='foo' bar='bar'>" }
+        it { expect(subject).to(eq("<div foo='foo' bar='bar'>")) }
       end
 
       context 'extra newline between name and first attribute' do
@@ -492,7 +492,7 @@ describe ERBLint::Linters::SpaceInHtmlTag do
 
             type="password" />
         HTML
-        it { expect(subject).to eq <<~HTML }
+        it { expect(subject).to(eq(<<~HTML)) }
           <input
             type="password" />
         HTML
@@ -504,7 +504,7 @@ describe ERBLint::Linters::SpaceInHtmlTag do
 
             />
         HTML
-        it { expect(subject).to eq <<~HTML }
+        it { expect(subject).to(eq(<<~HTML)) }
           <input />
         HTML
       end
@@ -516,7 +516,7 @@ describe ERBLint::Linters::SpaceInHtmlTag do
 
             class="foo" />
         HTML
-        it { expect(subject).to eq <<~HTML }
+        it { expect(subject).to(eq(<<~HTML)) }
           <input
             type="password"
             class="foo" />
@@ -530,7 +530,7 @@ describe ERBLint::Linters::SpaceInHtmlTag do
             class="foo"
             />
         HTML
-        it { expect(subject).to eq <<~HTML }
+        it { expect(subject).to(eq(<<~HTML)) }
           <input
             type="password"
             class="foo" />
@@ -544,7 +544,7 @@ describe ERBLint::Linters::SpaceInHtmlTag do
             class="foo"
             >
         HTML
-        it { expect(subject).to eq <<~HTML }
+        it { expect(subject).to(eq(<<~HTML)) }
           <input
             type="password"
             class="foo">
@@ -555,7 +555,7 @@ describe ERBLint::Linters::SpaceInHtmlTag do
         let(:file) { <<~HTML }
           <input/class="hide" />
         HTML
-        it { expect(subject).to eq <<~HTML }
+        it { expect(subject).to(eq(<<~HTML)) }
           <input class="hide" />
         HTML
       end
@@ -564,7 +564,7 @@ describe ERBLint::Linters::SpaceInHtmlTag do
         let(:file) { <<~HTML }
           <input class="hide"/name="foo" />
         HTML
-        it { expect(subject).to eq <<~HTML }
+        it { expect(subject).to(eq(<<~HTML)) }
           <input class="hide" name="foo" />
         HTML
       end

--- a/spec/erb_lint/linters/space_indentation_spec.rb
+++ b/spec/erb_lint/linters/space_indentation_spec.rb
@@ -18,31 +18,31 @@ describe ERBLint::Linters::SpaceIndentation do
 
     context 'no indentation present' do
       let(:file) { "this is a line" }
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
 
     context 'space indentation present' do
       let(:file) { "   this is a line\n   another line\n" }
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
 
     context 'tab indentation' do
       let(:file) { "\t\tthis is a line\n\t\tanother line\n" }
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(0..1, "Indent with spaces instead of tabs."),
           build_offense(17..18, "Indent with spaces instead of tabs."),
-        ]
+        ]))
       end
     end
 
     context 'tab and spaces indentation' do
       let(:file) { "  \t    this is a line\n  \t  another line\n" }
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(0..6, "Indent with spaces instead of tabs."),
           build_offense(22..26, "Indent with spaces instead of tabs."),
-        ]
+        ]))
       end
     end
   end
@@ -52,30 +52,30 @@ describe ERBLint::Linters::SpaceIndentation do
 
     context 'no indentation present' do
       let(:file) { "this is a line" }
-      it { expect(subject).to eq file }
+      it { expect(subject).to(eq(file)) }
     end
 
     context 'space indentation present' do
       let(:file) { "   this is a line\n   another line\n" }
-      it { expect(subject).to eq file }
+      it { expect(subject).to(eq(file)) }
     end
 
     context 'tab indentation' do
       let(:file) { "\tthis is a line\n\tanother line\n" }
 
       context 'with default tab width' do
-        it { expect(subject).to eq "  this is a line\n  another line\n" }
+        it { expect(subject).to(eq("  this is a line\n  another line\n")) }
       end
 
       context 'with custom tab width' do
         let(:linter_config) { described_class.config_schema.new(tab_width: 4) }
-        it { expect(subject).to eq "    this is a line\n    another line\n" }
+        it { expect(subject).to(eq("    this is a line\n    another line\n")) }
       end
     end
 
     context 'tab and spaces indentation' do
       let(:file) { "  \t    this is a line\n  \t  another line\n" }
-      it { expect(subject).to eq "        this is a line\n      another line\n" }
+      it { expect(subject).to(eq("        this is a line\n      another line\n")) }
     end
   end
 

--- a/spec/erb_lint/linters/trailing_whitespace_spec.rb
+++ b/spec/erb_lint/linters/trailing_whitespace_spec.rb
@@ -18,42 +18,42 @@ describe ERBLint::Linters::TrailingWhitespace do
 
     context 'when no trailing space is present' do
       let(:file) { "a perfect line\n" }
-      it { expect(subject).to eq [] }
+      it { expect(subject).to(eq([])) }
     end
 
     context 'when a trailing space is present at end of file' do
       let(:file) { "a not so perfect line    " }
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(21..24, "Extra whitespace detected at end of line."),
-        ]
+        ]))
       end
     end
 
     context 'when a trailing space before newline' do
       let(:file) { "a not so perfect line    \n" }
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(21..24, "Extra whitespace detected at end of line."),
-        ]
+        ]))
       end
     end
 
     context 'when tabs are present' do
       let(:file) { "a not so perfect line  \t\r\t  \n" }
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(21..27, "Extra whitespace detected at end of line."),
-        ]
+        ]))
       end
     end
 
     context 'when spaces are alone on a line' do
       let(:file) { "a line\n       \nanother line\n" }
       it do
-        expect(subject).to eq [
+        expect(subject).to(eq([
           build_offense(7..13, "Extra whitespace detected at end of line."),
-        ]
+        ]))
       end
     end
   end
@@ -63,27 +63,27 @@ describe ERBLint::Linters::TrailingWhitespace do
 
     context 'when no trailing space is present' do
       let(:file) { "a perfect line\n" }
-      it { expect(subject).to eq file }
+      it { expect(subject).to(eq(file)) }
     end
 
     context 'when a trailing space is present at end of file' do
       let(:file) { "a not so perfect line    " }
-      it { expect(subject).to eq "a not so perfect line" }
+      it { expect(subject).to(eq("a not so perfect line")) }
     end
 
     context 'when a trailing space before newline' do
       let(:file) { "a not so perfect line    \n" }
-      it { expect(subject).to eq "a not so perfect line\n" }
+      it { expect(subject).to(eq("a not so perfect line\n")) }
     end
 
     context 'when tabs are present' do
       let(:file) { "a not so perfect line  \t\r\t  \n" }
-      it { expect(subject).to eq "a not so perfect line\n" }
+      it { expect(subject).to(eq("a not so perfect line\n")) }
     end
 
     context 'when spaces are alone on a line' do
       let(:file) { "a line\n\nanother line\n" }
-      it { expect(subject).to eq file }
+      it { expect(subject).to(eq(file)) }
     end
   end
 

--- a/spec/erb_lint/runner_config_spec.rb
+++ b/spec/erb_lint/runner_config_spec.rb
@@ -7,11 +7,11 @@ describe ERBLint::RunnerConfig do
     subject(:runner_config) { described_class.default }
 
     it 'returns expected class' do
-      expect(subject.class).to be(described_class)
+      expect(subject.class).to(be(described_class))
     end
 
     it 'has FinalNewline enabled' do
-      expect(subject.for_linter('FinalNewline').enabled?).to be(true)
+      expect(subject.for_linter('FinalNewline').enabled?).to(be(true))
     end
   end
 
@@ -24,13 +24,13 @@ describe ERBLint::RunnerConfig do
       context 'with empty hash' do
         let(:config_hash) { {} }
 
-        it { expect(subject).to eq({}) }
+        it { expect(subject).to(eq({})) }
       end
 
       context 'with custom data' do
         let(:config_hash) { { foo: true } }
 
-        it { expect(subject).to eq('foo' => true) }
+        it { expect(subject).to(eq('foo' => true)) }
       end
     end
 
@@ -45,42 +45,42 @@ describe ERBLint::RunnerConfig do
       end
 
       before do
-        allow(ERBLint::LinterRegistry).to receive(:linters)
-          .and_return([ERBLint::Linters::FinalNewline, MyCustomLinter])
+        allow(ERBLint::LinterRegistry).to(receive(:linters)
+          .and_return([ERBLint::Linters::FinalNewline, MyCustomLinter]))
       end
 
       context 'with string argument' do
         let(:linter) { 'MyCustomLinter' }
         let(:config_hash) { { linters: { 'MyCustomLinter' => { 'my_option' => 'custom value' } } } }
 
-        it { expect(subject.class).to eq(MyCustomLinter::MySchema) }
-        it { expect(subject['my_option']).to eq('custom value') }
+        it { expect(subject.class).to(eq(MyCustomLinter::MySchema)) }
+        it { expect(subject['my_option']).to(eq('custom value')) }
       end
 
       context 'with class argument' do
         let(:linter) { MyCustomLinter }
         let(:config_hash) { { linters: { 'MyCustomLinter' => { my_option: 'custom value' } } } }
 
-        it { expect(subject.class).to eq(MyCustomLinter::MySchema) }
+        it { expect(subject.class).to(eq(MyCustomLinter::MySchema)) }
       end
 
       context 'with argument that isnt a string and does not inherit from Linter' do
         let(:linter) { Object }
         let(:config_hash) { { linters: { 'MyCustomLinter' => { my_option: 'custom value' } } } }
 
-        it { expect { subject }.to raise_error(ArgumentError, "expected String or linter class") }
+        it { expect { subject }.to(raise_error(ArgumentError, "expected String or linter class")) }
       end
 
       context 'for linter not present in config hash' do
         let(:linter) { 'FinalNewline' }
         let(:config_hash) {}
 
-        it { expect(subject.class).to eq(ERBLint::Linters::FinalNewline::ConfigSchema) }
+        it { expect(subject.class).to(eq(ERBLint::Linters::FinalNewline::ConfigSchema)) }
         it 'fills linter config with defaults from schema' do
-          expect(subject.to_hash).to eq("enabled" => false, "exclude" => [], "present" => true)
+          expect(subject.to_hash).to(eq("enabled" => false, "exclude" => [], "present" => true))
         end
         it 'is disabled by default' do
-          expect(subject.enabled?).to eq(false)
+          expect(subject.enabled?).to(eq(false))
         end
       end
 
@@ -98,7 +98,7 @@ describe ERBLint::RunnerConfig do
         end
 
         it 'excluded files are merged' do
-          expect(subject.exclude).to eq(['foo/bar.rb', '**/node_modules/**'])
+          expect(subject.exclude).to(eq(['foo/bar.rb', '**/node_modules/**']))
         end
       end
     end
@@ -109,24 +109,24 @@ describe ERBLint::RunnerConfig do
       subject { first_config.merge(second_config) }
 
       context 'creates a new object' do
-        it { expect(subject.class).to be(described_class) }
-        it { expect(subject).to_not be(first_config) }
-        it { expect(subject).to_not be(second_config) }
+        it { expect(subject.class).to(be(described_class)) }
+        it { expect(subject).to_not(be(first_config)) }
+        it { expect(subject).to_not(be(second_config)) }
       end
 
       context 'new object has keys from both configs' do
-        it { expect(subject.to_hash).to eq('foo' => 1, 'bar' => 2) }
+        it { expect(subject.to_hash).to(eq('foo' => 1, 'bar' => 2)) }
       end
 
       context 'second object overwrites keys from first object' do
         let(:second_config) { described_class.new(foo: 42) }
-        it { expect(subject.to_hash).to eq('foo' => 42) }
+        it { expect(subject.to_hash).to(eq('foo' => 42)) }
       end
 
       context 'performs a deep merge' do
         let(:first_config) { described_class.new(nested: { foo: 1 }) }
         let(:second_config) { described_class.new(nested: { bar: 2 }) }
-        it { expect(subject.to_hash).to eq('nested' => { 'foo' => 1, 'bar' => 2 }) }
+        it { expect(subject.to_hash).to(eq('nested' => { 'foo' => 1, 'bar' => 2 })) }
       end
     end
 
@@ -136,22 +136,22 @@ describe ERBLint::RunnerConfig do
       subject { first_config.merge!(second_config) }
 
       context 'returns first object' do
-        it { expect(subject).to be(first_config) }
+        it { expect(subject).to(be(first_config)) }
       end
 
       context 'first object has keys from both configs' do
-        it { expect(subject.to_hash).to eq('foo' => 1, 'bar' => 2) }
+        it { expect(subject.to_hash).to(eq('foo' => 1, 'bar' => 2)) }
       end
 
       context 'second object overwrites keys from first object' do
         let(:second_config) { described_class.new(foo: 42) }
-        it { expect(subject.to_hash).to eq('foo' => 42) }
+        it { expect(subject.to_hash).to(eq('foo' => 42)) }
       end
 
       context 'performs a deep merge' do
         let(:first_config) { described_class.new(nested: { foo: 1 }) }
         let(:second_config) { described_class.new(nested: { bar: 2 }) }
-        it { expect(subject.to_hash).to eq('nested' => { 'foo' => 1, 'bar' => 2 }) }
+        it { expect(subject.to_hash).to(eq('nested' => { 'foo' => 1, 'bar' => 2 })) }
       end
     end
 
@@ -170,8 +170,8 @@ describe ERBLint::RunnerConfig do
         gem_class = Struct.new(:gem_dir)
         %w(gemone).each do |gem_name|
           mock_spec = gem_class.new(File.join(gem_root, gem_name))
-          expect(Gem::Specification).to receive(:find_by_name)
-            .at_least(:once).with(gem_name).and_return(mock_spec)
+          expect(Gem::Specification).to(receive(:find_by_name)
+            .at_least(:once).with(gem_name).and_return(mock_spec))
         end
 
         runner_config = described_class.new({
@@ -180,7 +180,7 @@ describe ERBLint::RunnerConfig do
           },
         }, ERBLint::FileLoader.new(Dir.pwd))
 
-        expect(runner_config.to_hash['MyCustomLinter']).to eq("my_option" => "custom value")
+        expect(runner_config.to_hash['MyCustomLinter']).to(eq("my_option" => "custom value"))
       end
 
       it "inherits from a gem and merges the config" do
@@ -193,8 +193,8 @@ describe ERBLint::RunnerConfig do
         gem_class = Struct.new(:gem_dir)
         %w(gemone).each do |gem_name|
           mock_spec = gem_class.new(File.join(gem_root, gem_name))
-          expect(Gem::Specification).to receive(:find_by_name)
-            .at_least(:once).with(gem_name).and_return(mock_spec)
+          expect(Gem::Specification).to(receive(:find_by_name)
+            .at_least(:once).with(gem_name).and_return(mock_spec))
         end
 
         runner_config = described_class.new({
@@ -211,8 +211,8 @@ describe ERBLint::RunnerConfig do
         }, ERBLint::FileLoader.new(Dir.pwd))
 
         config_hash = runner_config.to_hash
-        expect(config_hash['MyCustomLinter1']).to eq("a" => "value for a", "b" => "value for b", "c" => "value for c")
-        expect(config_hash['MyCustomLinter2']).to eq("d" => "value for d")
+        expect(config_hash['MyCustomLinter1']).to(eq("a" => "value for a", "b" => "value for b", "c" => "value for c"))
+        expect(config_hash['MyCustomLinter2']).to(eq("d" => "value for d"))
       end
 
       it "inherits from a file and merges the config" do
@@ -234,8 +234,8 @@ describe ERBLint::RunnerConfig do
         }, ERBLint::FileLoader.new(Dir.pwd))
 
         config_hash = runner_config.to_hash
-        expect(config_hash['MyCustomLinter1']).to eq("a" => "value for a", "b" => "value for b", "c" => "value for c")
-        expect(config_hash['MyCustomLinter2']).to eq("d" => "value for d")
+        expect(config_hash['MyCustomLinter1']).to(eq("a" => "value for a", "b" => "value for b", "c" => "value for c"))
+        expect(config_hash['MyCustomLinter2']).to(eq("d" => "value for d"))
       end
 
       it "does not inherit from a file if file loader is not provided" do
@@ -257,8 +257,8 @@ describe ERBLint::RunnerConfig do
         )
 
         config_hash = runner_config.to_hash
-        expect(config_hash['MyCustomLinter1']).to eq("a" => "value for a", "c" => "value for c")
-        expect(config_hash['MyCustomLinter2']).to eq("d" => "value for d")
+        expect(config_hash['MyCustomLinter1']).to(eq("a" => "value for a", "c" => "value for c"))
+        expect(config_hash['MyCustomLinter2']).to(eq("d" => "value for d"))
       end
 
       it "inherits from a gem if file load is not provided" do
@@ -270,8 +270,8 @@ describe ERBLint::RunnerConfig do
         gem_class = Struct.new(:gem_dir)
         %w(gemone).each do |gem_name|
           mock_spec = gem_class.new(File.join(gem_root, gem_name))
-          expect(Gem::Specification).to receive(:find_by_name)
-            .at_least(:once).with(gem_name).and_return(mock_spec)
+          expect(Gem::Specification).to(receive(:find_by_name)
+            .at_least(:once).with(gem_name).and_return(mock_spec))
         end
 
         runner_config = described_class.new(
@@ -280,7 +280,7 @@ describe ERBLint::RunnerConfig do
           },
         )
 
-        expect(runner_config.to_hash).to eq({})
+        expect(runner_config.to_hash).to(eq({}))
       end
     end
   end
@@ -291,7 +291,7 @@ describe ERBLint::RunnerConfig do
     file_path = File.expand_path(file_path)
 
     dir_path = File.dirname(file_path)
-    FileUtils.makedirs dir_path unless File.exist?(dir_path)
+    FileUtils.makedirs(dir_path) unless File.exist?(dir_path)
 
     File.open(file_path, 'w') do |file|
       case content

--- a/spec/erb_lint/runner_spec.rb
+++ b/spec/erb_lint/runner_spec.rb
@@ -7,10 +7,10 @@ describe ERBLint::Runner do
   let(:runner) { described_class.new(file_loader, config) }
 
   before do
-    allow(ERBLint::LinterRegistry).to receive(:linters)
+    allow(ERBLint::LinterRegistry).to(receive(:linters)
       .and_return([ERBLint::Linters::FakeLinter1,
                    ERBLint::Linters::FakeLinter2,
-                   ERBLint::Linters::FinalNewline])
+                   ERBLint::Linters::FinalNewline]))
   end
 
   module ERBLint
@@ -42,11 +42,11 @@ describe ERBLint::Runner do
       end
 
       it 'returns each linter with their errors' do
-        expect(subject.size).to eq(2)
-        expect(subject[0].linter.class).to eq(ERBLint::Linters::FakeLinter1)
-        expect(subject[0].message).to eq("ERBLint::Linters::FakeLinter1 error")
-        expect(subject[1].linter.class).to eq(ERBLint::Linters::FakeLinter2)
-        expect(subject[1].message).to eq("ERBLint::Linters::FakeLinter2 error")
+        expect(subject.size).to(eq(2))
+        expect(subject[0].linter.class).to(eq(ERBLint::Linters::FakeLinter1))
+        expect(subject[0].message).to(eq("ERBLint::Linters::FakeLinter1 error"))
+        expect(subject[1].linter.class).to(eq(ERBLint::Linters::FakeLinter2))
+        expect(subject[1].message).to(eq("ERBLint::Linters::FakeLinter2 error"))
       end
     end
 
@@ -61,9 +61,9 @@ describe ERBLint::Runner do
       end
 
       it 'returns only enabled linters with their errors' do
-        expect(subject.size).to eq(1)
-        expect(subject[0].linter.class).to eq(ERBLint::Linters::FakeLinter1)
-        expect(subject[0].message).to eq("ERBLint::Linters::FakeLinter1 error")
+        expect(subject.size).to(eq(1))
+        expect(subject[0].linter.class).to(eq(ERBLint::Linters::FakeLinter1))
+        expect(subject[0].message).to(eq("ERBLint::Linters::FakeLinter1 error"))
       end
     end
 
@@ -78,7 +78,7 @@ describe ERBLint::Runner do
       end
 
       it 'returns no linters' do
-        expect(subject).to be_empty
+        expect(subject).to(be_empty)
       end
     end
 
@@ -93,7 +93,7 @@ describe ERBLint::Runner do
       end
 
       it 'returns no linters' do
-        expect(subject).to be_empty
+        expect(subject).to(be_empty)
       end
     end
 
@@ -101,7 +101,7 @@ describe ERBLint::Runner do
       let(:config) { ERBLint::RunnerConfig.new }
 
       it 'has all linters disabled' do
-        expect(subject).to eq []
+        expect(subject).to(eq([]))
       end
     end
 
@@ -109,9 +109,9 @@ describe ERBLint::Runner do
       let(:config) { nil }
 
       it 'returns default linters with their errors' do
-        expect(subject.size).to eq(1)
-        expect(subject[0].linter.class).to eq(ERBLint::Linters::FinalNewline)
-        expect(subject[0].message).to eq("Missing a trailing newline at the end of the file.")
+        expect(subject.size).to(eq(1))
+        expect(subject[0].linter.class).to(eq(ERBLint::Linters::FinalNewline))
+        expect(subject[0].message).to(eq("Missing a trailing newline at the end of the file."))
       end
     end
 
@@ -127,7 +127,7 @@ describe ERBLint::Runner do
 
       it 'clears all offenses from the offenses ivar' do
         runner.clear_offenses
-        expect(subject).to eq []
+        expect(subject).to(eq([]))
       end
     end
   end

--- a/spec/file_loader_spec.rb
+++ b/spec/file_loader_spec.rb
@@ -10,12 +10,12 @@ describe ERBLint::FileLoader do
   subject(:yaml) { file_loader.yaml(filename) }
 
   before do
-    allow(File).to receive(:read).with("#{base_path}/#{filename}").and_return yaml_content
+    allow(File).to(receive(:read).with("#{base_path}/#{filename}").and_return(yaml_content))
   end
 
   describe '.yaml' do
     context "it reads the file from disk" do
-      it { expect(subject).to eq('my_yaml_config' => 123) }
+      it { expect(subject).to(eq('my_yaml_config' => 123)) }
     end
 
     context "it allows regexp to be loaded" do
@@ -24,7 +24,7 @@ describe ERBLint::FileLoader do
         some_config:
           - !ruby/regexp /\\Afoo/i
       YAML
-      it { expect(subject).to eq('some_config' => [/\Afoo/i]) }
+      it { expect(subject).to(eq('some_config' => [/\Afoo/i])) }
     end
 
     context "it allows symbol to be loaded" do
@@ -32,7 +32,7 @@ describe ERBLint::FileLoader do
         ---
         :some_config: :symbol
       YAML
-      it { expect(subject).to eq(some_config: :symbol) }
+      it { expect(subject).to(eq(some_config: :symbol)) }
     end
 
     context "it does not allow other objects to be loaded" do
@@ -42,7 +42,7 @@ describe ERBLint::FileLoader do
           - !ruby/array:Array
             - fooo
       YAML
-      it { expect { subject }.to raise_exception(Psych::DisallowedClass) }
+      it { expect { subject }.to(raise_exception(Psych::DisallowedClass)) }
     end
   end
 end


### PR DESCRIPTION
Update rubocop to 0.72, autocorrect rubocop offences, and fix failing test.

Closes #128
Closes #129
