### PR TITLE
Ensure custom linters are loaded at the same time as linters

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -169,6 +169,13 @@ module ERBLint
       option_parser.parse!(args)
     end
 
+    def load_linters
+      @load_linters ||= begin
+        ERBLint::LinterRegistry.load_custom_linters
+        ERBLint::LinterRegistry.linters
+      end
+    end
+
     def lint_files
       @lint_files ||=
         if @options[:lint_all]
@@ -211,7 +218,7 @@ module ERBLint
     end
 
     def known_linter_names
-      @known_linter_names ||= ERBLint::LinterRegistry.linters
+      @known_linter_names ||= load_linters
         .map(&:simple_name)
         .map(&:underscore)
     end
@@ -224,7 +231,7 @@ module ERBLint
     end
 
     def enabled_linter_classes
-      @enabled_linter_classes ||= ERBLint::LinterRegistry.linters
+      @enabled_linter_classes ||= load_linters
         .select { |klass| linter_can_run?(klass) && enabled_linter_names.include?(klass.simple_name.underscore) }
     end
 
@@ -239,7 +246,7 @@ module ERBLint
     def runner_config_override
       RunnerConfig.new(
         linters: {}.tap do |linters|
-          ERBLint::LinterRegistry.linters.map do |klass|
+          load_linters.map do |klass|
             linters[klass.simple_name] = { 'enabled' => enabled_linter_classes.include?(klass) }
           end
         end

--- a/spec/erb_lint/cli_spec.rb
+++ b/spec/erb_lint/cli_spec.rb
@@ -51,7 +51,11 @@ describe ERBLint::CLI do
         expect { subject }.to(output(/erblint \[options\] \[file1, file2, ...\]/).to_stderr)
       end
 
-      it 'shows all known linters in stderr' do
+      it 'runs load_custom_linters when showing all known linters in stderr' do
+        expect(ERBLint::LinterRegistry).to(receive(:load_custom_linters))
+
+        # Custom linters won't be loaded because we stub the return value of
+        # ERBLint::LinterRegistry.linters (Line 21-44).
         expect { subject }.to(output(
           /Known linters are: linter_with_errors, linter_without_errors, final_newline/
         ).to_stderr)


### PR DESCRIPTION
Closes #164 

This PR updates the CLI to also load the custom linters when the options are parsed. This prevents `not a valid linter name` errors when attempting to run `erb-lint` with a specific custom linter:

```
$ bundle exec erblint --enable-linters custom_linter --lint-all
custom_linter: not a valid linter name (rubocop, rubocop_text, parser_errors, space_around_erb_tag, space_in_html_tag, extra_newline, right_trim, erb_safety, trailing_whitespace, closing_erb_tag_indent, space_indentation, hard_coded_string, no_javascript_tag_helper, allowed_script_type, self_closing_tag, final_newline, deprecated_classes)
```

A lot of the "why" is detailed in #164, but this seemed like the shortest lift.