### PR TITLE
Update linters to load custom linters 

### DIFF
--- a/lib/erb_lint/linter_registry.rb
+++ b/lib/erb_lint/linter_registry.rb
@@ -4,17 +4,20 @@ module ERBLint
   # Stores all linters available to the application.
   module LinterRegistry
     CUSTOM_LINTERS_DIR = '.erb-linters'
-    @linters = []
+    @loaded_linters = []
 
     class << self
-      attr_reader :linters
-
       def included(linter_class)
-        @linters << linter_class
+        @loaded_linters << linter_class
       end
 
       def find_by_name(name)
         linters.detect { |linter| linter.simple_name == name }
+      end
+
+      def linters
+        load_custom_linters
+        @loaded_linters
       end
 
       def load_custom_linters(directory = CUSTOM_LINTERS_DIR)

--- a/lib/erb_lint/linter_registry.rb
+++ b/lib/erb_lint/linter_registry.rb
@@ -16,8 +16,10 @@ module ERBLint
       end
 
       def linters
-        load_custom_linters
-        @loaded_linters
+        @linters ||= begin
+          load_custom_linters
+          @loaded_linters
+        end
       end
 
       def load_custom_linters(directory = CUSTOM_LINTERS_DIR)

--- a/lib/erb_lint/linter_registry.rb
+++ b/lib/erb_lint/linter_registry.rb
@@ -7,6 +7,10 @@ module ERBLint
     @loaded_linters = []
 
     class << self
+      def clear
+        @linters = nil
+      end
+
       def included(linter_class)
         @loaded_linters << linter_class
       end

--- a/lib/erb_lint/runner.rb
+++ b/lib/erb_lint/runner.rb
@@ -10,7 +10,6 @@ module ERBLint
       @config = config || RunnerConfig.default
       raise ArgumentError, 'expect `config` to be a RunnerConfig instance' unless @config.is_a?(RunnerConfig)
 
-      LinterRegistry.load_custom_linters
       linter_classes = LinterRegistry.linters.select { |klass| @config.for_linter(klass).enabled? }
       @linters = linter_classes.map do |linter_class|
         linter_class.new(@file_loader, @config.for_linter(linter_class))

--- a/spec/erb_lint/linter_registry_spec.rb
+++ b/spec/erb_lint/linter_registry_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper'
 
 describe ERBLint::LinterRegistry do
+  let(:custom_directory) { File.expand_path('../fixtures/linters', __FILE__) }
+
   context 'when including the LinterRegistry module' do
     after do
       described_class.linters.delete(FakeLinter)
@@ -15,11 +17,15 @@ describe ERBLint::LinterRegistry do
         end
       end.to(change { described_class.linters.count }.by(1))
     end
+
+    it 'adds custom linters to the set of registered linters' do
+      stub_const('ERBLint::LinterRegistry::CUSTOM_LINTERS_DIR', custom_directory)
+
+      expect(described_class.linters).to(include(ERBLint::Linters::CustomLinter))
+    end
   end
 
   describe '.load_custom_linters' do
-    let(:custom_directory) { File.expand_path('../fixtures/linters', __FILE__) }
-
     it 'adds the custom linter to the set of registered linters' do
       expect(described_class).to(receive(:require)
         .with(File.join(custom_directory, 'custom_linter.rb')).once)

--- a/spec/erb_lint/linter_registry_spec.rb
+++ b/spec/erb_lint/linter_registry_spec.rb
@@ -7,7 +7,7 @@ describe ERBLint::LinterRegistry do
 
   context 'when including the LinterRegistry module' do
     after do
-      described_class.linters.delete(FakeLinter)
+      described_class.clear
     end
 
     it 'adds the linter to the set of registered linters' do


### PR DESCRIPTION
Closes #164 

This PR builds on a suggestion by @etiennebarrie in [this PR](https://github.com/Shopify/erb-lint/pull/165).

The goal is to update the `linter_registry` so that it also loads the custom linters when the options are parsed. This prevents `not a valid linter name` errors when attempting to run `erb-lint` with a specific custom linter:

```
$ bundle exec erblint --enable-linters custom_linter --lint-all
custom_linter: not a valid linter name (rubocop, rubocop_text, parser_errors, space_around_erb_tag, space_in_html_tag, extra_newline, right_trim, erb_safety, trailing_whitespace, closing_erb_tag_indent, space_indentation, hard_coded_string, no_javascript_tag_helper, allowed_script_type, self_closing_tag, final_newline, deprecated_classes)
```

A lot of the "why" is detailed in #164, but this seemed like the shortest lift.