### PR TITLE
Stop erasing items in ARGV

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -33,8 +33,9 @@ module ERBLint
     end
 
     def run(args = ARGV)
-      load_options(args)
-      @files = args.dup
+      dupped_args = args.dup
+      load_options(dupped_args)
+      @files = dupped_args
 
       load_config
 


### PR DESCRIPTION
When running erb-lint, ARGV was being modified and all its items were being removed. This was causing issues when printing error messages with the original command that was run by users. This is happening because the code is modifying an object being passed by reference. Instead, this dups ARGV so it stays intact.

This fix would work also if `run` were called with any other `args` other than `ARGV` being passed in (ie. it it were called directly versus from the command-line).