### PR TITLE
Add InstanceVariable linter

### DIFF
--- a/lib/erb_lint/linters/instance_variable.rb
+++ b/lib/erb_lint/linters/instance_variable.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module ERBLint
+  module Linters
+    # Checks for instance variables in partials.
+    class InstanceVariable < Linter
+      include LinterRegistry
+
+      class ConfigSchema < LinterConfig
+        property :partials_only, accepts: [true, false], default: false, reader: :partials_only?
+      end
+      self.config_schema = ConfigSchema
+
+      INSTANCE_VARIABLE_REGEX = /[^@]?(@?@[a-z_][a-zA-Z_0-9]*)/.freeze
+      PARTIAL_FILE_REGEX = %r{(\A|.*/)_[^/\s]*\.html\.erb\z}.freeze
+
+      def run(processed_source)
+        return unless process_file?(processed_source)
+
+        matches = processed_source
+          .file_content
+          .to_enum(:scan, INSTANCE_VARIABLE_REGEX)
+          .map { Regexp.last_match }
+        return if matches.empty?
+
+        matches.each do |match|
+          range = match.begin(1)...match.end(1)
+          add_offense(processed_source.to_source_range(range), offense_message)
+        end
+      end
+
+      private
+
+      def process_file?(processed_source)
+        return true unless @config.partials_only?
+
+        processed_source.filename.match?(PARTIAL_FILE_REGEX)
+      end
+
+      def offense_message
+        "Instance variable detected."
+      end
+    end
+  end
+end

--- a/lib/erb_lint/linters/partial_instance_variable.rb
+++ b/lib/erb_lint/linters/partial_instance_variable.rb
@@ -2,21 +2,23 @@
 
 module ERBLint
   module Linters
-    # Checks for instance variables in partials.
-    class PartialInstanceVariable < Linter
-      include LinterRegistry
+    # Checks for instance variables in partials only
+    class PartialInstanceVariable < InstanceVariable
+      self.config_schema = ConfigSchema
 
