### PR TITLE
Update RuboCop cop name in documentation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ linters:
         - .rubocop.yml
       Layout/InitialIndentation:
         Enabled: false
+      Layout/LineLength:
+        Enabled: false
       Layout/TrailingEmptyLines:
         Enabled: false
       Layout/TrailingWhitespace:
@@ -212,8 +214,6 @@ linters:
       Naming/FileName:
         Enabled: false
       Style/FrozenStringLiteralComment:
-        Enabled: false
-      Metrics/LineLength:
         Enabled: false
       Lint/UselessAssignment:
         Enabled: false


### PR DESCRIPTION
Without this change, erb-lint outputs `Metrics/LineLength has the wrong namespace - should be Layout` when using the configuration given as an example in the README.