### PR TITLE
`RequireInputAutocomplete`: add missing helpers + remove `utf8_enforcer_tag`

### DIFF
--- a/lib/erb_lint/linters/require_input_autocomplete.rb
+++ b/lib/erb_lint/linters/require_input_autocomplete.rb
@@ -34,7 +34,6 @@ module ERBLint
         :email_field,
         :text_field_tag,
         :text_field,
-        :utf8_enforcer_tag,
         :month_field_tag,
         :month_field,
         :number_field_tag,

--- a/spec/erb_lint/linters/require_input_autocomplete_spec.rb
+++ b/spec/erb_lint/linters/require_input_autocomplete_spec.rb
@@ -21,7 +21,6 @@ describe ERBLint::Linters::RequireInputAutocomplete do
       :email_field,
       :text_field_tag,
       :text_field,
-      :utf8_enforcer_tag,
       :month_field_tag,
       :month_field,
       :number_field_tag,


### PR DESCRIPTION
- Add the helpers from [`ActionView::Helpers::FormHelper`](https://github.com/rails/rails/blob/v6.1.4/actionview/lib/action_view/helpers/form_helper.rb)
- Add the `phone_field_tag`/`phone_field` alias for `telephone_field_tag`/`telephone_field`
- Remove `utf8_enforcer_tag`, which [generates a hidden field](https://github.com/rails/rails/blob/v6.1.4/actionview/lib/action_view/helpers/form_tag_helper.rb#L826) and therefore should not require `autocomplete`