### PR TITLE
Update README code example for writing Custom linters with correct syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,16 +539,13 @@ module ERBLint
       end
       self.config_schema = ConfigSchema
 
-      def offenses(processed_source)
-        errors = []
+      def run(processed_source)
         unless processed_source.file_content.include?('this file is fine')
-          errors << Offense.new(
-            self,
+          add_offense(
             processed_source.to_source_range(0 ... processed_source.file_content.size),
             "This file isn't fine. #{@config.custom_message}"
           )
         end
-        errors
       end
     end
   end


### PR DESCRIPTION
The Custom linter code in the README was out of date and has been updated to use the latest syntax.

The code can be copy/pasted and will be working out of the box now.