### PR TITLE
Add Partial Instance Variable linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ linters:
 | [FinalNewline](#FinalNewline)                    | Yes      | warns about missing newline at the end of a ERB template |
 | [NoJavascriptTagHelper](#NoJavascriptTagHelper)  | Yes      | prevents the usage of Rails' `javascript_tag` |
 | ParserErrors                                     | Yes      |             |
+| PartialInstanceVariable                          | Yes      | detects instance variables in partials |
 | [RightTrim](#RightTrim)                          | Yes      | enforces trimming at the right of an ERB tag |
 | [SelfClosingTag](#SelfClosingTag)                | Yes      | enforces self closing tag styles for void elements |
 | [SpaceAroundErbTag](#SpaceAroundErbTag)          | Yes      | enforces a single space after `<%` and before `%>`|

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ linters:
 | [FinalNewline](#FinalNewline)                    | Yes      | warns about missing newline at the end of a ERB template |
 | [NoJavascriptTagHelper](#NoJavascriptTagHelper)  | Yes      | prevents the usage of Rails' `javascript_tag` |
 | ParserErrors                                     | Yes      |             |
-| PartialInstanceVariable                          | Yes      | detects instance variables in partials |
+| PartialInstanceVariable                          | No       | detects instance variables in partials |
 | [RightTrim](#RightTrim)                          | Yes      | enforces trimming at the right of an ERB tag |
 | [SelfClosingTag](#SelfClosingTag)                | Yes      | enforces self closing tag styles for void elements |
 | [SpaceAroundErbTag](#SpaceAroundErbTag)          | Yes      | enforces a single space after `<%` and before `%>`|

--- a/lib/erb_lint/linters/partial_instance_variable.rb
+++ b/lib/erb_lint/linters/partial_instance_variable.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module ERBLint
+  module Linters
+    # Checks for instance variables in partials.
+    class PartialInstanceVariable < Linter
+      include LinterRegistry
+
+      def run(processed_source)
+        instance_variable_regex = /\s@\w+/
+        return unless processed_source.filename.match?(/.*_.*.erb\z/) &&
+          processed_source.file_content.match?(instance_variable_regex)
+
+        add_offense(
+          processed_source.to_source_range(
+            processed_source.file_content =~ instance_variable_regex..processed_source.file_content.size
+          ),
+          "Instance variable detected in partial."
+        )
+      end
+    end
+  end
+end

--- a/lib/erb_lint/runner_config.rb
+++ b/lib/erb_lint/runner_config.rb
@@ -55,7 +55,6 @@ module ERBLint
             FinalNewline: { enabled: default_enabled },
             NoJavascriptTagHelper: { enabled: default_enabled },
             ParserErrors: { enabled: default_enabled },
-            PartialInstanceVariable: { enabled: default_enabled },
             RightTrim: { enabled: default_enabled },
             SelfClosingTag: { enabled: default_enabled },
             SpaceAroundErbTag: { enabled: default_enabled },

--- a/lib/erb_lint/runner_config.rb
+++ b/lib/erb_lint/runner_config.rb
@@ -55,6 +55,7 @@ module ERBLint
             FinalNewline: { enabled: default_enabled },
             NoJavascriptTagHelper: { enabled: default_enabled },
             ParserErrors: { enabled: default_enabled },
+            PartialInstanceVariable: { enabled: default_enabled },
             RightTrim: { enabled: default_enabled },
             SelfClosingTag: { enabled: default_enabled },
             SpaceAroundErbTag: { enabled: default_enabled },

--- a/spec/erb_lint/linters/partial_instance_variable_spec.rb
+++ b/spec/erb_lint/linters/partial_instance_variable_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ERBLint::Linters::PartialInstanceVariable do
+  let(:linter_config) { described_class.config_schema.new }
+  let(:file_loader) { ERBLint::FileLoader.new('.') }
+  let(:linter) { described_class.new(file_loader, linter_config) }
+  let(:processed_source) { ERBLint::ProcessedSource.new('_file.html.erb', file) }
+  let(:offenses) { linter.offenses }
+  before { linter.run(processed_source) }
+
+  describe 'offenses' do
+    subject { offenses }
+
+    context 'when instance varaible is not present' do
+      let(:file) { "<%= user.first_name %>" }
+      it { expect(subject).to(eq([])) }
+    end
+
+    context 'when instance variable is present' do
+      let(:file) { "<h2><%= @user.first_name %></h2>" }
+      it do
+        expect(subject).to(eq([
+          build_offense(7..32, "Instance variable detected in partial."),
+        ]))
+      end
+    end
+  end
+
+  private
+
+  def build_offense(range, message)
+    ERBLint::Offense.new(
+      linter,
+      processed_source.to_source_range(range),
+      message
+    )
+  end
+end


### PR DESCRIPTION
This PR adds a linter to detect instance variables in partials as discussed in this [issue](https://github.com/Shopify/erb-lint/issues/209).