### PR TITLE
docs(README.md): include HardCodedString linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ linters:
 | [ErbSafety](#erbsafety)                          | No       | detects unsafe interpolation of ruby data into various javascript contexts and enforce usage of safe helpers like `.to_json`. |
 | [Rubocop](#rubocop)                              | No       | runs RuboCop rules on ruby statements found in ERB templates |
 | [RequireScriptNonce](#requirescriptnonce)        | No       | warns about missing [Content Security Policy nonces](https://guides.rubyonrails.org/security.html#content-security-policy) in script tags |
-| [HardCodedString](#HardCodedString)              | No       | warns if there is a visible hardcoded string in the DOM (does not check for a hardcoded string nested inside a JavaScript tag)            |
+| [HardCodedString](#hardcodedstring)              | No       | warns if there is a visible hardcoded string in the DOM (does not check for a hardcoded string nested inside a JavaScript tag)            |
 
 ### DeprecatedClasses
 


### PR DESCRIPTION
## Summary

Closes #254

This updates the README's `Linters` section to include the [HardCodedString linter](https://github.com/Shopify/erb-lint/blob/main/lib/erb_lint/linters/hard_coded_string.rb).

I verified that this linter is _not_ enabled by default as it's [configured in this part of the `lib/erb_lint/runner_config.rb`](https://github.com/Shopify/erb-lint/blob/19c9ddb94f0ea1d73ac12e18a7ea822d76adeeab/lib/erb_lint/runner_config.rb#L49-L68). The description is sourced from the [pull request's OP that originally introduced the linter](https://github.com/Shopify/erb-lint/pull/39#issue-290085537).