### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ linters:
         - .rubocop.yml
       Layout/InitialIndentation:
         Enabled: false
-      Layout/TrailingBlankLines:
+      Layout/TrailingEmptyLines:
         Enabled: false
       Layout/TrailingWhitespace:
         Enabled: false


### PR DESCRIPTION
`Layout/TrailingBlankLines` was renamed to `Layout/TrailingEmptyLines` in v 0.77