### PR TITLE
remove special case for globally disabled rails cops

### DIFF
--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -108,10 +108,8 @@ module ERBLint
         if @only_cops.present?
           selected_cops = RuboCop::Cop::Cop.all.select { |cop| cop.match?(@only_cops) }
           RuboCop::Cop::Registry.new(selected_cops)
-        elsif @rubocop_config['Rails']['Enabled']
-          RuboCop::Cop::Registry.new(RuboCop::Cop::Cop.all)
         else
-          RuboCop::Cop::Cop.non_rails
+          RuboCop::Cop::Registry.new(RuboCop::Cop::Cop.all)
         end
       end
 


### PR DESCRIPTION
This breaks badly when there is no global enable option for all rails cops

I am not sure what this is good for, but there is apparently no test for it.