### PR TITLE
Add `--show-linter-names` option

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -74,7 +74,7 @@ module ERBLint
       @stats.linters = enabled_linter_classes.size
       @stats.autocorrectable_linters = enabled_linter_classes.count(&:support_autocorrect?)
 
-      reporter = Reporter.create_reporter(@options[:format], @stats, autocorrect?)
+      reporter = Reporter.create_reporter(@options[:format], @stats, autocorrect?, @options[:show_linter_names])
       reporter.preview
 
       runner = ERBLint::Runner.new(file_loader, @config, @options[:disable_inline_configs])
@@ -373,6 +373,10 @@ module ERBLint
 
         opts.on("-a", "--autocorrect", "Correct offenses automatically if possible (default: false)") do |config|
           @options[:autocorrect] = config
+        end
+
+        opts.on("--show-linter-names", "Show linter names") do
+          @options[:show_linter_names] = true
         end
 
         opts.on("--allow-no-files", "When no matching files found, exit successfully (default: false)") do |config|

--- a/lib/erb_lint/reporter.rb
+++ b/lib/erb_lint/reporter.rb
@@ -23,9 +23,10 @@ module ERBLint
         .sort
     end
 
-    def initialize(stats, autocorrect)
+    def initialize(stats, autocorrect, show_linter_names = false)
       @stats = stats
       @autocorrect = autocorrect
+      @show_linter_names = show_linter_names
     end
 
     def preview; end
@@ -34,7 +35,7 @@ module ERBLint
 
     private
 
-    attr_reader :stats, :autocorrect
+    attr_reader :stats, :autocorrect, :show_linter_names
 
     delegate :processed_files, to: :stats
   end

--- a/lib/erb_lint/reporters/compact_reporter.rb
+++ b/lib/erb_lint/reporters/compact_reporter.rb
@@ -33,8 +33,9 @@ module ERBLint
           "#{filename}:",
           "#{offense.line_number}:",
           "#{offense.column}: ",
+          ("[#{offense.simple_name}] " if show_linter_names),
           offense.message.to_s,
-        ].join
+        ].compact.join
       end
 
       def footer; end

--- a/lib/erb_lint/reporters/multiline_reporter.rb
+++ b/lib/erb_lint/reporters/multiline_reporter.rb
@@ -8,9 +8,14 @@ module ERBLint
       private
 
       def format_offense(filename, offense)
+        details = "#{offense.message}#{Rainbow(" (not autocorrected)").red if autocorrect}"
+        if show_linter_names
+          details = "[#{offense.simple_name}] " + details
+        end
+
         <<~EOF
 
-          #{offense.message}#{Rainbow(" (not autocorrected)").red if autocorrect}
+          #{details}
           In file: #{filename}:#{offense.line_number}
         EOF
       end

--- a/spec/erb_lint/reporters/compact_reporter_spec.rb
+++ b/spec/erb_lint/reporters/compact_reporter_spec.rb
@@ -4,7 +4,9 @@ require "spec_helper"
 
 describe ERBLint::Reporters::CompactReporter do
   describe ".show" do
