### PR TITLE
Fix '**/vendor/**/*' glob broken in dc7cc25

### DIFF
--- a/lib/erb_lint/linter.rb
+++ b/lib/erb_lint/linter.rb
@@ -46,7 +46,7 @@ module ERBLint
     end
 
     def excludes_file?(filename)
-      @config.excludes_file?(filename)
+      @config.excludes_file?(filename, @file_loader.base_path)
     end
 
     def run(_processed_source)

--- a/lib/erb_lint/linter_config.rb
+++ b/lib/erb_lint/linter_config.rb
@@ -53,9 +53,12 @@ module ERBLint
       end
     end
 
-    def excludes_file?(filename)
+    def excludes_file?(absolute_filename, base_path)
       exclude.any? do |path|
-        File.fnmatch?(path, filename)
+        return true if File.fnmatch?(path, absolute_filename)
+
+        relative_path = absolute_filename.delete_prefix("#{base_path}/")
+        File.fnmatch?(path, relative_path)
       end
     end
   end

--- a/lib/erb_lint/runner.rb
+++ b/lib/erb_lint/runner.rb
@@ -18,9 +18,8 @@ module ERBLint
     end
 
     def run(processed_source)
-      relative_filename = processed_source.filename.delete_prefix("#{@file_loader.base_path}/")
       @linters
-        .reject { |linter| linter.excludes_file?(relative_filename) }
+        .reject { |linter| linter.excludes_file?(processed_source.filename) }
         .each do |linter|
         linter.run(processed_source)
         @offenses.concat(linter.offenses)

--- a/spec/erb_lint/linter_config_spec.rb
+++ b/spec/erb_lint/linter_config_spec.rb
@@ -100,13 +100,25 @@ describe ERBLint::LinterConfig do
     describe "#excludes_file?" do
       context "when glob matches" do
         let(:config_hash) { { exclude: ["vendor/**/*"] } }
-        subject { linter_config.excludes_file?("vendor/gem/foo.rb") }
+        subject { linter_config.excludes_file?("/src/vendor/gem/foo.rb", "/src") }
         it { expect(subject).to(eq(true)) }
       end
 
       context "when glob does not match" do
         let(:config_hash) { { exclude: ["vendor/**/*"] } }
-        subject { linter_config.excludes_file?("app/foo.rb") }
+        subject { linter_config.excludes_file?("/src/app/foo.rb", "/src") }
+        it { expect(subject).to(eq(false)) }
+      end
+
+      context "when absolute glob matches" do
+        let(:config_hash) { { exclude: ["**/vendor/**/*"] } }
+        subject { linter_config.excludes_file?("/src/vendor/gem/foo.rb", "/src") }
+        it { expect(subject).to(eq(true)) }
+      end
+
+      context "when absolute glob does not match" do
+        let(:config_hash) { { exclude: ["**/vendor/**/*"] } }
+        subject { linter_config.excludes_file?("/src/app/foo.rb", "/src") }
         it { expect(subject).to(eq(false)) }
       end
     end


### PR DESCRIPTION
Fix `'**/vendor/**/*'` glob broken in dc7cc2553dd33df2466a5a31c6cd91d9e1ed7b60

This is similar to the strategy rubocop uses here https://github.com/rubocop/rubocop/blob/d19f902705cb5772f0bc81d87ac652c84bb4c99a/lib/rubocop/config.rb#L163 where they check against absolute and relative paths

I created an example repo to show that both absolute and relative globs work: https://github.com/hmcguire-shopify/erblint-0-1-2-exclude

cc @rafaelfranca 

Fixes #258 