### PR TITLE
Remove special handling of `inherit_from`

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -17,10 +17,11 @@ module ERBLint
     class ExitWithSuccess < RuntimeError; end
 
     class Stats
-      attr_accessor :found, :corrected
+      attr_accessor :found, :corrected, :exceptions
       def initialize
         @found = 0
         @corrected = 0
+        @exceptions = 0
       end
     end
 
@@ -57,7 +58,10 @@ module ERBLint
         begin
           run_with_corrections(filename)
         rescue => e
+          @stats.exceptions += 1
           puts "Exception occured when processing: #{relative_filename(filename)}"
+          puts "If this file cannot be processed by erb-lint, "\
+            "you can exclude it in your configuration file."
           puts e.message
           puts Rainbow(e.backtrace.join("\n")).red
           puts
@@ -79,7 +83,7 @@ module ERBLint
         puts Rainbow("No errors were found in ERB files").green
       end
 
-      @stats.found == 0
+      @stats.found == 0 && @stats.exceptions == 0
     rescue OptionParser::InvalidOption, OptionParser::InvalidArgument, ExitWithFailure => e
       warn(Rainbow(e.message).red)
       false

--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -98,7 +98,7 @@ module ERBLint
     end
 
     def run_with_corrections(filename)
-      file_content = File.read(filename)
+      file_content = File.read(filename, encoding: Encoding::UTF_8)
 
       runner = ERBLint::Runner.new(file_loader, @config)
 

--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -108,10 +108,8 @@ module ERBLint
         if @only_cops.present?
           selected_cops = RuboCop::Cop::Cop.all.select { |cop| cop.match?(@only_cops) }
           RuboCop::Cop::Registry.new(selected_cops)
-        elsif @rubocop_config['Rails']['Enabled']
-          RuboCop::Cop::Registry.new(RuboCop::Cop::Cop.all)
         else
-          RuboCop::Cop::Cop.non_rails
+          RuboCop::Cop::Registry.new(RuboCop::Cop::Cop.all)
         end
       end
 
@@ -127,34 +125,9 @@ module ERBLint
       end
 
       def config_from_hash(hash)
-        inherit_from = hash&.delete('inherit_from')
-        resolve_inheritance(hash, inherit_from)
-
         tempfile_from('.erblint-rubocop', hash.to_yaml) do |tempfile|
           RuboCop::ConfigLoader.load_file(tempfile.path)
         end
-      end
-
-      def resolve_inheritance(hash, inherit_from)
-        base_configs(inherit_from)
-          .reverse_each do |base_config|
-          base_config.each do |k, v|
-            hash[k] = hash.key?(k) ? RuboCop::ConfigLoader.merge(v, hash[k]) : v if v.is_a?(Hash)
-          end
-        end
-      end
-
-      def base_configs(inherit_from)
-        regex = URI::DEFAULT_PARSER.make_regexp(%w(http https))
-        configs = Array(inherit_from).compact.map do |base_name|
-          if base_name =~ /\A#{regex}\z/
-            RuboCop::ConfigLoader.load_file(RuboCop::RemoteConfig.new(base_name, Dir.pwd))
-          else
-            config_from_hash(@file_loader.yaml(base_name))
-          end
-        end
-
-        configs.compact
       end
 
       def add_offense(rubocop_offense, offense_range, correction, offset, bound_range)


### PR DESCRIPTION
Remove override for `inherit_from` which does not seem to be needed anymore, and don't check for `@rubocop_config['Rails']['Enabled']` because of the new rubocop version.