### PR TITLE
Add optional working-directory flag

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -168,8 +168,12 @@ module ERBLint
       @config.merge!(runner_config_override)
     end
 
+    def working_directory
+      @working_directory ||= @options[:working_dir] || Dir.pwd
+    end
+
     def file_loader
-      @file_loader ||= ERBLint::FileLoader.new(Dir.pwd)
+      @file_loader ||= ERBLint::FileLoader.new(working_directory)
     end
 
     def load_options(args)
@@ -259,6 +263,14 @@ module ERBLint
             @options[:config] = config
           else
             failure!("#{config}: does not exist")
+          end
+        end
+
+        opts.on("--working-dir DIRECTORY", "Working directory requires read/write access. [default: #{Dir.pwd}]") do |working_dir|
+          if File.directory?(working_dir)
+            @options[:working_dir] = working_dir
+          else
+            failure!("#{working_dir}: does not exist")
           end
         end
 

--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -120,7 +120,7 @@ module ERBLint
       end
 
       def tempfile_from(filename, content)
-        Tempfile.create(File.basename(filename), Dir.pwd) do |tempfile|
+        Tempfile.create(File.basename(filename), @file_loader.base_path) do |tempfile|
           tempfile.write(content)
           tempfile.rewind
 

--- a/spec/erb_lint/cli_spec.rb
+++ b/spec/erb_lint/cli_spec.rb
@@ -119,6 +119,28 @@ describe ERBLint::CLI do
       end
     end
 
+    context "with --working-dir" do
+      context "when working dir does not exist" do
+        let(:args) { ["--working-dir", "./somefolder/"] }
+
+        it { expect { subject }.to(output(/.\/somefolder\/: does not exist/).to_stderr) }
+        it "is not successful" do
+          expect(subject).to(be(false))
+        end
+      end
+
+      context "when directory does exist" do
+        before { FakeFS::FileSystem.clone(File.join(__dir__, "../fixtures"), "/") }
+
+        let(:args) { ["--working-dir", "/", "--config", "config.yml", "--lint-all"] }
+
+        it { expect { subject }.to_not(output(/.\/somefolder\/: does not exist/).to_stderr) }
+        it "is successful" do
+          expect(subject).to(be(true))
+        end
+      end
+    end
+
     context "with file as argument" do
       context "when file does not exist" do
         let(:linted_file) { "/path/to/myfile.html.erb" }


### PR DESCRIPTION
## Overview

While using the Erb-lint gem in our project, I ran into an issue getting it to work successfully in our CI pipeline. We run docker containers in Buildkite for our CI builds. 

The issue was when I attempted to use `inherit_from` in the rubocop linter. erb-lint assumes the current directory is writable when reading in the rubocop config file:

https://github.com/Shopify/erb-lint/blob/2bba85d4751b25b60a3d5bb2ed320e4a0c89b357/lib/erb_lint/linters/rubocop.rb#L122

The user we set up in Docker is intentionally not given write access to the current directory.

## Proposal

This PR adds an optional CLI flag to pass in a 'working directory' so that we can pass a path that we know has read/write access. 