### PR TITLE
Restore dropped HTML entities to HardCodedString::TEXT_NOT_ALLOWED

### DIFF
--- a/lib/erb_lint/linters/hard_coded_string.rb
+++ b/lib/erb_lint/linters/hard_coded_string.rb
@@ -36,6 +36,9 @@ module ERBLint
         "&rarr;",
         "&darr;",
         "&uarr;",
+        "&ensp;",
+        "&emsp;",
+        "&thinsp;",
       ])
 
       class ConfigSchema < LinterConfig


### PR DESCRIPTION
dea3a1f84c61ab41ea3b1269338ca378255df5d9 dropped a few when replacing the set