### PR TITLE
Rubocop version cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,4 @@ gemfile:
 - gemfiles/Gemfile.rubocop-next
 script:
   - bundle exec rspec spec
-  - bundle show rubocop
-  - bundle show rubocop-shopify
   - bundle exec rubocop

--- a/gemfiles/Gemfile.rubocop-next
+++ b/gemfiles/Gemfile.rubocop-next
@@ -2,7 +2,7 @@
 
 eval_gemfile "../Gemfile"
 
-gem "rubocop", ">= 0.87", "< 0.89"
+gem "rubocop", ">= 0.87"
 
-# most recent rubocop-shopify release (1.0.4) is not compatible with rubocop >= 0.87, but this unreleased version is
-gem "rubocop-shopify", git: "https://github.com/Shopify/ruby-style-guide.git", ref: "ee3b64392b09f7e8d8089a57c4e65f91c0594732"
+# latest rubocop-shopify release (1.0.4) is not compatible with rubocop 0.89, but this unreleased version is
+gem "rubocop-shopify", git: "https://github.com/Shopify/ruby-style-guide.git", ref: "1da32fee92427b3b04c0d1ede3f762889137a9e5"

--- a/lib/erb_lint/linter.rb
+++ b/lib/erb_lint/linter.rb
@@ -14,6 +14,7 @@ module ERBLint
       # `ERBLint::Linters::Foo.simple_name`          #=> "Foo"
       # `ERBLint::Linters::Compass::Bar.simple_name` #=> "Compass::Bar"
       def inherited(linter)
+        super
         linter.simple_name = if linter.name.start_with?('ERBLint::Linters::')
           name_parts = linter.name.split('::')
           name_parts[2..-1].join('::')


### PR DESCRIPTION
Use new rubocop-shopify that's compatible with rubocop 0.89