### PR TITLE
Update default glob to allow linting of js.erb and text.erb files

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -11,7 +11,7 @@ require 'rainbow'
 module ERBLint
   class CLI
     DEFAULT_CONFIG_FILENAME = '.erb-lint.yml'
-    DEFAULT_LINT_ALL_GLOB = "**/*.html{+*,}.erb"
+    DEFAULT_LINT_ALL_GLOB = "**/*.{html,js,text}{+*,}.erb"
 
     class ExitWithFailure < RuntimeError; end
     class ExitWithSuccess < RuntimeError; end


### PR DESCRIPTION
The default glob for erb files currently ignores `js.erb` and `text.erb` files. This change will allow those files to also be linted.

https://guides.rubyonrails.org/working_with_javascript_in_rails.html
https://docs.ruby-lang.org/en/2.2.0/ERB.html#class-ERB-label-Plain+Text