### PR TITLE
Allow for config file path to be passed to rubocop

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Linter-Specific Option | Description
 -----------------------|---------------------------------------------------------
 `rubocop_config`       | A valid rubocop configuration hash. Mandatory when this cop is enabled. See [rubocop's manual entry on Configuration](http://rubocop.readthedocs.io/en/latest/configuration/)
 `only`                 | Only run cops listed in this array instead of all cops.
+`config_file_path`     | A path to a valid rubocop configuration file. When this is provided, `rubocop_config` will be ignored.
 
 ### RequireInputAutocomplete
 This linter prevents the usage of certain types of HTML `<input>` without an `autocomplete` argument: `color`, `date`, `datetime-local`, `email`, `month`, `number`, `password`, `range`, `search`, `tel`, `text`, `time`, `url`, or `week`.
@@ -355,15 +356,15 @@ Linter-Specific Option | Description
 `correction_style`     | When configured with `cdata`, adds CDATA markers. When configured with `plain`, don't add makers. Defaults to `cdata`.
 
 ### RequireScriptNonce
-This linter prevents the usage of HTML `<script>`, Rails `javascript_tag`, `javascript_include_tag` and `javascript_pack_tag` without a `nonce` argument. The purpose of such a check is to ensure that when [content securty policy](https://edgeguides.rubyonrails.org/security.html#content-security-policy) is implemented in an application, there is a means of discovering tags that need to be updated with a `nonce` argument to enable script execution at application runtime. 
+This linter prevents the usage of HTML `<script>`, Rails `javascript_tag`, `javascript_include_tag` and `javascript_pack_tag` without a `nonce` argument. The purpose of such a check is to ensure that when [content securty policy](https://edgeguides.rubyonrails.org/security.html#content-security-policy) is implemented in an application, there is a means of discovering tags that need to be updated with a `nonce` argument to enable script execution at application runtime.
 
 ```
 Bad ❌
-<script> 
+<script>
     alert(1)
 </script>
 Good ✅
-<script nonce="<%= request.content_security_policy_nonce %>" > 
+<script nonce="<%= request.content_security_policy_nonce %>" >
     alert(1)
 </script>
 ```

--- a/lib/erb_lint/linters/rubocop_text.rb
+++ b/lib/erb_lint/linters/rubocop_text.rb
@@ -10,6 +10,7 @@ module ERBLint
       class ConfigSchema < LinterConfig
         property :only, accepts: array_of?(String)
         property :rubocop_config, accepts: Hash
+        property :config_file_path, accepts: String
       end
 
       self.config_schema = ConfigSchema

--- a/spec/erb_lint/linters/rubocop_spec.rb
+++ b/spec/erb_lint/linters/rubocop_spec.rb
@@ -231,6 +231,40 @@ describe ERBLint::Linters::Rubocop do
     end
   end
 
+  context "supports config from a provided path" do
+    after do
+      config_file.close
+      config_file.unlink
+    end
+
+    let(:config_file) do
+      tempfile = Tempfile.new("config.yml")
+      tempfile.write(nested_config.to_yaml)
+      tempfile.rewind
+      tempfile
+    end
+    let(:linter_config) do
+      described_class.config_schema.new(
+        only: ["ErbLint/AutoCorrectCop"],
+        config_file_path: config_file.path,
+      )
+    end
+    let(:nested_config) do
+      {
+        "ErbLint/AutoCorrectCop": {
+          "Enabled": false,
+        },
+      }.deep_stringify_keys
+    end
+    let(:file) { <<~FILE }
+      <% auto_correct_me %>
+    FILE
+
+    it "loads rubocop config from specified file path" do
+      expect(subject).to(eq([]))
+    end
+  end
+
   context "code is aligned to the column matching start of ruby code" do
     let(:linter_config) do
       described_class.config_schema.new(


### PR DESCRIPTION
https://github.com/Shopify/erb-lint/pull/262#issuecomment-1196418243 for context

Briefly, I'd like to be able to run `erblint` in our CI that has restrictions on writing to its current directory. Since Rubocop lacks an api to read in a config that is _not_ a file, we must give it a path. This PR adds support for passing a config path to rubocop instead of the gem writing to the current directory and passing that file to rubocop. 

Thanks to @etiennebarrie for your proposal

### Usage

```yml
--- # .erb-lint.yml
EnableDefaultLinters: true
linters:
  Rubocop:
    enabled: true
    config_file_path: .rubocop.erb-lint.yml

--- # .rubocop.erb-lint.yml
inherit_from:
  - .rubocop.yml
  # more here
```

