### PR TITLE
Support for rubocop 0.92 via rubocop-shopify

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,4 +102,4 @@ DEPENDENCIES
   rubocop-shopify
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/gemfiles/Gemfile.rubocop-next
+++ b/gemfiles/Gemfile.rubocop-next
@@ -2,7 +2,4 @@
 
 eval_gemfile "../Gemfile"
 
-gem "rubocop", ">= 0.87"
-
-# latest rubocop-shopify release (1.0.4) is not compatible with rubocop 0.89, but this unreleased version is
-gem "rubocop-shopify", git: "https://github.com/Shopify/ruby-style-guide.git", ref: "1da32fee92427b3b04c0d1ede3f762889137a9e5"
+gem "rubocop-shopify", "~> 1.0.6"


### PR DESCRIPTION
v1.0.6 has explicit support for 0.92 which should be a good step towards
rubocop 1.0.0 support which was released recently.

https://github.com/Shopify/ruby-style-guide/releases/tag/v1.0.6

Support for rubocop 1.0.0 should land soon as well:
https://github.com/Shopify/ruby-style-guide/pull/207