### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0
+        ruby-version: '3.0'
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Rubocop
       run: bundle exec rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0, head]
+        ruby: [2.5, 2.6, 2.7, '3.0', 3.1, head]
         gemfile: [rubocop-next, rubocop-old]
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.

It also quotes `3.0` in the `linting.yml` and `test.yml` files, to ensure that these are treated as `3.0` and not `3`.  YAML drops traling zeros when converting floats to strings.  Failing to include the quotes means that the loaded Ruby version will be the latest Ruby 3 version, which is Ruby 3.1.0 at this time.

[ruby-head is failing because of a problem in a dependent library](https://github.com/fakefs/fakefs/pull/467)