### PR TITLE
Allow relative path for excluded files

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -178,7 +178,8 @@ module ERBLint
 
     def excluded?(filename)
       @config.global_exclude.any? do |path|
-        File.fnmatch?(path, filename)
+        expanded_path = File.expand_path(path, Dir.pwd)
+        File.fnmatch?(expanded_path, filename)
       end
     end
 

--- a/spec/erb_lint/cli_spec.rb
+++ b/spec/erb_lint/cli_spec.rb
@@ -149,6 +149,21 @@ describe ERBLint::CLI do
             expect(subject).to(be(true))
           end
         end
+
+        context 'with excluded relative file in config file' do
+          let(:config_file) { '.exclude.yml' }
+          let(:config_file_content) { "exclude:\n  - app/views/template.html.erb" }
+          let(:args) { ['--config', config_file, '--enable-linter', 'linter_with_errors,final_newline', linted_file] }
+
+          before do
+            FileUtils.mkdir_p(File.dirname(config_file))
+            File.write(config_file, config_file_content)
+          end
+
+          it 'is successful' do
+            expect(subject).to(be(true))
+          end
+        end
       end
     end
 


### PR DESCRIPTION
This piece of code fix some part of the #87
To be totally honest, I wrote the code before reading @EiNSTeiN- 's advice to add  `**/` at the beginning of your glob.