### PR TITLE
Fix typo on CLI exception

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -58,7 +58,7 @@ module ERBLint
           run_with_corrections(runner, filename)
         rescue => e
           @stats.exceptions += 1
-          puts "Exception occured when processing: #{relative_filename(filename)}"
+          puts "Exception occurred when processing: #{relative_filename(filename)}"
           puts "If this file cannot be processed by erb-lint, "\
             "you can exclude it in your configuration file."
           puts e.message


### PR DESCRIPTION
Fix typo on CLI exception message

|BEFORE|AFTER|
|-|-|
|<img width="999" alt="before" src="https://user-images.githubusercontent.com/6463701/119756464-b2bf1980-bef7-11eb-8eb8-2d941b58a3c3.png">|<img width="999" alt="Screen Shot 2021-05-27 at 14 24 39" src="https://user-images.githubusercontent.com/6463701/119756471-b5ba0a00-bef7-11eb-84e3-40432cdfcc36.png">|