### PR TITLE
add cache option to config file

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -31,15 +31,14 @@ module ERBLint
       dupped_args = args.dup
       load_options(dupped_args)
 
-      if cache? && autocorrect?
-        failure!("cannot run autocorrect mode with cache")
-      end
-
       @files = @options[:stdin] || dupped_args
 
       load_config
 
-      cache_dir = @options[:cache_dir]
+      if cache? && autocorrect?
+        failure!("cannot run autocorrect mode with cache")
+      end
+
       @cache = Cache.new(@config, cache_dir) if cache? || clear_cache?
 
       if clear_cache?
@@ -148,7 +147,11 @@ module ERBLint
     end
 
     def cache?
-      @options[:cache]
+      @config.to_hash.dig("cache", "enabled") || @options[:cache]
+    end
+
+    def cache_dir
+      @config.to_hash.dig("cache", "dir") || @options[:cache_dir]
     end
 
     def clear_cache?


### PR DESCRIPTION
Solves #309 

Added the cache options to the configuration file as requested in that issue.

1. If given no configuration of cache in file nor in command line options behave as actual implementation
2. If given configuration in the file the cache options are set, but can be overrided if given in the CLI command line options

So this is usefull to not have to put the command line options all the time when running the command.