-      def run(processed_source)
-        instance_variable_regex = /\s@\w+/
-        return unless processed_source.filename.match?(%r{(\A|.*/)_[^/\s]*\.html\.erb\z}) &&
-          processed_source.file_content.match?(instance_variable_regex)
-
-        add_offense(
-          processed_source.to_source_range(
-            processed_source.file_content =~ instance_variable_regex..processed_source.file_content.size
-          ),
-          "Instance variable detected in partial."
+      def initialize(file_loader, config)
+        warn(
+          "PartialInstanceVariable is deprecated. "\
+          "Please use InstanceVariable with partials_only=true."
         )
+        config[:partials_only] = true
+        super(file_loader, config)
+      end
+
+      private
+
+      def offense_message
+        "Instance variable detected in partial."
       end
     end
   end

--- a/spec/erb_lint/linters/instance_variable_spec.rb
+++ b/spec/erb_lint/linters/instance_variable_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ERBLint::Linters::InstanceVariable do
+  let(:linter_config) { described_class.config_schema.new }
+  let(:file_loader) { ERBLint::FileLoader.new(".") }
+  let(:linter) { described_class.new(file_loader, linter_config) }
+  let(:processed_source_one) { ERBLint::ProcessedSource.new("_file.html.erb", file) }
+  let(:processed_source_two) { ERBLint::ProcessedSource.new("app/views/_a_model/a_view.html.erb", file) }
+  let(:offenses) { linter.offenses }
+  before do
+    linter_config[:partials_only] = partials_only
+    linter.run(processed_source_one)
+    linter.run(processed_source_two)
+  end
+
+  describe "offenses" do
+    subject { offenses }
+
+    context "with partials_only=true" do
+      let(:partials_only) { true }
+
+      context "when an instance variable is not present" do
+        let(:file) { "<%= user.first_name %>" }
+        it { expect(subject).to(eq([])) }
+      end
+
+      context "when an instance variable is present" do
+        let(:file) { "<h2><%= @user.first_name %></h2>" }
+        it do
+          expect(subject).to(eq([
+            build_offense(processed_source_one, 8...13, "Instance variable detected."),
+          ]))
+        end
+      end
+
+      context "when a class instance variable is present" do
+        let(:file) { "<h2><%= @@user.first_name %></h2>" }
+        it do
+          expect(subject).to(eq([
+            build_offense(processed_source_one, 8...14, "Instance variable detected."),
+          ]))
+        end
+      end
+
+      context "when multiple instance variables are present" do
+        let(:file) { "<h2><%= @user.first_name %> <%= @user.last_name %></h2>" }
+        it do
+          expect(subject).to(eq([
+            build_offense(processed_source_one, 8...13, "Instance variable detected."),
+            build_offense(processed_source_one, 32...37, "Instance variable detected."),
+          ]))
+        end
+      end
+    end
+
+    context "with partials_only=true" do
+      let(:partials_only) { false }
+
+      context "when an instance variable is not present" do
+        let(:file) { "<%= user.first_name %>" }
+        it { expect(subject).to(eq([])) }
+      end
+
+      context "when an instance variable is present" do
+        let(:file) { "<h2><%= @user.first_name %></h2>" }
+        it do
+          expect(subject).to(eq([
+            build_offense(processed_source_one, 8...13, "Instance variable detected."),
+            build_offense(processed_source_two, 8...13, "Instance variable detected."),
+          ]))
+        end
+      end
+
+      context "when a class instance variable is present" do
+        let(:file) { "<h2><%= @@user.first_name %></h2>" }
+        it do
+          expect(subject).to(eq([
+            build_offense(processed_source_one, 8...14, "Instance variable detected."),
+            build_offense(processed_source_two, 8...14, "Instance variable detected."),
+          ]))
+        end
+      end
+
+      context "when multiple instance variables are present" do
+        let(:file) { "<h2><%= @user.first_name %> <%= @user.last_name %></h2>" }
+        it do
+          expect(subject).to(eq([
+            build_offense(processed_source_one, 8...13, "Instance variable detected."),
+            build_offense(processed_source_one, 32...37, "Instance variable detected."),
+            build_offense(processed_source_two, 8...13, "Instance variable detected."),
+            build_offense(processed_source_two, 32...37, "Instance variable detected."),
+          ]))
+        end
+      end
+    end
+  end
+
+  private
+
+  def build_offense(processed_source, range, message)
+    ERBLint::Offense.new(
+      linter,
+      processed_source.to_source_range(range),
+      message
+    )
+  end
+end

--- a/spec/erb_lint/linters/partial_instance_variable_spec.rb
+++ b/spec/erb_lint/linters/partial_instance_variable_spec.rb
@@ -26,7 +26,26 @@ describe ERBLint::Linters::PartialInstanceVariable do
       let(:file) { "<h2><%= @user.first_name %></h2>" }
       it do
         expect(subject).to(eq([
-          build_offense(processed_source_one, 7..32, "Instance variable detected in partial."),
+          build_offense(processed_source_one, 8...13, "Instance variable detected in partial."),
+        ]))
+      end
+    end
+
+    context "when a class instance variable is present" do
+      let(:file) { "<h2><%= @@user.first_name %></h2>" }
+      it do
+        expect(subject).to(eq([
+          build_offense(processed_source_one, 8...14, "Instance variable detected in partial."),
+        ]))
+      end
+    end
+
+    context "when multiple instance variables are present" do
+      let(:file) { "<h2><%= @user.first_name %> <%= @user.last_name %></h2>" }
+      it do
+        expect(subject).to(eq([
+          build_offense(processed_source_one, 8...13, "Instance variable detected in partial."),
+          build_offense(processed_source_one, 32...37, "Instance variable detected in partial."),
         ]))
       end
     end


### PR DESCRIPTION
Adds the InstanceVariable linter, which can be limited to partials only
(thus deprecating PartialInstanceVariable), but considers an instance
variable in any template to be an offense by default.

Also changed range behavior in both linters to highlight the instance
variables themselves. The previous behavior highlighted the start of the
variable to the end of the file.

Finally, added support for detecting class instance variables.

Resolves #240 