### PR TITLE
Ensure HtmlError class is available

### DIFF
--- a/lib/erb_lint/linters/no_javascript_tag_helper.rb
+++ b/lib/erb_lint/linters/no_javascript_tag_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'better_html/ast/node'
+require 'better_html'
 require 'better_html/test_helper/ruby_node'
 require 'erb_lint/utils/block_map'
 require 'erb_lint/utils/ruby_to_erb'


### PR DESCRIPTION
Avoids 'uninitialized constant BetterHtml::Parser::HtmlError' error in certain cases.