### PR TITLE
Require better_html for no javascript tag helper linter

### DIFF
--- a/lib/erb_lint/linters/no_javascript_tag_helper.rb
+++ b/lib/erb_lint/linters/no_javascript_tag_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'better_html'
 require 'better_html/ast/node'
 require 'better_html/test_helper/ruby_node'
 require 'erb_lint/utils/block_map'

--- a/spec/erb_lint/linters/no_javascript_tag_helper_spec.rb
+++ b/spec/erb_lint/linters/no_javascript_tag_helper_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'better_html'
 
 describe ERBLint::Linters::NoJavascriptTagHelper do
   let(:linter_config) { described_class.config_schema.new }


### PR DESCRIPTION
In order to preload required utils and prevent missed constants

Related to https://github.com/Shopify/better-html/pull/62