### PR TITLE
Customizable fail level

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -274,6 +274,15 @@ module ERBLint
           @options[:enabled_linters] = linters
         end
 
+        opts.on("--fail-level SEVERITY", "Minimum severity for exit with error code") do |level|
+          parsed_severity = SEVERITY_CODE_TABLE[level.upcase.to_sym] || (SEVERITY_NAMES & [level.downcase]).first
+
+          if parsed_severity.nil?
+            failure!("#{level}: not a valid failure level (#{SEVERITY_NAMES.join(', ')})")
+          end
+          @options[:fail_level] = severity_level_for_name(parsed_severity)
+        end
+
         opts.on("-a", "--autocorrect", "Correct offenses automatically if possible (default: false)") do |config|
           @options[:autocorrect] = config
         end

--- a/lib/erb_lint/linter.rb
+++ b/lib/erb_lint/linter.rb
@@ -53,8 +53,8 @@ module ERBLint
       raise NotImplementedError, "must implement ##{__method__}"
     end
 
-    def add_offense(source_range, message, context = nil)
-      @offenses << Offense.new(self, source_range, message, context)
+    def add_offense(source_range, message, context = nil, severity = nil)
+      @offenses << Offense.new(self, source_range, message, context, severity)
     end
 
     def clear_offenses

--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -191,7 +191,7 @@ module ERBLint
           { rubocop_correction: correction, offset: offset, bound_range: bound_range }
         end
 
-        super(offense_range, rubocop_offense.message.strip, context)
+        super(offense_range, rubocop_offense.message.strip, context, rubocop_offense.severity.name)
       end
     end
   end

--- a/lib/erb_lint/offense.rb
+++ b/lib/erb_lint/offense.rb
@@ -3,9 +3,9 @@
 module ERBLint
   # Defines common functionality available to all linters.
   class Offense
-    attr_reader :linter, :source_range, :message, :context
+    attr_reader :linter, :source_range, :message, :context, :severity
 
-    def initialize(linter, source_range, message, context = nil)
+    def initialize(linter, source_range, message, context = nil, severity = nil)
       unless source_range.is_a?(Parser::Source::Range)
         raise ArgumentError, "expected Parser::Source::Range for arg 2"
       end
@@ -13,19 +13,22 @@ module ERBLint
       @source_range = source_range
       @message = message
       @context = context
+      @severity = severity
     end
 
     def inspect
       "#<#{self.class.name} linter=#{linter.class.name} "\
         "source_range=#{source_range.begin_pos}...#{source_range.end_pos} "\
-        "message=#{message}>"
+        "message=#{message}> "\
+        "severity=#{severity}"
     end
 
     def ==(other)
       other.class <= ERBLint::Offense &&
         other.linter == linter &&
         other.source_range == source_range &&
-        other.message == message
+        other.message == message &&
+        other.severity == severity
     end
 
     def line_range

--- a/lib/erb_lint/reporters/compact_reporter.rb
+++ b/lib/erb_lint/reporters/compact_reporter.rb
@@ -35,8 +35,14 @@ module ERBLint
       def summary
         if stats.corrected > 0
           report_corrected_offenses
-        elsif stats.found > 0
-          warn(Rainbow("#{stats.found} error(s) were found in ERB files").red)
+        elsif stats.ignored > 0 || stats.found > 0
+          if stats.ignored > 0
+            warn(Rainbow("#{stats.ignored} error(s) were ignored in ERB files").yellow)
+          end
+
+          if stats.found > 0
+            warn(Rainbow("#{stats.found} error(s) were found in ERB files").red)
+          end
         else
           puts Rainbow("No errors were found in ERB files").green
         end

--- a/lib/erb_lint/stats.rb
+++ b/lib/erb_lint/stats.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 module ERBLint
   class Stats
-    attr_accessor :found,
+    attr_accessor :ignored,
+                  :found,
                   :corrected,
                   :exceptions,
                   :linters,
@@ -9,6 +10,7 @@ module ERBLint
                   :processed_files
 
     def initialize(
+      ignored: 0,
       found: 0,
       corrected: 0,
       exceptions: 0,
@@ -16,6 +18,7 @@ module ERBLint
       files: 0,
       processed_files: {}
     )
+      @ignored = ignored
       @found = found
       @corrected = corrected
       @exceptions = exceptions

--- a/lib/erb_lint/utils/severity_levels.rb
+++ b/lib/erb_lint/utils/severity_levels.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ERBLint
+  module Utils
+    module SeverityLevels
+      SEVERITY_NAMES = %i[info refactor convention warning error fatal].freeze
+
+      SEVERITY_CODE_TABLE = { I: :info, R: :refactor, C: :convention,
+                              W: :warning, E: :error, F: :fatal }.freeze
+
+      def severity_level_for_name(name)
+        SEVERITY_NAMES.index(name || :error) + 1
+      end
+    end
+  end
+end

--- a/spec/erb_lint/cli_spec.rb
+++ b/spec/erb_lint/cli_spec.rb
@@ -248,6 +248,62 @@ describe ERBLint::CLI do
       end
     end
 
