### PR TITLE
Run non-autocorrectable linters in autocorrect mode; improve message

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -50,6 +50,7 @@ module ERBLint
       @options[:fail_level] ||= severity_level_for_name(:refactor)
       @stats.files = lint_files.size
       @stats.linters = enabled_linter_classes.size
+      @stats.autocorrectable_linters = enabled_linter_classes.count(&:support_autocorrect?)
 
       reporter = Reporter.create_reporter(@options[:format], @stats, autocorrect?)
       reporter.preview
@@ -232,11 +233,7 @@ module ERBLint
 
     def enabled_linter_classes
       @enabled_linter_classes ||= ERBLint::LinterRegistry.linters
-        .select { |klass| linter_can_run?(klass) && enabled_linter_names.include?(klass.simple_name.underscore) }
-    end
-
-    def linter_can_run?(klass)
-      !autocorrect? || klass.support_autocorrect?
+        .select { |klass| enabled_linter_names.include?(klass.simple_name.underscore) }
     end
 
     def relative_filename(filename)

--- a/lib/erb_lint/reporters/compact_reporter.rb
+++ b/lib/erb_lint/reporters/compact_reporter.rb
@@ -4,8 +4,7 @@ module ERBLint
   module Reporters
     class CompactReporter < Reporter
       def preview
-        puts "Linting #{stats.files} files with "\
-          "#{stats.linters} #{"autocorrectable " if autocorrect}linters..."
+        puts "#{linting} #{stats.files} files with #{linters}..."
       end
 
       def show
@@ -20,6 +19,14 @@ module ERBLint
       end
 
       private
+
+      def linting
+        "Linting" + (autocorrect ? " and autocorrecting" : "")
+      end
+
+      def linters
+        "#{stats.linters} linters" + (autocorrect ? " (#{stats.autocorrectable_linters} autocorrectable)" : "")
+      end
 
       def format_offense(filename, offense)
         [

--- a/lib/erb_lint/stats.rb
+++ b/lib/erb_lint/stats.rb
@@ -6,6 +6,7 @@ module ERBLint
       :corrected,
       :exceptions,
       :linters,
+      :autocorrectable_linters,
       :files,
       :processed_files
 
@@ -15,6 +16,7 @@ module ERBLint
       corrected: 0,
       exceptions: 0,
       linters: 0,
+      autocorrectable_linters: 0,
       files: 0,
       processed_files: {}
     )
@@ -23,6 +25,7 @@ module ERBLint
       @corrected = corrected
       @exceptions = exceptions
       @linters = linters
+      @autocorrectable_linters = autocorrectable_linters
       @files = files
       @processed_files = processed_files
     end

--- a/spec/erb_lint/cli_spec.rb
+++ b/spec/erb_lint/cli_spec.rb
@@ -514,7 +514,16 @@ describe ERBLint::CLI do
           end
 
           context "when autocorrecting an error" do
-            let(:args) { ["--enable-linter", "final_newline", "--stdin", linted_file, "--autocorrect"] }
+            # We assume that linter_without_errors is not autocorrectable...
+            let(:args) { ["--enable-linter", "final_newline,linter_without_errors", "--stdin", linted_file, "--autocorrect"] }
+
+            it "tells the user it is autocorrecting" do
+              expect { subject }.to(output(/Linting and autocorrecting/).to_stdout)
+            end
+
+            it "shows how many total and autocorrectable linters are used" do
+              expect { subject }.to(output(/2 linters \(1 autocorrectable\)/).to_stdout)
+            end
 
             it "outputs the corrected ERB" do
               expect { subject }.to(output(/#{file_content}\n/).to_stdout)


### PR DESCRIPTION
Fixes https://github.com/Shopify/erb-lint/issues/145

Run all configured/enabled linters even when in autocorrect mode, and improve the messaging somewhat when run in autocorrect mode.

I ran into this after configuring erb-lint with 12 total linters, of which only 9 are autocorrectable. The `dev style` command would run with autocorrect, but this may leave lint failures which were from non-autocorrectable linters. This would then cause CI to fail for the branch later, very annoyingly, when it's run without autocorrect mode.

This PR causes a behavior change for `-a`/`--autocorrect`, but it matches the behavior of Rubocop's autocorrect, and I think matches most users' expectations better.

The message from a real project looks like so:

```
Linting and autocorrecting 184 files with 12 linters (9 autocorrectable)...
```

Additionally I have added tests for the autocorrect message output (which didn't exist before).