### PR TITLE
lib/erb_lint/linters: Add a new CommentSyntax linter 

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ linters:
 | [ErbSafety](#ErbSafety)                          | No       | detects unsafe interpolation of ruby data into various javascript contexts and enforce usage of safe helpers like `.to_json`. |
 | [Rubocop](#Rubocop)                              | No       | runs RuboCop rules on ruby statements found in ERB templates |
 | [RequireScriptNonce](#RequireScriptNonce)        | No       | warns about missing [Content Security Policy nonces](https://guides.rubyonrails.org/security.html#content-security-policy) in script tags |
-| CommentSyntax                                    | No       | detects bad comment syntax, ie `<% # comment %>` is not technically valid ERB but `<%# comment %>` is |
+| [CommentSyntax](#CommentSyntax)                  | No       | detects bad ERB comment syntax |
 
 ### DeprecatedClasses
 
@@ -487,6 +487,27 @@ Linter-Specific Option    | Description
 `allowed_types`           | An array of allowed types. Defaults to `["text/javascript"]`.
 `allow_blank`             | True or false, depending on whether or not the `type` attribute may be omitted entirely from a `<script>` tag. Defaults to `true`.
 `disallow_inline_scripts` | Do not allow inline `<script>` tags anywhere in ERB templates. Defaults to `false`.
+
+## CommentSyntax
+
+This linter enforces the use of the correct ERB comment syntax, since Ruby comments (`<% # comment %>` with a space) are not technically valid ERB comments.
+
+```erb
+Bad ❌
+<% # This is a Ruby comment %>
+Good ✅
+<%# This is an ERB comment %>
+
+Bad ❌
+<% # This is a Ruby comment; it can fail to parse. %>
+Good ✅
+<%# This is an ERB comment; it is parsed correctly. %>
+
+Good ✅
+<%
+  # This is a multi-line ERB comment.
+%>
+```
 
 ## Custom Linters
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ linters:
 | [ErbSafety](#ErbSafety)                          | No       | detects unsafe interpolation of ruby data into various javascript contexts and enforce usage of safe helpers like `.to_json`. |
 | [Rubocop](#Rubocop)                              | No       | runs RuboCop rules on ruby statements found in ERB templates |
 | [RequireScriptNonce](#RequireScriptNonce)        | No       | warns about missing [Content Security Policy nonces](https://guides.rubyonrails.org/security.html#content-security-policy) in script tags |
+| CommentSyntax                                    | No       | detects bad comment syntax, ie `<% # comment %>` is not technically valid ERB but `<%# comment %>` is |
 
 ### DeprecatedClasses
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ linters:
 | ------------------------------------------------ |:--------:|-------------|
 | [AllowedScriptType](#AllowedScriptType)          | Yes      | prevents the addition of `<script>` tags that have `type` attributes that are not in a white-list of allowed values |
 | ClosingErbTagIndent                              | Yes      |             |
+| [CommentSyntax](#CommentSyntax)                  | Yes      | detects bad ERB comment syntax |
 | ExtraNewline                                     | Yes      |             |
 | [FinalNewline](#FinalNewline)                    | Yes      | warns about missing newline at the end of a ERB template |
 | [NoJavascriptTagHelper](#NoJavascriptTagHelper)  | Yes      | prevents the usage of Rails' `javascript_tag` |
@@ -110,7 +111,6 @@ linters:
 | [ErbSafety](#ErbSafety)                          | No       | detects unsafe interpolation of ruby data into various javascript contexts and enforce usage of safe helpers like `.to_json`. |
 | [Rubocop](#Rubocop)                              | No       | runs RuboCop rules on ruby statements found in ERB templates |
 | [RequireScriptNonce](#RequireScriptNonce)        | No       | warns about missing [Content Security Policy nonces](https://guides.rubyonrails.org/security.html#content-security-policy) in script tags |
-| [CommentSyntax](#CommentSyntax)                  | No       | detects bad ERB comment syntax |
 
 ### DeprecatedClasses
 

--- a/lib/erb_lint/linters/comment_syntax.rb
+++ b/lib/erb_lint/linters/comment_syntax.rb
@@ -12,7 +12,6 @@ module ERBLint
 
       def run(processed_source)
         file_content = processed_source.file_content
-
         return if file_content.empty?
 
         processed_source.ast.descendants(:erb).each do |erb_node|

--- a/lib/erb_lint/linters/comment_syntax.rb
+++ b/lib/erb_lint/linters/comment_syntax.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module ERBLint
+  module Linters
+    # Detects comment syntax that isn't valid ERB.
+    class CommentSyntax < Linter
+      include LinterRegistry
+
+      def initialize(file_loader, config)
+        super
+      end
+
+      def run(processed_source)
+        file_content = processed_source.file_content
+
+        return if file_content.empty?
+
+        processed_source.ast.descendants(:erb).each do |erb_node|
+          indicator_node, _, code_node, _ = *erb_node
+          next if indicator_node.nil? || code_node.nil?
+
+          indicator_node_str = indicator_node.deconstruct.last
+          next if indicator_node_str == "#"
+
+          if indicator_node_str == "="
+            range = find_range(erb_node, indicator_node_str)
+            source_range = processed_source.to_source_range(range)
+
+            add_offense(
+              source_range,
+              <<~EOF.chomp
+                Bad ERB comment syntax. Should be `<%#=` without a space between.
+                Leaving a space between ERB tags and the Ruby comment character can cause parser errors.
+              EOF
+            )
+          end
+
+          code_node_str = code_node.deconstruct.last
+          next unless code_node_str.start_with?(" #")
+
+          range = find_range(erb_node, code_node_str)
+          source_range = processed_source.to_source_range(range)
+
+          add_offense(
+            source_range,
+            <<~EOF.chomp
+              Bad ERB comment syntax. Should be `<%#` without a space between.
+              Leaving a space between ERB tags and the Ruby comment character can cause parser errors.
+            EOF
+          )
+        end
+      end
+
+      def find_range(node, str)
+        match = node.loc.source.match(Regexp.new(Regexp.quote(str.strip)))
+        return unless match
+
+        range_begin = match.begin(0) + node.loc.begin_pos
+        range_end   = match.end(0) + node.loc.begin_pos
+        (range_begin...range_end)
+      end
+    end
+  end
+end

--- a/lib/erb_lint/runner_config.rb
+++ b/lib/erb_lint/runner_config.rb
@@ -63,6 +63,7 @@ module ERBLint
             SpaceInHtmlTag: { enabled: default_enabled },
             TrailingWhitespace: { enabled: default_enabled },
             RequireInputAutocomplete: { enabled: default_enabled },
+            CommentSyntax: { enabled: default_enabled },
           },
         )
       end

--- a/spec/erb_lint/linters/comment_syntax_spec.rb
+++ b/spec/erb_lint/linters/comment_syntax_spec.rb
@@ -22,6 +22,18 @@ describe ERBLint::Linters::CommentSyntax do
     end
   end
 
+  context "when the ERB multi-line comment syntax is correct" do
+    let(:file) { <<~FILE }
+      <%
+        # good comment
+      %>
+    FILE
+
+    it "does not report any offenses" do
+      expect(subject.size).to(eq(0))
+    end
+  end
+
   context "when the ERB comment syntax is incorrect" do
     let(:file) { <<~FILE }
       <% # first bad comment %>

--- a/spec/erb_lint/linters/comment_syntax_spec.rb
+++ b/spec/erb_lint/linters/comment_syntax_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ERBLint::Linters::CommentSyntax do
+  let(:linter_config) { described_class.config_schema.new }
+
+  let(:file_loader) { ERBLint::FileLoader.new(".") }
+  let(:linter) { described_class.new(file_loader, linter_config) }
+  let(:processed_source) { ERBLint::ProcessedSource.new("file.rb", file) }
+
+  subject { linter.offenses }
+  before { linter.run(processed_source) }
+
+  context "when the ERB comment syntax is correct" do
+    let(:file) { <<~FILE }
+      <%# good comment %>
+    FILE
+
+    it "does not report any offenses" do
+      expect(subject.size).to(eq(0))
+    end
+  end
+
+  context "when the ERB comment syntax is incorrect" do
+    let(:file) { <<~FILE }
+      <% # first bad comment %>
+      <%= # second bad comment %>
+    FILE
+
+    it "reports two offenses" do
+      expect(subject.size).to(eq(2))
+    end
+
+    it "reports two offenses with their suggested fixes" do
+      expect(subject.first.message).to(include("Bad ERB comment syntax. Should be `<%#=` without a space between."))
+      expect(subject.last.message).to(include("Bad ERB comment syntax. Should be `<%#` without a space between."))
+    end
+  end
+end

--- a/spec/erb_lint/linters/comment_syntax_spec.rb
+++ b/spec/erb_lint/linters/comment_syntax_spec.rb
@@ -36,6 +36,20 @@ describe ERBLint::Linters::CommentSyntax do
 
   context "when the ERB comment syntax is incorrect" do
     let(:file) { <<~FILE }
+      <% # bad comment %>
+    FILE
+
+    it "reports one offense" do
+      expect(subject.size).to(eq(1))
+    end
+
+    it "reports the suggested fix" do
+      expect(subject.first.message).to(include("Bad ERB comment syntax. Should be <%# without a space between."))
+    end
+  end
+
+  context "when the ERB comment syntax is incorrect multiple times in one file" do
+    let(:file) { <<~FILE }
       <% # first bad comment %>
       <%= # second bad comment %>
     FILE
@@ -44,9 +58,9 @@ describe ERBLint::Linters::CommentSyntax do
       expect(subject.size).to(eq(2))
     end
 
-    it "reports two offenses with their suggested fixes" do
-      expect(subject.first.message).to(include("Bad ERB comment syntax. Should be `<%#=` without a space between."))
-      expect(subject.last.message).to(include("Bad ERB comment syntax. Should be `<%#` without a space between."))
+    it "reports the suggested fixes" do
+      expect(subject.first.message).to(include("Bad ERB comment syntax. Should be <%# without a space between."))
+      expect(subject.last.message).to(include("Bad ERB comment syntax. Should be <%#= without a space between."))
     end
   end
 end


### PR DESCRIPTION
- This adds a new ERB comment syntax linter to catch ERB comments that could trip up the Ruby parser in latest versions of Ruby.

- The ERB documentation[1] says that Ruby comments are not valid in ERB, and that comments in ERB should be of the form `<%# comment here %>` and not `<% # comment here %>`. That is, no space between the opening `<%` and the `#` character.

- This documentation is only a guideline usually, because in most cases Ruby-style comments work just fine. However, using the Ruby 3.1 parser, RuboCop's `Lint/Syntax` cop started failing on ERB files that included comments with semicolons in them.

- Take an example ERB file:

```erb
<%# This is the correct comment syntax. %>
<%# Recommending the "proper" ERB comment syntax seems like the safest way to go; even with semicolons it will parse. %>
<% # This is technically incorrect comment syntax but it generally parses. %>
<% # Until someone puts a ; in. %>
```

- This led to output from RuboCop's `Lint/Syntax` cop (RuboCop v1.36, `TargetRubyVersion: 3.1`) where it failed to parse the file, but its code snippets and offense locations were not very useful. (Admittedly it's less visible in this contrived example, you'll have to trust me!)

```shell
app/views/proof_of_concept.html.erb:7:2: E: Lint/Syntax: unexpected token kIN
(Using Ruby 3.1 parser; configure using TargetRubyVersion parameter, under AllCops)
 in.
 ^^

1 file inspected, 1 offense detected
```

- After lots of being confused, because the code looked like valid Ruby and the editor was syntax highlighting it if it were a valid comment, we realised that it was the semicolon in the comment in the ERB that was tripping the Ruby 3.1 parser up.

- Doing some digging, it turns out that this could have all been avoided if our codebase had respected ERB's "Ruby comments are not valid" guideline[1]. I went hunting for a RuboCop rule for this, then remembered that ERBLint existed and is way better suited to linting ERB. There wasn't an existing rule for ERB comment syntax that I could find, hence this addition, because I feel like individual developers shouldn't have to know this quirk of ERB off the top of their heads!

[1] - https://github.com/ruby/erb/tree/a3492c4bd1061071814cca085544ce259a9d8d56#recognized-tags

----

Example ERB file:

```erb
<%# erb comment here %>
<%= # bad erb comment here %>
<%
  # apparently this comment syntax is valid?
%>
<% # very; bad erb comment here %>
```

Example behaviour of this new linter:

```shell
❯ exe/erblint --enable-linters=comment_syntax test_comment_syntax.html.erb
.erb-lint.yml not found: using default config
Linting 1 files with 1 linters...

Bad ERB comment syntax. Should be <%#= without a space between.
Leaving a space between ERB tags and the Ruby comment character can cause parser errors.
In file: test_comment_syntax.html.erb:2

Bad ERB comment syntax. Should be <%# without a space between.
Leaving a space between ERB tags and the Ruby comment character can cause parser errors.
In file: test_comment_syntax.html.erb:6

2 error(s) were found in ERB files
```

---

Thanks for building ERBLint, and thanks in advance for the review here! ✨ 