### PR TITLE
Improve comment syntax suggestions

### DIFF
--- a/lib/erb_lint/linters/comment_syntax.rb
+++ b/lib/erb_lint/linters/comment_syntax.rb
@@ -15,7 +15,7 @@ module ERBLint
         return if file_content.empty?
 
         processed_source.ast.descendants(:erb).each do |erb_node|
-          indicator_node, _, code_node, _ = *erb_node
+          indicator_node, trim, code_node, _ = *erb_node
           next if code_node.nil?
 
           indicator_node_str = indicator_node&.deconstruct&.last
@@ -27,7 +27,13 @@ module ERBLint
           range = find_range(erb_node, code_node_str)
           source_range = processed_source.to_source_range(range)
 
-          correct_erb_tag = indicator_node_str == "=" ? "<%#=" : "<%#"
+          correct_erb_tag = if indicator_node_str == "="
+            "<%#= or <%#"
+          elsif trim
+            "<%-#"
+          else
+            "<%#"
+          end
 
           add_offense(
             source_range,

--- a/spec/erb_lint/linters/comment_syntax_spec.rb
+++ b/spec/erb_lint/linters/comment_syntax_spec.rb
@@ -52,15 +52,25 @@ describe ERBLint::Linters::CommentSyntax do
     let(:file) { <<~FILE }
       <% # first bad comment %>
       <%= # second bad comment %>
+      <%- # third bad comment %>
     FILE
 
-    it "reports two offenses" do
-      expect(subject.size).to(eq(2))
+    it "reports all offenses" do
+      expect(subject.size).to(eq(file.each_line.count))
     end
 
     it "reports the suggested fixes" do
-      expect(subject.first.message).to(include("Bad ERB comment syntax. Should be <%# without a space between."))
-      expect(subject.last.message).to(include("Bad ERB comment syntax. Should be <%#= without a space between."))
+      expected_messages = [
+        "Bad ERB comment syntax. Should be <%# without a space between.",
+        "Bad ERB comment syntax. Should be <%#= or <%# without a space between.",
+        "Bad ERB comment syntax. Should be <%-# without a space between.",
+      ]
+      actual_messages = subject.map(&:message)
+      expect(actual_messages.size).to(eq(expected_messages.size))
+
+      expected_messages.zip(actual_messages).each do |expected, actual|
+        expect(actual).to(include(expected))
+      end
     end
   end
 end


### PR DESCRIPTION
This adds handling for `<%- #`, and clarifies that `<%#=` is just a comment starting with `=`, as opposed to some special construct.

Original|Replacement|Notes
-|-|-
`<% #`|`<%#`
`<%= #`|`<%#`|If the `=` was there unintentionally, it can be removed.
`<%= #`|`<%#=`|If temporarily commenting out the line, with the intent of restoring it.
`<%- #`|`<%-#`|`-` affect whitespace, so we it should be kept, even if this is a comment.