### PR TITLE
Clarify list of strings that don't need translating

### DIFF
--- a/lib/erb_lint/linters/hard_coded_string.rb
+++ b/lib/erb_lint/linters/hard_coded_string.rb
@@ -17,7 +17,7 @@ module ERBLint
       ALLOWED_CORRECTORS = ["I18nCorrector", "RuboCop::Corrector::I18n::HardCodedString"]
 
       NON_TEXT_TAGS = Set.new(["script", "style", "xmp", "iframe", "noembed", "noframes", "listing"])
-      TEXT_NOT_ALLOWED = Set.new([
+      NO_TRANSLATION_NEEDED = Set.new([
         "&nbsp;",
         "&amp;",
         "&lt;",
@@ -96,7 +96,7 @@ module ERBLint
 
       def check_string?(str)
         string = str.gsub(/\s*/, "")
-        string.length > 1 && !TEXT_NOT_ALLOWED.include?(string)
+        string.length > 1 && !NO_TRANSLATION_NEEDED.include?(string)
       end
 
       def load_corrector


### PR DESCRIPTION
The name `TEXT_NOT_ALLOWED` was confusing and indicated the opposite meaning of what was intended, namely text that is allowed to stay hard-coded.
