### PR TITLE
Use RSpec as the default rake task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 .rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml
 
 gemfiles/Gemfile*.lock
+
+rdoc

--- a/Rakefile
+++ b/Rakefile
@@ -18,12 +18,7 @@ end
 
 require 'bundler/gem_tasks'
 
-require 'rake/testtask'
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new
 
-Rake::TestTask.new(:test) do |t|
-  t.libs << 'test'
-  t.pattern = 'test/**/*_test.rb'
-  t.verbose = false
-end
-
-task(default: :test)
+task(default: :spec)


### PR DESCRIPTION
It's very common to expect that the default rake task will run tests/specs for a given project.
This PR fixes the legacy test task that was the default in the Rakefile.