### PR TITLE
Detect instance variable in partial without leading whitespace

### DIFF
--- a/lib/erb_lint/linters/partial_instance_variable.rb
+++ b/lib/erb_lint/linters/partial_instance_variable.rb
@@ -7,7 +7,7 @@ module ERBLint
       include LinterRegistry
 
       def run(processed_source)
-        instance_variable_regex = /\s@\w+/
+        instance_variable_regex = /[^\w]?@\w+/
         return unless processed_source.filename.match?(%r{(\A|.*/)_[^/\s]*\.html\.erb\z}) &&
           processed_source.file_content.match?(instance_variable_regex)
 

--- a/spec/erb_lint/linters/partial_instance_variable_spec.rb
+++ b/spec/erb_lint/linters/partial_instance_variable_spec.rb
@@ -30,6 +30,15 @@ describe ERBLint::Linters::PartialInstanceVariable do
         ]))
       end
     end
+
+    context "when instance variable is present without leading whitespace" do
+      let(:file) { "<%= link_to(@user) %>" }
+      it do
+        expect(subject).to(eq([
+          build_offense(processed_source_one, 11..21, "Instance variable detected in partial."),
+        ]))
+      end
+    end
   end
 
   private


### PR DESCRIPTION
The regex used to detect an instance variable in a partial currently misses instance variables that are not immediately preceded by whitespace, as in this example:

```erb
<%= link_to(project.name, [@project_developer, project] %>
```

This modifies the regex to detect such cases, and adds a test.