### PR TITLE
Allow custom cache directory via --cache-dir option

### DIFF
--- a/lib/erb_lint/cache.rb
+++ b/lib/erb_lint/cache.rb
@@ -4,9 +4,8 @@ module ERBLint
   class Cache
     CACHE_DIRECTORY = ".erb-lint-cache"
 
-    def initialize(config, file_loader = nil)
+    def initialize(config)
       @config = config
-      @file_loader = file_loader
       @hits = []
       @new_results = []
       puts "Cache mode is on"

--- a/lib/erb_lint/cache.rb
+++ b/lib/erb_lint/cache.rb
@@ -4,8 +4,9 @@ module ERBLint
   class Cache
     CACHE_DIRECTORY = ".erb-lint-cache"
 
-    def initialize(config)
+    def initialize(config, cache_dir = nil)
       @config = config
+      @cache_dir = cache_dir || CACHE_DIRECTORY
       @hits = []
       @new_results = []
       puts "Cache mode is on"
@@ -15,7 +16,7 @@ module ERBLint
       file_checksum = checksum(filename, file_content)
       begin
         cache_file_contents_as_offenses = JSON.parse(
-          File.read(File.join(CACHE_DIRECTORY, file_checksum))
+          File.read(File.join(@cache_dir, file_checksum))
         ).map do |offense_hash|
           ERBLint::CachedOffense.new(offense_hash)
         end
@@ -30,9 +31,9 @@ module ERBLint
       file_checksum = checksum(filename, file_content)
       @new_results.push(file_checksum)
 
-      FileUtils.mkdir_p(CACHE_DIRECTORY)
+      FileUtils.mkdir_p(@cache_dir)
 
-      File.open(File.join(CACHE_DIRECTORY, file_checksum), "wb") do |f|
+      File.open(File.join(@cache_dir, file_checksum), "wb") do |f|
         f.write(offenses_as_json)
       end
     end
@@ -47,23 +48,23 @@ module ERBLint
         return
       end
 
-      cache_files = Dir.new(CACHE_DIRECTORY).children
+      cache_files = Dir.new(@cache_dir).children
       cache_files.each do |cache_file|
         next if hits.include?(cache_file) || new_results.include?(cache_file)
 
-        File.delete(File.join(CACHE_DIRECTORY, cache_file))
+        File.delete(File.join(@cache_dir, cache_file))
       end
     end
 
     def cache_dir_exists?
-      File.directory?(CACHE_DIRECTORY)
+      File.directory?(@cache_dir)
     end
 
     def clear
       return unless cache_dir_exists?
 
       puts "Clearing cache by deleting cache directory"
-      FileUtils.rm_r(CACHE_DIRECTORY)
+      FileUtils.rm_r(@cache_dir)
     end
 
     private

--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -39,7 +39,8 @@ module ERBLint
 
       load_config
 
-      @cache = Cache.new(@config) if cache? || clear_cache?
+      cache_dir = @options[:cache_dir]
+      @cache = Cache.new(@config, cache_dir) if cache? || clear_cache?
 
       if clear_cache?
         if cache.cache_dir_exists?
@@ -336,6 +337,10 @@ module ERBLint
 
         opts.on("--cache", "Enable caching") do |config|
           @options[:cache] = config
+        end
+
+        opts.on("--cache-dir DIR", "Set the cache directory") do |dir|
+          @options[:cache_dir] = dir
         end
 
         opts.on("--clear-cache", "Clear cache") do |config|

--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -39,7 +39,7 @@ module ERBLint
 
       load_config
 
-      @cache = Cache.new(@config, file_loader) if cache? || clear_cache?
+      @cache = Cache.new(@config) if cache? || clear_cache?
 
       if clear_cache?
         if cache.cache_dir_exists?

--- a/spec/erb_lint/cache_spec.rb
+++ b/spec/erb_lint/cache_spec.rb
@@ -9,10 +9,10 @@ describe ERBLint::Cache do
   include FakeFS::SpecHelpers
 
   let(:linter_config) { ERBLint::LinterConfig.new }
-  let(:cache) { described_class.new(linter_config) }
+  let(:cache) { described_class.new(linter_config, cache_dir) }
   let(:linted_file_path) { "app/components/elements/image_component/image_component.html.erb" }
   let(:checksum) { "2dc3e17183b87889cc783b0157723570d4bbb90a" }
-  let(:cache_dir) { ERBLint::Cache::CACHE_DIRECTORY }
+  let(:cache_dir) { "tmp/erb_lint" }
   let(:rubocop_yml) { %(SpaceAroundErbTag:\n  Enabled: true\n) }
   let(:cache_file_content) do
     FakeFS.deactivate!
@@ -74,6 +74,7 @@ describe ERBLint::Cache do
     it "returns true if the cache dir exists" do
       expect(cache.cache_dir_exists?).to(be(true))
     end
+
     it "returns false if the cache dir does not exist" do
       FileUtils.rm_rf(cache_dir)
       expect(cache.cache_dir_exists?).to(be(false))

--- a/spec/erb_lint/cli_spec.rb
+++ b/spec/erb_lint/cli_spec.rb
@@ -148,6 +148,19 @@ describe ERBLint::CLI do
       end
     end
 
+    context "with custom --cache-dir" do
+      let(:args) { ["--lint-all", "--enable-linter", "linter_with_errors", "--clear-cache", "--cache-dir", cache_dir] }
+      let(:cache_dir) { "tmp/erb_lint" }
+
+      before do
+        FileUtils.mkdir_p(cache_dir)
+      end
+
+      it "uses the specified directory" do
+        expect { subject }.to(output(/cache directory cleared/).to_stdout)
+      end
+    end
+
     context "with file as argument" do
       context "when file does not exist" do
         let(:linted_file) { "/path/to/myfile.html.erb" }


### PR DESCRIPTION
### Motivation

Follow up to: https://github.com/Shopify/erb-lint/pull/268#issuecomment-1277724794

As discussed in the prior PR, it would be nice to be able to specify the cache directory like you can do with Rubocop.