+    context 'with --fail-level as argument' do
+      let(:linted_file) { 'app/views/template.html.erb' }
+      let(:file_content) { "this is a fine file" }
+
+      before do
+        FileUtils.mkdir_p(File.dirname(linted_file))
+        File.write(linted_file, file_content)
+      end
+
+      context 'when fail level is higher than found errors' do
+        let(:args) { ['--lint-all', '--fail-level', 'R', '--enable-linter', 'linter_with_info_errors'] }
+
+        context "with the default glob" do
+          it 'shows all error messages and line numbers' do
+            expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stdout)
+
+              fake info message from a fake linter
+              In file: /app/views/template.html.erb:1
+
+            EOF
+          end
+
+          it 'prints that errors were ignored to stderr' do
+            expect { subject }.to(output(/1 error\(s\) were ignored in ERB files/).to_stderr)
+          end
+
+          it 'is successful' do
+            expect(subject).to(be(true))
+          end
+        end
+      end
+
+      context 'when fail level is lower or equal than found errors' do
+        let(:args) { ['--lint-all', '--fail-level', 'I', '--enable-linter', 'linter_with_info_errors'] }
+
+        context "with the default glob" do
+          it 'shows all error messages and line numbers' do
+            expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stdout)
+
+              fake info message from a fake linter
+              In file: /app/views/template.html.erb:1
+
+            EOF
+          end
+
+          it 'prints that errors were ignored to stderr' do
+            expect { subject }.to(output(/1 error\(s\) were found in ERB files/).to_stderr)
+          end
+
+          it 'is successful' do
+            expect(subject).to(be(false))
+          end
+        end
+      end
+    end
+
     context 'with dir as argument' do
       context 'when dir does not exist' do
         let(:linted_dir) { '/path/to' }

--- a/spec/erb_lint/linters/rubocop_spec.rb
+++ b/spec/erb_lint/linters/rubocop_spec.rb
@@ -298,7 +298,9 @@ describe ERBLint::Linters::Rubocop do
     ERBLint::Offense.new(
       linter,
       processed_source.to_source_range(range),
-      "ErbLint/AutoCorrectCop: An arbitrary rule has been violated."
+      "ErbLint/AutoCorrectCop: An arbitrary rule has been violated.",
+      nil,
+      :convention,
     )
   end
 end

--- a/spec/erb_lint/linters/rubocop_text_spec.rb
+++ b/spec/erb_lint/linters/rubocop_text_spec.rb
@@ -51,7 +51,9 @@ describe ERBLint::Linters::RubocopText do
     ERBLint::Offense.new(
       linter,
       processed_source.to_source_range(range),
-      "ErbLint/AutoCorrectCop: An arbitrary rule has been violated."
+      "ErbLint/AutoCorrectCop: An arbitrary rule has been violated.",
+      nil,
+      :convention,
     )
   end
 end

--- a/spec/erb_lint/reporters/compact_reporter_spec.rb
+++ b/spec/erb_lint/reporters/compact_reporter_spec.rb
@@ -8,6 +8,7 @@ describe ERBLint::Reporters::CompactReporter do
 
     let(:stats) do
       ERBLint::Stats.new(
+        ignored: 2,
         found: 4,
         processed_files: {
           'app/views/users/show.html.erb' => show_file_offenses,
@@ -26,6 +27,11 @@ describe ERBLint::Reporters::CompactReporter do
                         message: 'Remove multiple trailing newline at the end of the file.',
                         line_number: 125,
                         column: 1),
+        instance_double(ERBLint::Offense,
+                        message: 'Trailing comma expected.',
+                        line_number: 145,
+                        column: 4,
+                        severity: :info),
       ]
     end
 
@@ -39,6 +45,11 @@ describe ERBLint::Reporters::CompactReporter do
                         message: 'Extra space detected where there should be no space.',
                         line_number: 7,
                         column: 1),
+        instance_double(ERBLint::Offense,
+                        message: 'Trailing comma expected.',
+                        line_number: 8,
+                        column: 4,
+                        severity: :info),
       ]
     end
 
@@ -46,8 +57,17 @@ describe ERBLint::Reporters::CompactReporter do
       expect { subject }.to(output(<<~MESSAGE).to_stdout)
         app/views/users/show.html.erb:61:10: Extra space detected where there should be no space.
         app/views/users/show.html.erb:125:1: Remove multiple trailing newline at the end of the file.
+        app/views/users/show.html.erb:145:4: Trailing comma expected.
         app/views/shared/_notifications.html.erb:3:1: Indent with spaces instead of tabs.
         app/views/shared/_notifications.html.erb:7:1: Extra space detected where there should be no space.
+        app/views/shared/_notifications.html.erb:8:4: Trailing comma expected.
+      MESSAGE
+    end
+
+    it "outputs offenses summary to stderr" do
+      expect { subject }.to(output(<<~MESSAGE).to_stderr)
+        #{Rainbow('2 error(s) were ignored in ERB files').yellow}
+        #{Rainbow('4 error(s) were found in ERB files').red}
       MESSAGE
     end
   end


### PR DESCRIPTION
As discussed in #220 this PR adds the `--fail-level` option to configure the minimum offense severity which will cause `erblint` to fail.

By default it will ignore offenses reported with severity `info` (as rubocop does) which is a breaking change but only for users that configure linters with this severity (AFAIK none by default)

More than happy to discuss the approach/possible improvements