### PR TITLE
Add --prevent-empty-failure flag

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -42,6 +42,10 @@ module ERBLint
       if !@files.empty? && lint_files.empty?
         failure!("no files found...\n")
       elsif lint_files.empty?
+        if @options[:prevent_empty_failure]
+          success!('No files found or given, skipping because "--prevent-empty-failure" flag was passed')
+        end
+
         failure!("no files found or given, specify files or config...\n#{option_parser}")
       end
 
@@ -278,6 +282,10 @@ module ERBLint
 
         opts.on("-a", "--autocorrect", "Correct offenses automatically if possible (default: false)") do |config|
           @options[:autocorrect] = config
+        end
+
+        opts.on("--prevent-empty-failure", "Skip the linter check if no files match the given glob [default: #{DEFAULT_LINT_ALL_GLOB}]") do
+          @options[:prevent_empty_failure] = true
         end
 
         opts.on_tail("-h", "--help", "Show this message") do

--- a/spec/erb_lint/cli_spec.rb
+++ b/spec/erb_lint/cli_spec.rb
@@ -273,6 +273,19 @@ describe ERBLint::CLI do
       end
     end
 
+    context 'with --prevent-empty-failure' do
+      let(:args) { ['--prevent-empty-failure'] }
+
+      context 'when there are no files' do
+        before do
+          allow(cli).to(receive(:glob).and_return("no/file/glob"))
+        end
+
+        it { expect { subject }.not_to output(/no files found/).to_stderr }
+        it { expect { subject }.to output(/No files found or given, skipping because "--prevent-empty-failure" flag was passed/).to_stdout }
+      end
+    end
+
     context 'with unknown argument' do
       let(:args) { ['--foo'] }
 


### PR DESCRIPTION
This flag aims to prevent a failure throw when there are no files that
match either the given glob or the default one, this can be helpful in
some cases such as some pre-commit hooks that run against the diff-ed
files, for example:

Commiting files that do not include any erb extension, then, running
linters as part of a pre-commit check, including (as an example) rubocop,
reek, stylelint, fasterer, and erb-lint, would throw an error since there are no
files to run erb-lint against, preventing the user to properly create a
commit.