### PR TITLE
Configurable glob

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ This gem provides a command-line interface which can be run like so:
 For example, `erblint --lint-all --enable-all-linters` will run all available
 linters on all ERB files in the current directory or its descendants (`**/*.html{+*,}.erb`).
 
+If you want to change the glob that is used, you can configure it by adding it to your config file as follows:
+
+```yaml
+---
+glob: "**/*.{html,text,js}{+*,}.erb"
+linters:
+  ErbSafety:
+    enabled: true
+    better_html_config: .better-html.yml
+  Rubocop:
+    enabled: true
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
+```
+
 ## Enable or disable default linters
 `EnableDefaultLinters`: enables or disables default linters. [Default linters](#Linters) are enabled by default.
 

--- a/spec/erb_lint/cli_spec.rb
+++ b/spec/erb_lint/cli_spec.rb
@@ -152,6 +152,33 @@ describe ERBLint::CLI do
       end
     end
 
+    context 'with --lint-all as argument' do
+      let(:args) { ['--lint-all', '--enable-linter', 'linter_with_errors,final_newline'] }
+      context 'when a file exists' do
+        let(:linted_file) { 'app/views/template.html.erb' }
+        let(:file_content) { "this is a fine file" }
+
+        before do
+          FileUtils.mkdir_p(File.dirname(linted_file))
+          File.write(linted_file, file_content)
+        end
+
+        context "with the default glob" do
+          it 'shows how many files and linters are used' do
+            allow(cli).to(receive(:glob).and_return(cli.class::DEFAULT_LINT_ALL_GLOB))
+            expect { subject }.to(output(/Linting 1 files with 2 linters/).to_stdout)
+          end
+        end
+
+        context "with a custom glob that does not match any files" do
+          it 'shows no files or linters' do
+            allow(cli).to(receive(:glob).and_return("no/file/glob"))
+            expect { subject }.to(output(/no files found/).to_stderr)
+          end
+        end
+      end
+    end
+
     context 'with dir as argument' do
       context 'when dir does not exist' do
         let(:linted_dir) { '/path/to' }


### PR DESCRIPTION
### The problem

Per [the readme file](https://github.com/Shopify/erb-lint/blob/3a2ee22877d2361ff2591b4f17a52430eecd496e/README.md#usage):

> `erblint --lint-all --enable-all-linters` will run all available linters on all ERB files in the current directory or its descendants `(**/*.html{+*,}.erb)`.

Unfortunately this glob does not encompass all ERB files for some projects. Notably, `.text.erb` and `.js.erb` files will not be linted.

### The culprit
[The relevant code](https://github.com/Shopify/erb-lint/blob/3a2ee22877d2361ff2591b4f17a52430eecd496e/lib/erb_lint/cli.rb#L14) is found in `cli.rb`.

The glob is defined as a class constant with no configuration possible.

### The solution
This PR changes the class constant to a private method. The private method first attempts to load a glob from [the configuration file](https://github.com/Shopify/erb-lint/tree/3a2ee22877d2361ff2591b4f17a52430eecd496e#configuration), if that fails it falls back on the existing default of `**/*.html{+*,}.erb`.

