### PR TITLE
Test renamed cops

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ This gem provides a command-line interface which can be run like so:
 For example, `erblint --lint-all --enable-all-linters` will run all available
 linters on all ERB files in the current directory or its descendants (`**/*.html{+*,}.erb`).
 
+If you want to change the glob that is used, you can configure it by adding it to your config file as follows:
+
+```yaml
+---
+glob: **/*.{html,text,js}{+*,}.erb
+linters:
+  ErbSafety:
+    enabled: true
+    better_html_config: .better-html.yml
+  Rubocop:
+    enabled: true
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
+```
+
 ## Available linters
 
 `erb-lint` comes with linters on-board:


### PR DESCRIPTION
Seeing some strange behaviour on CI, hoping this will test for the presence of these errors:
```     
RuboCop::ValidationError:
       The `Layout/AlignArguments` cop has been renamed to `Layout/ArgumentAlignment`.
       (obsolete configuration found in .erblint-rubocop20191204-16421-1ulkne4, please update it)
```