### PR TITLE
Require active_support library for deep_dup

### DIFF
--- a/lib/erb_lint/runner_config.rb
+++ b/lib/erb_lint/runner_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'erb_lint/runner_config_resolver'
+require 'active_support/core_ext/object/deep_dup'
 
 module ERBLint
   class RunnerConfig


### PR DESCRIPTION
Explicitly require `active_support/core_ext/object/deep_dup` for access to `deep_dup`, otherwise in some instances it is not loaded and raises an exception.