### PR TITLE
separate test run for rubocop >= 0.87

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 .bundle
 
 .rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml
+
+gemfiles/Gemfile*.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,4 +5,5 @@ AllCops:
   TargetRubyVersion: 2.4
   Exclude:
     - 'vendor/**/*'
+    - 'gemfiles/vendor/**/*'
   DisplayCopNames: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: ruby
-before_install:
-  - rm ./Gemfile.lock
 cache: bundler
 rvm:
   - 2.4.1
   - 2.5
   - 2.6
   - 2.7
+gemfile:
+- gemfiles/Gemfile.rubocop-old
+- gemfiles/Gemfile.rubocop-next
 script:
   - bundle exec rspec spec
   - bundle exec rubocop

--- a/gemfiles/Gemfile.rubocop-next
+++ b/gemfiles/Gemfile.rubocop-next
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+eval_gemfile "../Gemfile"
+
+gem "rubocop", ">= 0.87"

--- a/gemfiles/Gemfile.rubocop-old
+++ b/gemfiles/Gemfile.rubocop-old
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+eval_gemfile "../Gemfile"
+
+gem "rubocop", "< 0.87"


### PR DESCRIPTION
This came up as a requirement in https://github.com/Shopify/erb-lint/pull/179#issuecomment-668793574