### PR TITLE
Make HardCodedString linter ignore &times;

### DIFF
--- a/lib/erb_lint/linters/hard_coded_string.rb
+++ b/lib/erb_lint/linters/hard_coded_string.rb
@@ -40,6 +40,7 @@ module ERBLint
         "&ensp;",
         "&emsp;",
         "&thinsp;",
+        "&times;",
       ])
 
       class ConfigSchema < LinterConfig


### PR DESCRIPTION
This symbol is often used for close buttons and does not really need to be translated.
