### PR TITLE
Bump development Ruby version

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,7 +1,7 @@
 name: erb-lint
 
 up:
-  - ruby: 2.5.3
+  - ruby: '3.2.2'
   - bundler
 
 commands:


### PR DESCRIPTION
`bundle install` fails for the current version, and it's less than the minimum version we require anyway.

Since we run CI against previous versions, we can jump all the way to a recent version locally, and rely on tests to catch incompatibilities.