### PR TITLE
Remove YAML.safe_load warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     parallel (1.19.1)
-    parser (2.7.0.2)
+    parser (2.7.1.2)
       ast (~> 2.4.0)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)

--- a/lib/erb_lint/file_loader.rb
+++ b/lib/erb_lint/file_loader.rb
@@ -9,8 +9,14 @@ module ERBLint
       @base_path = base_path
     end
 
-    def yaml(filename)
-      YAML.safe_load(read_content(filename), [Regexp, Symbol], [], false, filename) || {}
+    if RUBY_VERSION >= "2.6"
+      def yaml(filename)
+        YAML.safe_load(read_content(filename), permitted_classes: [Regexp, Symbol], filename: filename) || {}
+      end
+    else
+      def yaml(filename)
+        YAML.safe_load(read_content(filename), [Regexp, Symbol], [], false, filename) || {}
+      end
     end
 
     private


### PR DESCRIPTION
`permitted_symbols: [], aliases: false` are the defaults so I just removed them.

https://ruby-doc.org/stdlib-2.7.1/libdoc/psych/rdoc/Psych.html#method-c-safe_load