### PR TITLE
Added Rake support

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,25 @@ def autocorrect(_processed_source, offense)
 end
 ```
 
+## Rake
+
+You can add Rake support by adding the following to your `Rakefile`:
+
+    require "erb_lint/rake_task"
+    ERBLint::RakeTask.new
+
+The Rake task can be customized as follows:
+
+    # Custom arguments.
+    ERBLint::RakeTask.new { %w[--autocorrect .] }
+
+    # Custom name and arguments.
+    ERBLint::RakeTask.new(:erb_auto_correct) { %w[--autocorrect .] }
+
+Once required, the default tasks will be available (i.e. `bundle exec rake -T`) unless customized further:
+
+    rake erb_lint
+
 ## Output formats
 
 You can change the output format of ERB Lint by specifying formatters with the `-f/--format` option.

--- a/lib/erb_lint/rake_task.rb
+++ b/lib/erb_lint/rake_task.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rake"
+require "rake/tasklib"
+require "erb_lint/cli"
+
+module ERBLint
+  # Defines Rake tasks for use.
+  class RakeTask < ::Rake::TaskLib
+    def initialize(name = :erb_lint, cli: ERBLint::CLI.new)
+      super()
+      @name = name
+      @cli = cli
+      @arguments = block_given? ? yield : ["--lint-all"]
+
+      define
+    end
+
+    private
+
+    attr_reader :name, :arguments, :cli
+
+    def define
+      desc("Run ERB Lint")
+      task(name) { run }
+    end
+
+    def run
+      rake_output_message("Running ERB Lint...")
+      cli.run(arguments)
+    end
+  end
+end

--- a/spec/lib/rake_task_spec.rb
+++ b/spec/lib/rake_task_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fakefs"
+require "fakefs/spec_helpers"
+
+FakeFS.deactivate!
+require "erb_lint/rake_task"
+FakeFS.activate!
+
+RSpec.describe(ERBLint::RakeTask) do
+  subject(:task) { described_class.new(cli: cli) }
+
+  let(:cli) { instance_spy ERBLint::CLI }
+
+  before { Rake::Task.clear }
+
+  describe "#initialize" do
+    it "logs error" do
+      task
+      expectation = proc { Rake::Task["erb_lint"].execute }
+
+      expect(&expectation).to(output(/Running ERB Lint.../).to_stderr)
+    end
+
+    it "executes with default name and arguments" do
+      task
+      Rake::Task["erb_lint"].execute
+
+      expect(cli).to(have_received(:run).with(["--lint-all"]))
+    end
+
+    it "executes with default name and custom arguments" do
+      described_class.new(cli: cli) { ["--autocorrect", "."] }
+      Rake::Task["erb_lint"].execute
+
+      expect(cli).to(have_received(:run).with(["--autocorrect", "."]))
+    end
+
+    it "executes with custom name and arguments" do
+      described_class.new(:erb_auto_correct, cli: cli) { ["--autocorrect", "."] }
+      Rake::Task["erb_auto_correct"].execute
+
+      expect(cli).to(have_received(:run).with(["--autocorrect", "."]))
+    end
+  end
+end


### PR DESCRIPTION
## Overview

The following adds Rake support so it's easier to wire up this gem using Rake and run code quality analysis from the CLI (or wired up via CI).

## Details

- See commits for details.

## Notes

Something is off with the way FakeFS works where the full RSpec test suite won't run with this new spec. You can only verify this works locally by running:

``` 
bundle exec rspec spec/lib/rake/task_spec.rb
```

I'm not familiar with FakeFS so maybe there is a configuration option that I'm missing?

