### PR TITLE
Fix master build by executing rubocop separately in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,8 @@ gemfile:
 - gemfiles/Gemfile.rubocop-next
 script:
   - bundle exec rspec spec
-  - bundle exec rubocop
+jobs:
+  include:
+    - stage: Lint Ruby
+      gemfile: Gemfile
+      script: bundle exec rubocop


### PR DESCRIPTION
rubocop's version requirements are a bit broken for the version we're testing older versions of erblint against. The fix is easy: run rubocop without the strict version restrictions we use when running erblint's test suite.

This should also make the build faster by only running rubocop once instead of 6 times (each entry in the build matrix).

This problem came up in https://github.com/Shopify/erb-lint/pull/194, as that PR inherits the red build from master.