### PR TITLE
Let Rubocop handle config loading

### DIFF
--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -158,34 +158,9 @@ module ERBLint
       end
 
       def config_from_hash(hash)
-        inherit_from = hash&.delete("inherit_from")
-        resolve_inheritance(hash, inherit_from)
-
         tempfile_from(".erblint-rubocop", hash.to_yaml) do |tempfile|
           ::RuboCop::ConfigLoader.load_file(tempfile.path)
         end
-      end
-
-      def resolve_inheritance(hash, inherit_from)
-        base_configs(inherit_from)
-          .reverse_each do |base_config|
-          base_config.each do |k, v|
-            hash[k] = hash.key?(k) ? ::RuboCop::ConfigLoader.merge(v, hash[k]) : v if v.is_a?(Hash)
-          end
-        end
-      end
-
-      def base_configs(inherit_from)
-        regex = URI::DEFAULT_PARSER.make_regexp(["http", "https"])
-        configs = Array(inherit_from).compact.map do |base_name|
-          if base_name =~ /\A#{regex}\z/
-            ::RuboCop::ConfigLoader.load_file(::RuboCop::RemoteConfig.new(base_name, Dir.pwd))
-          else
-            config_from_hash(@file_loader.yaml(base_name))
-          end
-        end
-
-        configs.compact
       end
 
       def add_offense(rubocop_offense, offense_range, correction, offset, bound_range)

--- a/spec/erb_lint/linters/rubocop_spec.rb
+++ b/spec/erb_lint/linters/rubocop_spec.rb
@@ -24,7 +24,10 @@ describe ERBLint::Linters::Rubocop do
   let(:inherit_from_filename) { "custom_rubocop.yml" }
   subject { offenses }
   before do
-    allow(file_loader).to(receive(:yaml).with(inherit_from_filename).and_return(nested_config))
+    allow(::RuboCop::ConfigLoader).to(receive(:load_file).and_call_original)
+    allow(::RuboCop::ConfigLoader).to(
+      receive(:load_file).with(a_string_ending_with(inherit_from_filename)).and_return(nested_config),
+    )
   end
   before { linter.run(processed_source) }
 


### PR DESCRIPTION
Hello,

I was migrating some rubocop configuration to use actual ERB syntax to [leverage git ignored files](https://docs.rubocop.org/rubocop/configuration.html#pre-processing), and I actually noticed that erblint (which I also use) becomes incompatible with it.

I believe the easiest way to support that is to fully let `RuboCop` handle the config loading, as they already support inheritance in their config file instead of having similar but slightly different behavior within this gem.