### PR TITLE
Print the linter name on offence for `MultilineReporter`

### DIFF
--- a/lib/erb_lint/reporters/multiline_reporter.rb
+++ b/lib/erb_lint/reporters/multiline_reporter.rb
@@ -10,7 +10,7 @@ module ERBLint
       def format_offense(filename, offense)
         <<~EOF
 
-          #{offense.message}#{Rainbow(" (not autocorrected)").red if autocorrect}
+          #{offense.simple_name}: #{offense.message}#{Rainbow(" (not autocorrected)").red if autocorrect}
           In file: #{filename}:#{offense.line_number}
         EOF
       end

--- a/spec/erb_lint/cli_spec.rb
+++ b/spec/erb_lint/cli_spec.rb
@@ -235,10 +235,10 @@ describe ERBLint::CLI do
           it "shows all error messages and line numbers" do
             expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stdout)
 
-              fake message from a fake linter
+              LinterWithErrors: fake message from a fake linter
               In file: /app/views/template.html.erb:1
 
-              Missing a trailing newline at the end of the file.
+              FinalNewline: Missing a trailing newline at the end of the file.
               In file: /app/views/template.html.erb:1
 
             EOF
@@ -259,7 +259,7 @@ describe ERBLint::CLI do
           it "shows all error messages and line numbers" do
             expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stdout)
 
-              fake info message from a fake linter
+              LinterWithInfoErrors: fake info message from a fake linter
               In file: /app/views/template.html.erb:1
 
             EOF
@@ -360,7 +360,7 @@ describe ERBLint::CLI do
           it "shows all error messages and line numbers" do
             expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stdout)
 
-              fake info message from a fake linter
+              LinterWithInfoErrors: fake info message from a fake linter
               In file: /app/views/template.html.erb:1
 
             EOF
@@ -383,7 +383,7 @@ describe ERBLint::CLI do
           it "shows all error messages and line numbers" do
             expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stdout)
 
-              fake info message from a fake linter
+              LinterWithInfoErrors: fake info message from a fake linter
               In file: /app/views/template.html.erb:1
 
             EOF
@@ -452,10 +452,10 @@ describe ERBLint::CLI do
             it "shows all error messages and line numbers" do
               expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stdout)
 
-                fake message from a fake linter
+                LinterWithErrors: fake message from a fake linter
                 In file: /app/views/template.html.erb:1
 
-                Missing a trailing newline at the end of the file.
+                FinalNewline: Missing a trailing newline at the end of the file.
                 In file: /app/views/template.html.erb:1
 
               EOF
@@ -606,10 +606,10 @@ describe ERBLint::CLI do
           it "shows all error messages and line numbers" do
             expect { subject }.to(output(Regexp.new(Regexp.escape(<<~EOF))).to_stdout)
 
-              fake message from a fake linter
+              LinterWithErrors: fake message from a fake linter
               In file: /app/views/template.html.erb:1
 
-              Missing a trailing newline at the end of the file.
+              FinalNewline: Missing a trailing newline at the end of the file.
               In file: /app/views/template.html.erb:1
 
             EOF

--- a/spec/erb_lint/reporters/multiline_reporter_spec.rb
+++ b/spec/erb_lint/reporters/multiline_reporter_spec.rb
@@ -18,10 +18,12 @@ describe ERBLint::Reporters::MultilineReporter do
     let(:offenses) do
       [
         instance_double(ERBLint::Offense,
+          simple_name: "SpaceInHtmlTag",
           message: "Extra space detected where there should be no space.",
           line_number: 1,
           column: 7),
         instance_double(ERBLint::Offense,
+          simple_name: "ClosingErbTagIndent",
           message: "Remove newline before `%>` to match start of tag.",
           line_number: 52,
           column: 10),
@@ -34,10 +36,10 @@ describe ERBLint::Reporters::MultilineReporter do
       it "displays formatted offenses output" do
         expect { subject }.to(output(<<~MESSAGE).to_stdout)
 
-          Extra space detected where there should be no space.
+          SpaceInHtmlTag: Extra space detected where there should be no space.
           In file: app/views/subscriptions/_loader.html.erb:1
 
-          Remove newline before `%>` to match start of tag.
+          ClosingErbTagIndent: Remove newline before `%>` to match start of tag.
           In file: app/views/subscriptions/_loader.html.erb:52
 
         MESSAGE


### PR DESCRIPTION
The offences not showing from which linter they originate from makes it difficult to find information about the individual linters I need to take action on. Most are plenty self-explanatory and there aren't that many to begin with but `HardCodedString` isn't even documented right now, requiring me to look into the source code to find out how to disable it.