### PR TITLE
Option to allow for no files

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -35,7 +35,11 @@ module ERBLint
       load_config
 
       if !@files.empty? && lint_files.empty?
-        failure!("no files found...\n")
+        if allow_no_files?
+          success!("no files found...\n")
+        else
+          failure!("no files found...\n")
+        end
       elsif lint_files.empty?
         failure!("no files found or given, specify files or config...\n#{option_parser}")
       end
@@ -302,6 +306,10 @@ module ERBLint
           @options[:autocorrect] = config
         end
 
+        opts.on("--allow-no-files", "When no matching files found, exit successfully (default: false)") do |config|
+          @options[:allow_no_files] = config
+        end
+
         opts.on(
           "-sFILE",
           "--stdin FILE",
@@ -332,6 +340,10 @@ module ERBLint
 
     def stdin?
       @options[:stdin].present?
+    end
+
+    def allow_no_files?
+      @options[:allow_no_files]
     end
   end
 end

--- a/spec/erb_lint/cli_spec.rb
+++ b/spec/erb_lint/cli_spec.rb
@@ -561,6 +561,17 @@ describe ERBLint::CLI do
             expect { subject }.to(output(/no files found\.\.\./).to_stderr)
             expect(subject).to(be(false))
           end
+
+          context "allowing for no matching files" do
+            let(:args) do
+              ["--config", config_file, "--enable-linter", "linter_with_errors,final_newline", "--allow-no-files", "--stdin", linted_file]
+            end
+
+            it "exits with success status" do
+              expect { subject }.to(output(/no files found\.\.\./).to_stdout)
+              expect(subject).to(be(true))
+            end
+          end
         end
       end
     end

--- a/spec/erb_lint/cli_spec.rb
+++ b/spec/erb_lint/cli_spec.rb
@@ -568,7 +568,7 @@ describe ERBLint::CLI do
                 "--config", config_file,
                 "--enable-linter", "linter_with_errors,final_newline",
                 "--stdin", linted_file,
-                "--allow-no-files"
+                "--allow-no-files",
               ]
             end
 

--- a/spec/erb_lint/cli_spec.rb
+++ b/spec/erb_lint/cli_spec.rb
@@ -564,7 +564,12 @@ describe ERBLint::CLI do
 
           context "allowing for no matching files" do
             let(:args) do
-              ["--config", config_file, "--enable-linter", "linter_with_errors,final_newline", "--allow-no-files", "--stdin", linted_file]
+              [
+                "--config", config_file,
+                "--enable-linter", "linter_with_errors,final_newline",
+                "--stdin", linted_file,
+                "--allow-no-files"
+              ]
             end
 
             it "exits with success status" do


### PR DESCRIPTION
We use erb-lint in a pre-commit hook and in our CI. Sometimes files have changed (ie. in `git diff`) which are excluded from our erb-lint checks. This causes an error of `no files found...` to be output, which doesn't allow the commit to take place.

We have workarounds in place:

```bash
git diff HEAD^ --name-only --diff-filter=d -m **/*.erb | xargs --no-run-if-empty bundle exec erblint 2> error_output || [ "$(cat error_output)" == "no files found..." ]
```

And:

```bash
PAGER=cat git diff --diff-filter=d --name-only --cached -- "*.erb" | xargs bundle exec erblint 2> /tmp/erblint; (( erblint_status = $? ))

# No files found are treated as an error, let's treat it as success
if [[ "$(cat /tmp/erblint)" == "no files found..." ]]; then
  erblint_status=0
fi
```

But having a `--allow-no-files` option would let us treat this as a successful check without additional logic for this scenario.