### PR TITLE
Add option to disable default linters

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -149,7 +149,7 @@ module ERBLint
     def load_config
       if File.exist?(config_filename)
         config = RunnerConfig.new(file_loader.yaml(config_filename), file_loader)
-        @config = RunnerConfig.default.merge(config)
+        @config = RunnerConfig.default_for(config)
       else
         warn(Rainbow("#{config_filename} not found: using default config").yellow)
         @config = RunnerConfig.default

--- a/lib/erb_lint/runner_config.rb
+++ b/lib/erb_lint/runner_config.rb
@@ -45,23 +45,29 @@ module ERBLint
     end
 
     class << self
-      def default
+      def default(default_enabled: nil)
+        default_enabled = default_enabled.nil? ? true : default_enabled
         new(
           linters: {
-            AllowedScriptType: { enabled: true },
-            ClosingErbTagIndent: { enabled: true },
-            ExtraNewline: { enabled: true },
-            FinalNewline: { enabled: true },
-            NoJavascriptTagHelper: { enabled: true },
-            ParserErrors: { enabled: true },
-            RightTrim: { enabled: true },
-            SelfClosingTag: { enabled: true },
-            SpaceAroundErbTag: { enabled: true },
-            SpaceIndentation: { enabled: true },
-            SpaceInHtmlTag: { enabled: true },
-            TrailingWhitespace: { enabled: true },
+            AllowedScriptType: { enabled: default_enabled },
+            ClosingErbTagIndent: { enabled: default_enabled },
+            ExtraNewline: { enabled: default_enabled },
+            FinalNewline: { enabled: default_enabled },
+            NoJavascriptTagHelper: { enabled: default_enabled },
+            ParserErrors: { enabled: default_enabled },
+            RightTrim: { enabled: default_enabled },
+            SelfClosingTag: { enabled: default_enabled },
+            SpaceAroundErbTag: { enabled: default_enabled },
+            SpaceIndentation: { enabled: default_enabled },
+            SpaceInHtmlTag: { enabled: default_enabled },
+            TrailingWhitespace: { enabled: default_enabled },
           },
         )
+      end
+
+      def default_for(config)
+        default_linters_enabled = config.to_hash.dig("EnableDefaultLinters")
+        default(default_enabled: default_linters_enabled).merge(config)
       end
     end
 

--- a/spec/erb_lint/runner_config_spec.rb
+++ b/spec/erb_lint/runner_config_spec.rb
@@ -4,14 +4,63 @@ require 'spec_helper'
 
 describe ERBLint::RunnerConfig do
   describe '.default' do
-    subject(:runner_config) { described_class.default }
-
     it 'returns expected class' do
-      expect(subject.class).to(be(described_class))
+      expect(described_class.default.class).to(be(described_class))
     end
 
-    it 'has FinalNewline enabled' do
-      expect(subject.for_linter('FinalNewline').enabled?).to(be(true))
+    it 'has default linters enabled' do
+      expect(described_class.default.for_linter('FinalNewline').enabled?).to(be(true))
+    end
+
+    it 'disables default linters if asked to do so' do
+      expect(
+        described_class
+          .default(default_enabled: false)
+          .for_linter('FinalNewline').enabled?
+      ).to(be(false))
+    end
+  end
+
+  describe '.default_for' do
+    let(:enabled_default_linters) do
+      described_class.default(default_enabled: true)
+    end
+
+    let(:disabled_default_linters) do
+      described_class.default(default_enabled: false)
+    end
+
+    context 'without EnableDefaultLinters option' do
+      let(:config_hash) do
+        { foo: true }.deep_stringify_keys
+      end
+
+      subject { described_class.default_for(config_hash) }
+      it 'enables the default linters' do
+        expect(subject.to_hash["linters"].to_json).to(eq(enabled_default_linters.to_hash["linters"].to_json))
+      end
+    end
+
+    context 'with EnableDefaultLinters option set to true' do
+      let(:config_hash) do
+        { "EnableDefaultLinters" => true }
+      end
+
+      subject { described_class.default_for(config_hash) }
+      it 'enables the default linters' do
+        expect(subject.to_hash["linters"].to_json).to(eq(enabled_default_linters.to_hash["linters"].to_json))
+      end
+    end
+
+    context 'with EnableDefaultLinters set to false' do
+      let(:config_hash) do
+        { "EnableDefaultLinters" => false }
+      end
+
+      subject { described_class.default_for(config_hash) }
+      it 'disables the default linters' do
+        expect(subject.to_hash["linters"].to_json).to(eq(disabled_default_linters.to_hash["linters"].to_json))
+      end
     end
   end
 


### PR DESCRIPTION
### Background 
Erblint has no option to disable the default linters that are enabled by default. To only enable one linter, one would have to explicitly disable all the default linters on erblint, which can be annoying to do. 

### Proposed Fix
This patch adds the option to disable the default linters through the `DefaultLintersEnabled` option. 

If `DefaultLintersEnabled` is set to false, then the default linters are disabled. This option is default to true (i.e. this patch does not introduce any behaviour change). 


Co-authored-by: Philip Müller <philip.mueller@shopify.com>