### PR TITLE
Add shorthand `-f` for `format` option.

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -266,7 +266,7 @@ module ERBLint
           end
         end
 
-        opts.on("--format FORMAT", format_options_help) do |format|
+        opts.on("-f", "--format FORMAT", format_options_help) do |format|
           unless Reporter.available_format?(format)
             error_message = invalid_format_error_message(format)
             failure!(error_message)


### PR DESCRIPTION
Hi. This is a small improvement.

Implemented `-f`, an option shorthand for specifying the result format when executing cli.
There is a description in the README, but it was not actually implemented.

https://github.com/Shopify/erb-lint#output-formats

### Result

```
$ ./exe/erblint -h
Usage: erblint [options] [file1, file2, ...]
        --config FILENAME            Config file [default: .erb-lint.yml]
    -f, --format FORMAT              Report offenses in the given format: (compact, json, multiline) (default: multiline)
        --lint-all                   Lint all files matching configured glob [default: **/*.html{+*,}.erb]
        --enable-all-linters         Enable all known linters
        --enable-linters LINTER[,LINTER,...]
                                     Only use specified linter
                                     Known linters are: allowed_script_type, closing_erb_tag_indent, deprecated_classes, erb_safety, extra_newline, final_newline, hard_coded_string, no_javascript_tag_helper, parser_errors, partial_instance_variable, require_input_autocomplete, require_script_nonce, right_trim, rubocop, rubocop_text, self_closing_tag, space_around_erb_tag, space_in_html_tag, space_indentation, trailing_whitespace
        --fail-level SEVERITY        Minimum severity for exit with error code
    -a, --autocorrect                Correct offenses automatically if possible (default: false)
        --allow-no-files             When no matching files found, exit successfully (default: false)
    -s, --stdin FILE                 Pipe source from STDIN. Takes the path to be used to check which rules to apply.
    -h, --help                       Show this message
        --version                    Show version

$ ./exe/erblint ./ -f compact
.erb-lint.yml not found: using default config
no files found...
```
