### PR TITLE
Fix bug with excluding files by linter

### DIFF
--- a/lib/erb_lint/runner.rb
+++ b/lib/erb_lint/runner.rb
@@ -18,8 +18,9 @@ module ERBLint
     end
 
     def run(processed_source)
+      relative_filename = processed_source.filename.delete_prefix("#{@file_loader.base_path}/")
       @linters
-        .reject { |linter| linter.excludes_file?(processed_source.filename) }
+        .reject { |linter| linter.excludes_file?(relative_filename) }
         .each do |linter|
         linter.run(processed_source)
         @offenses.concat(linter.offenses)

--- a/spec/erb_lint/runner_spec.rb
+++ b/spec/erb_lint/runner_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe ERBLint::Runner do
-  let(:file_loader) { ERBLint::FileLoader.new(".") }
+  let(:file_loader) { ERBLint::FileLoader.new("/root/directory") }
   let(:runner) { described_class.new(file_loader, config) }
 
   before do
@@ -27,7 +27,7 @@ describe ERBLint::Runner do
 
   describe "#run" do
     let(:file) { "DummyFileContent" }
-    let(:filename) { "somefolder/otherfolder/dummyfile.html.erb" }
+    let(:filename) { "/root/directory/somefolder/otherfolder/dummyfile.html.erb" }
     let(:processed_source) { ERBLint::ProcessedSource.new(filename, file) }
     before { runner.run(processed_source) }
     subject { runner.offenses }


### PR DESCRIPTION
**Problem**

When excluding files from specific linters, globs that are relative to the application root directory do not exclude files matching the glob. For example, the following example from the readme:

```
---
linters:
  DeprecatedClasses:
    enabled: true
    exclude:
      - 'app/views/shared/deprecated/**'
```
...would not actually exclude the `DeprecatedClasses` linter for any views under `app/views/shared/deprecated/**`

I have reproduced this bug in a separate git repository as follows.

The following commit https://github.com/joshski/erblint-exclude-bug-demo/commit/6477573fc128352369415db1ebf990b6e8c5da50

* adds `erb_lint` to a new rails 7 app
* [violates](https://github.com/joshski/erblint-exclude-bug-demo/commit/6477573fc128352369415db1ebf990b6e8c5da50#diff-685daaee2b6716c73d06ee0cee9a2d9640a4a2cf8445034cc21aad1b3be3d54c) the `ErbSafety` lint rule.
* includes a [script](https://github.com/joshski/erblint-exclude-bug-demo/commit/6477573fc128352369415db1ebf990b6e8c5da50#diff-685daaee2b6716c73d06ee0cee9a2d9640a4a2cf8445034cc21aad1b3be3d54c) to reproduce the bug.

The subsequent commit in the same repo demonstrates the bug is fixed, using the revision of `erb_lint` proposed by this PR.

https://github.com/joshski/erblint-exclude-bug-demo/commit/bcace06a43bc3ffcc4406ae45e0d5447eedb8268

**Solution**

When the `ErbLint::Runner` rejects linters for a given processed source file, match against exclusion globs using a filename relative to the `base_path` of the `ERBLint::FileLoader`.