### PR TITLE
[PartialInstanceVariable] Fix the Regex that looks for partials

### DIFF
--- a/lib/erb_lint/linters/partial_instance_variable.rb
+++ b/lib/erb_lint/linters/partial_instance_variable.rb
@@ -8,7 +8,7 @@ module ERBLint
 
       def run(processed_source)
         instance_variable_regex = /\s@\w+/
-        return unless processed_source.filename.match?(/(\A|.*\/)_[^\/\s]*\.html\.erb\z/) &&
+        return unless processed_source.filename.match?(%r{(\A|.*/)_[^/\s]*\.html\.erb\z}) &&
           processed_source.file_content.match?(instance_variable_regex)
 
         add_offense(

--- a/lib/erb_lint/linters/partial_instance_variable.rb
+++ b/lib/erb_lint/linters/partial_instance_variable.rb
@@ -8,7 +8,7 @@ module ERBLint
 
       def run(processed_source)
         instance_variable_regex = /\s@\w+/
-        return unless processed_source.filename.match?(/.*_.*.erb\z/) &&
+        return unless processed_source.filename.match?(/(\A|.*\/)_[^\/\s]*\.html\.erb\z/) &&
           processed_source.file_content.match?(instance_variable_regex)
 
         add_offense(

--- a/spec/erb_lint/linters/partial_instance_variable_spec.rb
+++ b/spec/erb_lint/linters/partial_instance_variable_spec.rb
@@ -6,9 +6,14 @@ describe ERBLint::Linters::PartialInstanceVariable do
   let(:linter_config) { described_class.config_schema.new }
   let(:file_loader) { ERBLint::FileLoader.new(".") }
   let(:linter) { described_class.new(file_loader, linter_config) }
-  let(:processed_source) { ERBLint::ProcessedSource.new("_file.html.erb", file) }
+  let(:processed_source_one) { ERBLint::ProcessedSource.new("_file.html.erb", file) }
+  let(:processed_source_two) { ERBLint::ProcessedSource.new("app/views/_a_model/a_view.html.erb", file) }
   let(:offenses) { linter.offenses }
-  before { linter.run(processed_source) }
+  before do
+    linter.run(processed_source_one)
+    linter.run(processed_source_two)
+  end
+
 
   describe "offenses" do
     subject { offenses }
@@ -22,7 +27,7 @@ describe ERBLint::Linters::PartialInstanceVariable do
       let(:file) { "<h2><%= @user.first_name %></h2>" }
       it do
         expect(subject).to(eq([
-          build_offense(7..32, "Instance variable detected in partial."),
+          build_offense(processed_source_one, 7..32, "Instance variable detected in partial."),
         ]))
       end
     end
@@ -30,7 +35,7 @@ describe ERBLint::Linters::PartialInstanceVariable do
 
   private
 
-  def build_offense(range, message)
+  def build_offense(processed_source, range, message)
     ERBLint::Offense.new(
       linter,
       processed_source.to_source_range(range),

--- a/spec/erb_lint/linters/partial_instance_variable_spec.rb
+++ b/spec/erb_lint/linters/partial_instance_variable_spec.rb
@@ -14,7 +14,6 @@ describe ERBLint::Linters::PartialInstanceVariable do
     linter.run(processed_source_two)
   end
 
-
   describe "offenses" do
     subject { offenses }
 


### PR DESCRIPTION
## TL;DR

This PR updates the regex, that now matches `**/_*.html.erb` paths instead of `*_*erb` paths

## The problem

In a Rails project, I have ActiveModel models deriving from modules (e.g. `User::SharedInvitations`). The associated views are nested in a folder like this:
``` text
app
└─ views
   └─ users
      └─ shared_invitations
         └─ new.html.erb
```

I noticed that the `PartialInstanceVariable` linter threw me an offense on my `new.html.erb` file, but it is _not_ a partial.

This is the current regex to identify partials:
``` ruby
/.*_.*.erb\z/
```
This Rubular link shows some probable false positives for that regex: https://rubular.com/r/1yIyENixRAmAFF
Notice that any path containing an underscore is matched as a partial: `*_*erb`

## A solution

This PR updates the regex to:
``` ruby
/(\A|.*\/)_[^\/\s]*\.html\.erb\z/
```
And the Rubular link to compare: https://rubular.com/r/Qs9SWPxbyCxMPJ
* `\.html\.erb\z` means the file path should end with `.html.erb`. In my understanding, `erb-lint` only lints such files, so why not be specific?
* `_[^\/\s]*` maps the file name, to match the `_*` pattern
* `(\A|.*\/)` disjuncts two cases: either a raw file name without any path before (e.g. `_file.html.erb` used in the tests, highly unlikely in my understanding) or any other path like `**/_*.html.erb`

### Tests

I added a `processed_source` with a path that is _not_ a partial (thus breaking the test with the previous regex). Any suggestion on how to more properly include such test is welcome!