-    subject { described_class.new(stats, false).show }
+    let(:autocorrect) { false }
+    let(:show_linter_names) { false }
+    subject { described_class.new(stats, autocorrect, show_linter_names).show }
 
     let(:stats) do
       ERBLint::Stats.new(
@@ -21,18 +23,21 @@ describe ERBLint::Reporters::CompactReporter do
       [
         instance_double(
           ERBLint::Offense,
+          simple_name: "SpaceInHtmlTag",
           message: "Extra space detected where there should be no space.",
           line_number: 61,
           column: 10,
         ),
         instance_double(
           ERBLint::Offense,
+          simple_name: "FinalNewline",
           message: "Remove multiple trailing newline at the end of the file.",
           line_number: 125,
           column: 1,
         ),
         instance_double(
           ERBLint::Offense,
+          simple_name: "TrailingComma",
           message: "Trailing comma expected.",
           line_number: 145,
           column: 4,
@@ -45,18 +50,21 @@ describe ERBLint::Reporters::CompactReporter do
       [
         instance_double(
           ERBLint::Offense,
+          simple_name: "SpaceIndentation",
           message: "Indent with spaces instead of tabs.",
           line_number: 3,
           column: 1,
         ),
         instance_double(
           ERBLint::Offense,
+          simple_name: "SpaceInHtmlTag",
           message: "Extra space detected where there should be no space.",
           line_number: 7,
           column: 1,
         ),
         instance_double(
           ERBLint::Offense,
+          simple_name: "TrailingComma",
           message: "Trailing comma expected.",
           line_number: 8,
           column: 4,
@@ -74,6 +82,21 @@ describe ERBLint::Reporters::CompactReporter do
         app/views/shared/_notifications.html.erb:7:1: Extra space detected where there should be no space.
         app/views/shared/_notifications.html.erb:8:4: Trailing comma expected.
       MESSAGE
+    end
+
+    context "with show linter names enabled" do
+      let(:show_linter_names) { true }
+
+      it "displays formatted offenses output with linter names" do
+        expect { subject }.to(output(<<~MESSAGE).to_stdout)
+          app/views/users/show.html.erb:61:10: [SpaceInHtmlTag] Extra space detected where there should be no space.
+          app/views/users/show.html.erb:125:1: [FinalNewline] Remove multiple trailing newline at the end of the file.
+          app/views/users/show.html.erb:145:4: [TrailingComma] Trailing comma expected.
+          app/views/shared/_notifications.html.erb:3:1: [SpaceIndentation] Indent with spaces instead of tabs.
+          app/views/shared/_notifications.html.erb:7:1: [SpaceInHtmlTag] Extra space detected where there should be no space.
+          app/views/shared/_notifications.html.erb:8:4: [TrailingComma] Trailing comma expected.
+        MESSAGE
+      end
     end
 
     it "outputs offenses summary to stderr" do

--- a/spec/erb_lint/reporters/multiline_reporter_spec.rb
+++ b/spec/erb_lint/reporters/multiline_reporter_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe ERBLint::Reporters::MultilineReporter do
   describe ".show" do
-    subject { described_class.new(stats, autocorrect).show }
+    subject { described_class.new(stats, autocorrect, show_linter_names).show }
 
     let(:stats) do
       ERBLint::Stats.new(
@@ -19,12 +19,14 @@ describe ERBLint::Reporters::MultilineReporter do
       [
         instance_double(
           ERBLint::Offense,
+          simple_name: "SpaceInHtmlTag",
           message: "Extra space detected where there should be no space.",
           line_number: 1,
           column: 7,
         ),
         instance_double(
           ERBLint::Offense,
+          simple_name: "ClosingErbTagIndent",
           message: "Remove newline before `%>` to match start of tag.",
           line_number: 52,
           column: 10,
@@ -34,6 +36,7 @@ describe ERBLint::Reporters::MultilineReporter do
 
     context "when autocorrect is false" do
       let(:autocorrect) { false }
+      let(:show_linter_names) { false }
 
       it "displays formatted offenses output" do
         expect { subject }.to(output(<<~MESSAGE).to_stdout)
@@ -48,8 +51,26 @@ describe ERBLint::Reporters::MultilineReporter do
       end
     end
 
+    context "when show_linter_names is true" do
+      let(:autocorrect) { false }
+      let(:show_linter_names) { true }
+
+      it "displays formatted offenses output" do
+        expect { subject }.to(output(<<~MESSAGE).to_stdout)
+
+          [SpaceInHtmlTag] Extra space detected where there should be no space.
+          In file: app/views/subscriptions/_loader.html.erb:1
+
+          [ClosingErbTagIndent] Remove newline before `%>` to match start of tag.
+          In file: app/views/subscriptions/_loader.html.erb:52
+
+        MESSAGE
+      end
+    end
+
     context "when autocorrect is true" do
       let(:autocorrect) { true }
+      let(:show_linter_names) { false }
 
       it "displays not autocorrected warning" do
         expect { subject }.to(output(/(not autocorrected)/).to_stdout)


### PR DESCRIPTION
Closes #336

This PR adds a `--show-linter-names` option. It prepends each offence with the linter name.

It applies only to the Multiline and Compact reporters. The JSON and JUnit reporters already include the linter name, so I have left them as-is.

Note: If RuboCop is enabled, RuboCop offences will display as:

```
[Rubocop] Layout/TrailingEmptyLines: Final newline missing.
In file: app/views/announcements/index.html.erb:2
```
(the cop name part was already there, but having the `[RuboCop]` prefix now makes it easier to distinguish the source of each offence).