### PR TITLE
Added JUnit.xml support via --format junit

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,25 @@ app/views/users/_graph.html.erb:27:37: Extra space detected where there should b
 2 error(s) were found in ERB files
 ```
 
+### JUnit.xml
+
+```sh
+erblint --format junit
+<?xml version="1.0" encoding="UTF-8"?>\n<testsuite name="erblint" tests="2" failures="2">\n<properties>\n<property name="erb_lint_version" value="0.3.1" />\n<property name="ruby_engine" value="ruby" />\n<property name="ruby_version" value="3.1.2" />\n<property name="ruby_patchlevel" value="20" />\n<property name="ruby_platform" value="arm64-darwin21" />\n</properties>\n<testcase name="app.views.index.html.erb" file="app/views/index.html.erb">\n</testcase>\n<testcase name="app.views.subscriptions._loader.html.erb" file="app/views/subscriptions/_loader.html.erb">\n<failure message="Extra space detected where there should be no space." type="SpaceInHtmlTag">\nExtra space detected where there should be no space.\n</failure>\n</testcase>\n<testcase name="app.views.subscriptions._loader.html.erb" file="app/views/subscriptions/_loader.html.erb">\n<failure message="Remove newline before `%&gt;` to match start of tag." type="ClosingErbTagIndent">\nRemove newline before `%&gt;` to match start of tag.\n</failure>\n</testcase>\n</testsuite>\n
+```
+
+Use it with [GitlabCI](https://gitlab.com):
+
+```yml
+erblint:
+  stage: lint
+  script:
+    - bundle exec erblint --lint-all --format junit > erblint-junit.xml
+  artifacts:
+    reports:
+      junit: erblint-junit.xml
+```
+
 ## Caching
 
 The cache is currently opt-in - to turn it on, use the --cache option:

--- a/lib/erb_lint/reporters/junit_reporter.rb
+++ b/lib/erb_lint/reporters/junit_reporter.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+module ERBLint
+  module Reporters
+    class JunitReporter < Reporter
+      def preview; end
+
+      def show
+        @output = []
+        xml_dump
+        puts @output.join("\n")
+      end
+
+      private
+
+      def xml_dump
+        @output << %{<?xml version="1.0" encoding="UTF-8"?>}
+        tests = stats.processed_files.size
+        failures = stats.found
+        @output << %{<testsuite name="erblint" tests="#{tests}" failures="#{failures}">}
+        xml_dump_properties
+        xml_dump_examples
+        @output << %{</testsuite>\n}
+      end
+
+      def xml_dump_properties
+        @output << %{<properties>}
+        [
+          { name: "erb_lint_version", value: ERBLint::VERSION },
+          { name: "ruby_engine", value: RUBY_ENGINE },
+          { name: "ruby_version", value: RUBY_VERSION },
+          { name: "ruby_patchlevel", value: RUBY_PATCHLEVEL.to_s },
+          { name: "ruby_platform", value: RUBY_PLATFORM },
+        ].each do |property|
+          @output << %{<property name="#{property[:name]}" value="#{escape(property[:value])}" />}
+        end
+        @output << %{</properties>}
+      end
+
+      def xml_dump_examples
+        processed_files.each do |filename, offenses|
+          next xml_dump_example(filename) if offenses.empty?
+
+          offenses.each do |offense|
+            xml_dump_failed(filename, offense)
+          end
+        end
+      end
+
+      def xml_dump_failed(filename, offense)
+        xml_dump_example(filename) do
+          message = escape(offense.message)
+          type = escape(offense.simple_name)
+          @output << %{<failure message="#{message}" type="#{type}">}
+          @output << escape(offense.message)
+          @output << %{</failure>}
+        end
+      end
+
+      def xml_dump_example(filename)
+        name = escape(filename.downcase.gsub(/[^a-z\-_]+/, "."))
+        file = escape(filename)
+        @output << %{<testcase name="#{name}" file="#{file}">}
+        yield if block_given?
+        @output << %{</testcase>}
+      end
+
+      # Inversion of character range from https://www.w3.org/TR/xml/#charsets
+      ILLEGAL_REGEXP = Regexp.new(
+        "[^".dup <<
+        "\u{9}" << # => \t
+        "\u{a}" << # => \n
+        "\u{d}" << # => \r
+        "\u{20}-\u{d7ff}" \
+          "\u{e000}-\u{fffd}" \
+          "\u{10000}-\u{10ffff}" \
+          "]"
+      )
+
+      # Replace illegals with a Ruby-like escape
+      ILLEGAL_REPLACEMENT = Hash.new do |_, c|
+        x = c.ord
+        # rubocop:disable Style/FormatString
+        if x <= 0xff
+          "\\x%02X" % x
+        elsif x <= 0xffff
+          "\\u%04X" % x
+        else
+          "\\u{%X}" % x
+        end.freeze
+        # rubocop:enable Style/FormatString
+      end.update(
+        "\0" => "\\0",
+        "\a" => "\\a",
+        "\b" => "\\b",
+        "\f" => "\\f",
+        "\v" => "\\v",
+        "\e" => "\\e",
+      ).freeze
+
+      # Discouraged characters from https://www.w3.org/TR/xml/#charsets
+      # Plus special characters with well-known entity replacements
+      DISCOURAGED_REGEXP = Regexp.new(
+        "[".dup <<
+        "\u{22}" << # => "
+        "\u{26}" << # => &
+        "\u{27}" << # => '
+        "\u{3c}" << # => <
+        "\u{3e}" << # => >
+        "\u{7f}-\u{84}" \
+          "\u{86}-\u{9f}" \
+          "\u{fdd0}-\u{fdef}" \
+          "\u{1fffe}-\u{1ffff}" \
+          "\u{2fffe}-\u{2ffff}" \
+          "\u{3fffe}-\u{3ffff}" \
+          "\u{4fffe}-\u{4ffff}" \
+          "\u{5fffe}-\u{5ffff}" \
+          "\u{6fffe}-\u{6ffff}" \
+          "\u{7fffe}-\u{7ffff}" \
+          "\u{8fffe}-\u{8ffff}" \
+          "\u{9fffe}-\u{9ffff}" \
+          "\u{afffe}-\u{affff}" \
+          "\u{bfffe}-\u{bffff}" \
+          "\u{cfffe}-\u{cffff}" \
+          "\u{dfffe}-\u{dffff}" \
+          "\u{efffe}-\u{effff}" \
+          "\u{ffffe}-\u{fffff}" \
+          "\u{10fffe}-\u{10ffff}" \
+          "]"
+      )
+
+      # Translate well-known entities, or use generic unicode hex entity
+      DISCOURAGED_REPLACEMENTS = Hash.new { |_, c| "&#x#{c.ord.to_s(16)};" }.update(
+        '"' => "&quot;",
+        "&" => "&amp;",
+        "'" => "&apos;",
+        "<" => "&lt;",
+        ">" => "&gt;",
+      ).freeze
+
+      def escape(text)
+        # Make sure it's utf-8, replace illegal characters with ruby-like
+        # escapes, and replace special and discouraged characters with entities
+        text
+          .to_s
+          .encode(Encoding::UTF_8)
+          .gsub(ILLEGAL_REGEXP, ILLEGAL_REPLACEMENT)
+          .gsub(DISCOURAGED_REGEXP, DISCOURAGED_REPLACEMENTS)
+      end
+    end
+  end
+end

--- a/spec/erb_lint/fixtures/junit.xml
+++ b/spec/erb_lint/fixtures/junit.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="erblint" tests="2" failures="2">
+<properties>
+<property name="erb_lint_version" value="0.3.1" />
+<property name="ruby_engine" value="ruby" />
+<property name="ruby_version" value="3.1.2" />
+<property name="ruby_patchlevel" value="20" />
+<property name="ruby_platform" value="arm64-darwin21" />
+</properties>
+<testcase name="app.views.index.html.erb" file="app/views/index.html.erb">
+</testcase>
+<testcase name="app.views.subscriptions._loader.html.erb" file="app/views/subscriptions/_loader.html.erb">
+<failure message="Extra space detected where there should be no space." type="SpaceInHtmlTag">
+Extra space detected where there should be no space.
+</failure>
+</testcase>
+<testcase name="app.views.subscriptions._loader.html.erb" file="app/views/subscriptions/_loader.html.erb">
+<failure message="Remove newline before `%&gt;` to match start of tag." type="ClosingErbTagIndent">
+Remove newline before `%&gt;` to match start of tag.
+</failure>
+</testcase>
+</testsuite>

--- a/spec/erb_lint/reporters/junit_reporter_spec.rb
+++ b/spec/erb_lint/reporters/junit_reporter_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "pry"
+
+describe ERBLint::Reporters::JunitReporter do
+  describe ".show" do
+    subject { described_class.new(stats, false).show }
+
+    let(:stats) do
+      ERBLint::Stats.new(
+        found: 2,
+        processed_files: {
+          "app/views/index.html.erb" => [],
+          "app/views/subscriptions/_loader.html.erb" => offenses,
+        },
+        corrected: 1
+      )
+    end
+
+    let(:offenses) do
+      [
+        instance_double(
+          ERBLint::Offense,
+          message: "Extra space detected where there should be no space.",
+          line_number: 1,
+          column: 7,
+          simple_name: "SpaceInHtmlTag",
+          last_line: 1,
+          last_column: 9,
+          length: 2,
+        ),
+        instance_double(
+          ERBLint::Offense,
+          message: "Remove newline before `%>` to match start of tag.",
+          line_number: 52,
+          column: 10,
+          simple_name: "ClosingErbTagIndent",
+          last_line: 54,
+          last_column: 10,
+          length: 10,
+        ),
+      ]
+    end
+
+    let(:expected_xml) do
+      File.read(File.expand_path("./spec/erb_lint/fixtures/junit.xml"))
+    end
+
+    it "displays formatted offenses output" do
+      expect { subject }.to(output(expected_xml).to_stdout)
+    end
+  end
+end


### PR DESCRIPTION
Addresses #295. 

Shamelessly based on [sj26/rspec_junit_formatter](https://github.com/sj26/rspec_junit_formatter/blob/main/lib/rspec_junit_formatter.rb). I additionally validated the `spec/erb_lint/fixtures/junit.xml` with [xmlvalidation.com](https://www.xmlvalidation.com/) for a good measure.

This is a minimal example, without timings and hostnames, but good enough to display this test summary on GitlabCI, and I assume on other CI interfaces as well.

<img width="972" alt="image" src="https://user-images.githubusercontent.com/16985871/208950188-d65b07a4-c596-42ff-bb2a-4ff866243830.png">
