### PR TITLE
Don't repeat global excludes in linter config

### DIFF
--- a/lib/erb_lint/runner_config.rb
+++ b/lib/erb_lint/runner_config.rb
@@ -83,7 +83,7 @@ module ERBLint
     def config_hash_for_linter(klass_name)
       config_hash = linters_config[klass_name] || {}
       config_hash["exclude"] ||= []
-      config_hash["exclude"].concat(global_exclude) if config_hash["exclude"].is_a?(Array)
+      config_hash["exclude"].concat(global_exclude).uniq! if config_hash["exclude"].is_a?(Array)
       config_hash
     end
 

--- a/spec/erb_lint/runner_config_spec.rb
+++ b/spec/erb_lint/runner_config_spec.rb
@@ -138,7 +138,7 @@ describe ERBLint::RunnerConfig do
         let(:config_hash) do
           {
             linters: {
-              "MyCustomLinter" => { exclude: ["foo/bar.rb"] },
+              "MyCustomLinter" => { exclude: linter_excludes },
             },
             exclude: [
               "**/node_modules/**",
@@ -146,8 +146,20 @@ describe ERBLint::RunnerConfig do
           }
         end
 
-        it "excluded files are merged" do
-          expect(subject.exclude).to(eq(["foo/bar.rb", "**/node_modules/**"]))
+        context "when linter excludes do not contain global excludes" do
+          let(:linter_excludes) { ["foo/bar.rb"] }
+
+          it "excluded files are merged" do
+            expect(subject.exclude).to(eq(["foo/bar.rb", "**/node_modules/**"]))
+          end
+        end
+
+        context "when linter excludes already contain global excludes" do
+          let(:linter_excludes) { ["foo/bar.rb", "**/node_modules/**"] }
+
+          it "does not duplicate the global excluded files" do
+            expect(subject.exclude).to(eq(["foo/bar.rb", "**/node_modules/**"]))
+          end
         end
       end
     end


### PR DESCRIPTION
This caused the config to keep growing (and therefore modifying) which affected the file caching fingerprinting which relies on the config hash.

The `for_linter` request for a config for the new ERBLint::Linters::NoUnusedDisable triggers this.

This causes the caching feature to not actually work since 0.4.0.

Reported in issue #318