### PR TITLE
Move requires to erb_lint/all

### DIFF
--- a/lib/erb_lint.rb
+++ b/lib/erb_lint.rb
@@ -1,26 +1,3 @@
 # frozen_string_literal: true
 
-require 'rubocop'
-
-require 'erb_lint/corrector'
-require 'erb_lint/file_loader'
-require 'erb_lint/linter_config'
-require 'erb_lint/linter_registry'
-require 'erb_lint/linter'
-require 'erb_lint/offense'
-require 'erb_lint/processed_source'
-require 'erb_lint/runner_config'
-require 'erb_lint/runner'
 require 'erb_lint/version'
-require 'erb_lint/stats'
-require 'erb_lint/reporter'
-
-# Load linters
-Dir[File.expand_path('erb_lint/linters/**/*.rb', File.dirname(__FILE__))].each do |file|
-  require file
-end
-
-# Load reporters
-Dir[File.expand_path('erb_lint/reporters/**/*.rb', File.dirname(__FILE__))].each do |file|
-  require file
-end

--- a/lib/erb_lint/all.rb
+++ b/lib/erb_lint/all.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+
+require 'erb_lint'
+require 'erb_lint/corrector'
+require 'erb_lint/file_loader'
+require 'erb_lint/linter_config'
+require 'erb_lint/linter_registry'
+require 'erb_lint/linter'
+require 'erb_lint/offense'
+require 'erb_lint/processed_source'
+require 'erb_lint/runner_config'
+require 'erb_lint/runner'
+require 'erb_lint/stats'
+require 'erb_lint/reporter'
+
+# Load linters
+Dir[File.expand_path('linters/**/*.rb', __dir__)].each do |file|
+  require file
+end
+
+# Load reporters
+Dir[File.expand_path('reporters/**/*.rb', __dir__)].each do |file|
+  require file
+end

--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'erb_lint'
+require 'erb_lint/all'
 require 'active_support'
 require 'active_support/inflector'
 require 'optparse'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require 'erb_lint'
+require 'erb_lint/all'


### PR DESCRIPTION
Moves requires to `erb_lint/all`. This allows the gem to be required by bundler without unnecessary overhead. It takes ~800ms to load the gem (mainly rubocop) with the current setup.