### PR TITLE
Rubocop v0.87+ compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 .bundle
 
 .rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml
+
+gemfiles/Gemfile*.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,4 +5,5 @@ AllCops:
   TargetRubyVersion: 2.4
   Exclude:
     - 'vendor/**/*'
+    - 'gemfiles/vendor/**/*'
   DisplayCopNames: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: ruby
-before_install:
-  - rm ./Gemfile.lock
 cache: bundler
 rvm:
   - 2.4.1
   - 2.5
   - 2.6
   - 2.7
+gemfile:
+- gemfiles/Gemfile.rubocop-old
+- gemfiles/Gemfile.rubocop-next
 script:
   - bundle exec rspec spec
   - bundle exec rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       activesupport
       better_html (~> 1.0.7)
       html_tokenizer
+      parser (>= 2.7.1.4)
       rainbow
       rubocop (~> 0.79)
       smart_properties
@@ -23,7 +24,7 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    ast (2.4.0)
+    ast (2.4.1)
     better_html (1.0.15)
       actionview (>= 4.0)
       activesupport (>= 4.0)
@@ -42,16 +43,16 @@ GEM
     i18n (1.8.1)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
-    loofah (2.5.0)
+    loofah (2.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mini_portile2 (2.4.0)
     minitest (5.13.0)
-    nokogiri (1.10.9)
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     parallel (1.19.1)
-    parser (2.7.1.2)
-      ast (~> 2.4.0)
+    parser (2.7.1.4)
+      ast (~> 2.4.1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)

--- a/erb_lint.gemspec
+++ b/erb_lint.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency('better_html', '~> 1.0.7')
   s.add_dependency('html_tokenizer')
   s.add_dependency('rubocop', '~> 0.79')
+  s.add_dependency('parser', '>= 2.7.1.4')
   s.add_dependency('activesupport')
   s.add_dependency('smart_properties')
   s.add_dependency('rainbow')

--- a/gemfiles/Gemfile.rubocop-next
+++ b/gemfiles/Gemfile.rubocop-next
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+eval_gemfile "../Gemfile"
+
+gem "rubocop", ">= 0.87"

--- a/gemfiles/Gemfile.rubocop-old
+++ b/gemfiles/Gemfile.rubocop-old
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+eval_gemfile "../Gemfile"
+
+gem "rubocop", "< 0.87"

--- a/lib/erb_lint.rb
+++ b/lib/erb_lint.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rubocop'
+
 require 'erb_lint/corrector'
 require 'erb_lint/file_loader'
 require 'erb_lint/linter_config'

--- a/lib/erb_lint/corrector.rb
+++ b/lib/erb_lint/corrector.rb
@@ -17,7 +17,7 @@ module ERBLint
     end
 
     def corrector
-      RuboCop::Cop::Corrector.new(@processed_source.source_buffer, corrections)
+      ::RuboCop::Cop::Corrector.new(@processed_source.source_buffer, corrections)
     end
 
     def diagnostics

--- a/lib/erb_lint/corrector.rb
+++ b/lib/erb_lint/corrector.rb
@@ -17,11 +17,22 @@ module ERBLint
     end
 
     def corrector
-      ::RuboCop::Cop::Corrector.new(@processed_source.source_buffer, corrections)
+      BASE.new(@processed_source.source_buffer, corrections)
     end
 
-    def diagnostics
-      corrector.diagnostics
+    if ::RuboCop::Version::STRING.to_f >= 0.87
+      require 'rubocop/cop/legacy/corrector'
+      BASE = ::RuboCop::Cop::Legacy::Corrector
+
+      def diagnostics
+        []
+      end
+    else
+      BASE = ::RuboCop::Cop::Corrector
+
+      def diagnostics
+        corrector.diagnostics
+      end
     end
   end
 end

--- a/lib/erb_lint/linters/hard_coded_string.rb
+++ b/lib/erb_lint/linters/hard_coded_string.rb
@@ -63,7 +63,7 @@ module ERBLint
         string = offense.source_range.source
         return unless (klass = load_corrector)
         return unless string.strip.length > 1
-        node = RuboCop::AST::StrNode.new(:str, [string])
+        node = ::RuboCop::AST::StrNode.new(:str, [string])
         corrector = klass.new(node, processed_source.filename, corrector_i18n_load_path, offense.source_range)
         corrector.autocorrect(tag_start: '<%= ', tag_end: ' %>')
       rescue MissingCorrector, MissingI18nLoadPath

--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -26,7 +26,7 @@ module ERBLint
         super
         @only_cops = @config.only
         custom_config = config_from_hash(@config.rubocop_config)
-        @rubocop_config = RuboCop::ConfigLoader.merge_with_default(custom_config, '')
+        @rubocop_config = ::RuboCop::ConfigLoader.merge_with_default(custom_config, '')
       end
 
       def run(processed_source)
@@ -97,7 +97,7 @@ module ERBLint
       end
 
       def rubocop_processed_source(content, filename)
-        RuboCop::ProcessedSource.new(
+        ::RuboCop::ProcessedSource.new(
           content,
           @rubocop_config.target_ruby_version,
           filename
@@ -106,15 +106,15 @@ module ERBLint
 
       def cop_classes
         if @only_cops.present?
-          selected_cops = RuboCop::Cop::Cop.all.select { |cop| cop.match?(@only_cops) }
-          RuboCop::Cop::Registry.new(selected_cops)
+          selected_cops = ::RuboCop::Cop::Cop.all.select { |cop| cop.match?(@only_cops) }
+          ::RuboCop::Cop::Registry.new(selected_cops)
         else
-          RuboCop::Cop::Registry.new(RuboCop::Cop::Cop.all)
+          ::RuboCop::Cop::Registry.new(::RuboCop::Cop::Cop.all)
         end
       end
 
       def build_team
-        RuboCop::Cop::Team.new(
+        ::RuboCop::Cop::Team.new(
           cop_classes,
           @rubocop_config,
           extra_details: true,
@@ -129,7 +129,7 @@ module ERBLint
         resolve_inheritance(hash, inherit_from)
 
         tempfile_from('.erblint-rubocop', hash.to_yaml) do |tempfile|
-          RuboCop::ConfigLoader.load_file(tempfile.path)
+          ::RuboCop::ConfigLoader.load_file(tempfile.path)
         end
       end
 
@@ -137,7 +137,7 @@ module ERBLint
         base_configs(inherit_from)
           .reverse_each do |base_config|
           base_config.each do |k, v|
-            hash[k] = hash.key?(k) ? RuboCop::ConfigLoader.merge(v, hash[k]) : v if v.is_a?(Hash)
+            hash[k] = hash.key?(k) ? ::RuboCop::ConfigLoader.merge(v, hash[k]) : v if v.is_a?(Hash)
           end
         end
       end
@@ -146,7 +146,7 @@ module ERBLint
         regex = URI::DEFAULT_PARSER.make_regexp(%w(http https))
         configs = Array(inherit_from).compact.map do |base_name|
           if base_name =~ /\A#{regex}\z/
-            RuboCop::ConfigLoader.load_file(RuboCop::RemoteConfig.new(base_name, Dir.pwd))
+            ::RuboCop::ConfigLoader.load_file(::RuboCop::RemoteConfig.new(base_name, Dir.pwd))
           else
             config_from_hash(@file_loader.yaml(base_name))
           end

--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -62,6 +62,7 @@ module ERBLint
         original_source = code_node.loc.source
         trimmed_source = original_source.sub(BLOCK_EXPR, '').sub(SUFFIX_EXPR, '')
         alignment_column = code_node.loc.column
+        offset = code_node.loc.begin_pos - alignment_column
         aligned_source = "#{' ' * alignment_column}#{trimmed_source}"
 
         source = rubocop_processed_source(aligned_source, processed_source.filename)
@@ -77,7 +78,6 @@ module ERBLint
               correction_offset += 1
             end
 
-            offset = code_node.loc.begin_pos - alignment_column
             offense_range = processed_source
               .to_source_range(rubocop_offense.location)
               .offset(offset)

--- a/lib/erb_lint/linters/rubocop_text.rb
+++ b/lib/erb_lint/linters/rubocop_text.rb
@@ -28,9 +28,9 @@ module ERBLint
       end
 
       def cop_classes
-        selected_cops = RuboCop::Cop::Cop.all.select { |cop| cop.match?(@only_cops) }
+        selected_cops = ::RuboCop::Cop::Cop.all.select { |cop| cop.match?(@only_cops) }
 
-        RuboCop::Cop::Registry.new(selected_cops)
+        ::RuboCop::Cop::Registry.new(selected_cops)
       end
     end
   end


### PR DESCRIPTION
Rubocop 0.87 is a prelude to 1.0 and introduces major refactoring of internal classes, some of which are used by `erb-lint`.

This PR maintains compatibility.

Note that this needs the very latest `parser` to use the new `TreeRewriter#import` feature.