### PR TITLE
add support for form helpers to RequireInputAutocomplete

### DIFF
--- a/lib/erb_lint/linters/require_input_autocomplete.rb
+++ b/lib/erb_lint/linters/require_input_autocomplete.rb
@@ -8,7 +8,7 @@ module ERBLint
     class RequireInputAutocomplete < Linter
       include LinterRegistry
 
-      TYPES_REQUIRING_AUTOCOMPLETE = [
+      HTML_INPUT_TYPES_REQUIRING_AUTOCOMPLETE = [
         "color",
         "date",
         "datetime-local",
@@ -26,16 +26,41 @@ module ERBLint
         "week",
       ].freeze
 
+      FORM_HELPERS_REQUIRING_AUTOCOMPLETE = [
+        :date_field_tag,
+        :color_field_tag,
+        :email_field_tag,
+        :text_field_tag,
+        :utf8_enforcer_tag,
+        :month_field_tag,
+        :hidden_field_tag,
+        :number_field_tag,
+        :password_field_tag,
+        :search_field_tag,
+        :telephone_field_tag,
+        :time_field_tag,
+        :url_field_tag,
+        :week_field_tag,
+      ].freeze
+
       def run(processed_source)
         parser = processed_source.parser
 
+        find_html_input_tags(parser)
+        find_rails_helper_input_tags(parser)
+      end
+
+      private
+
+      def find_html_input_tags(parser)
         parser.nodes_with_type(:tag).each do |tag_node|
           tag = BetterHtml::Tree::Tag.from_node(tag_node)
+
           autocomplete_attribute = tag.attributes['autocomplete']
           type_attribute = tag.attributes['type']
 
-          next if tag.name != 'input' || autocomplete_present?(autocomplete_attribute)
-          next unless type_requires_autocomplete_attribute?(type_attribute)
+          next if !html_input_tag?(tag) || autocomplete_present?(autocomplete_attribute)
+          next unless html_type_requires_autocomplete_attribute?(type_attribute)
 
           add_offense(
             tag_node.to_a[1].loc,
@@ -46,15 +71,52 @@ module ERBLint
         end
       end
 
-      private
-
-      def type_requires_autocomplete_attribute?(type_attribute)
-        type_present = type_attribute.present? && type_attribute.value_node.present?
-        type_present && TYPES_REQUIRING_AUTOCOMPLETE.include?(type_attribute.value)
-      end
-
       def autocomplete_present?(autocomplete_attribute)
         autocomplete_attribute.present? && autocomplete_attribute.value_node.present?
+      end
+
+      def html_input_tag?(tag)
+        !tag.closing? && tag.name == 'input'
+      end
+
+      def html_type_requires_autocomplete_attribute?(type_attribute)
+        type_present = type_attribute.present? && type_attribute.value_node.present?
+        type_present && HTML_INPUT_TYPES_REQUIRING_AUTOCOMPLETE.include?(type_attribute.value)
+      end
+
+      def find_rails_helper_input_tags(parser)
+        parser.ast.descendants(:erb).each do |erb_node|
+          indicator_node, _, code_node, _ = *erb_node
+          source = code_node.loc.source
+          ruby_node = extract_ruby_node(source)
+          send_node = ruby_node&.descendants(:send)&.first
+
+          next if code_comment?(indicator_node) ||
+            !ruby_node ||
+            !input_helper?(send_node) ||
+            source.include?("autocomplete")
+
+          add_offense(
+            erb_node.loc,
+            "Input field helper is missing an autocomplete attribute. If no "\
+            "autocomplete behaviour is desired, use the value `off` or `nope`.",
+            [erb_node, send_node]
+          )
+        end
+      end
+
+      def input_helper?(send_node)
+        FORM_HELPERS_REQUIRING_AUTOCOMPLETE.include?(send_node&.method_name)
+      end
+
+      def code_comment?(indicator_node)
+        indicator_node&.loc&.source == '#'
+      end
+
+      def extract_ruby_node(source)
+        BetterHtml::TestHelper::RubyNode.parse(source)
+      rescue ::Parser::SyntaxError
+        nil
       end
     end
   end


### PR DESCRIPTION
## Summary
In response to https://github.com/Shopify/erb-lint/pull/215#issuecomment-861576080 as part of https://vault.shopify.io/projects/17459

Enforces the `RequireInputAutocomplete` rule on appropriate form helpers:

```ruby
        send_node&.method_name?(:date_field_tag) ||
        send_node&.method_name?(:color_field_tag) ||
        send_node&.method_name?(:email_field_tag) ||
        send_node&.method_name?(:text_field_tag) ||
        send_node&.method_name?(:utf8_enforcer_tag) ||
        send_node&.method_name?(:month_field_tag) ||
        send_node&.method_name?(:hidden_field_tag) ||
        send_node&.method_name?(:number_field_tag) ||
        send_node&.method_name?(:password_field_tag) ||
        send_node&.method_name?(:search_field_tag) ||
        send_node&.method_name?(:telephone_field_tag) ||
        send_node&.method_name?(:time_field_tag) ||
        send_node&.method_name?(:url_field_tag) ||
        send_node&.method_name?(:week_field_tag)
```

I used [this](https://api.rubyonrails.org/v5.1.7/classes/ActionView/Helpers/FormTagHelper.html) as my source.

[More info about the autocomplete attribute can be read here.](https://development.shopify.io/engineering/developing_at_Shopify/accessibility/forms/autocomplete)

## Reviewer Notes
Are there any cases that I need to cover that haven't been covered?

## 🎩  Instructions
`dev t` will run associated tests. I think this is sufficient, but if needed:

If I wanted to test this rule locally on a file or set of files I have stored on my machine in another directory, I'd open them and apply the linter rule on the newly read files:

```ruby
file_data = File.read("relative/path/to/file/example_file_name_here")
processed_source = ERBLint::ProcessedSource.new(filename, file_data)
ERBLint::Linters::RequireInputAutocomplete.run(processed_source)
```

Or, similarly, set this up in a new test to run along with the others:
```ruby
context 'foo' do
      file_data = File.read("relative/path/to/file/example_file_name_here")
      let(:file) { file_data}
      it { expect(subject).to(eq({expected violations, etc.....})) }
end
```