### PR TITLE
Release 0.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    erb_lint (0.2.0)
+    erb_lint (0.3.0)
       activesupport
       better_html (>= 2.0.1)
       parser (>= 2.7.1.4)
@@ -12,13 +12,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    actionview (7.0.3.1)
-      activesupport (= 7.0.3.1)
+    actionview (7.0.4)
+      activesupport (= 7.0.4)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activesupport (7.0.3.1)
+    activesupport (7.0.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -39,7 +39,7 @@ GEM
     fakefs (1.5.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    loofah (2.18.0)
+    loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mini_portile2 (2.8.0)

--- a/gemfiles/Gemfile.rubocop-next
+++ b/gemfiles/Gemfile.rubocop-next
@@ -2,4 +2,4 @@
 
 eval_gemfile "../Gemfile"
 
-gem "rubocop", ">= 0.87"
+gem "rubocop", "~> 1.37.1"

--- a/lib/erb_lint/version.rb
+++ b/lib/erb_lint/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ERBLint
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
Release new version of `erb-lint` with recent cache features. Release notes prepped [here](https://github.com/Shopify/erb-lint/releases/edit/untagged-4453879d2af3a0d9f43e).

There are a bunch of [failures](https://github.com/Shopify/erb-lint/actions/runs/3369355769/jobs/5588916316) in CI with rubocop 1.38.0, which was [released today](https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#1380-2022-11-01), so for now I've pinned Rubocop in the Gemfile to 1.37.1.

