### PR TITLE
Support RuboCop 1.38

### DIFF
--- a/gemfiles/Gemfile.rubocop-next
+++ b/gemfiles/Gemfile.rubocop-next
@@ -2,4 +2,4 @@
 
 eval_gemfile "../Gemfile"
 
-gem "rubocop", "~> 1.37.1"
+gem "rubocop", ">= 1.38.0"

--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -131,11 +131,17 @@ module ERBLint
       end
 
       def rubocop_processed_source(content, filename)
-        ::RuboCop::ProcessedSource.new(
+        source = ::RuboCop::ProcessedSource.new(
           content,
           @rubocop_config.target_ruby_version,
           filename
         )
+        if ::RuboCop::Version::STRING.to_f >= 1.38
+          registry = RuboCop::Cop::Registry.global
+          source.registry = registry
+          source.config = @rubocop_config
+        end
+        source
       end
 
       def cop_classes


### PR DESCRIPTION
This fixes #286.

- Bump and loosen rubocop version in rubocop-next bundle
- Make RuboCop linter work with RuboCop 1.38
