### PR TITLE
Check variant files when looking for instance variables

### DIFF
--- a/lib/erb_lint/linters/partial_instance_variable.rb
+++ b/lib/erb_lint/linters/partial_instance_variable.rb
@@ -8,7 +8,7 @@ module ERBLint
 
       def run(processed_source)
         instance_variable_regex = /\s@\w+/
-        return unless processed_source.filename.match?(%r{(\A|.*/)_[^/\s]*\.html\.erb\z}) &&
+        return unless processed_source.filename.match?(%r{(\A|.*/)_[^/\s]*\.html(\+[^/\s]+)?\.erb\z}) &&
           processed_source.file_content.match?(instance_variable_regex)
 
         add_offense(

--- a/spec/erb_lint/linters/partial_instance_variable_spec.rb
+++ b/spec/erb_lint/linters/partial_instance_variable_spec.rb
@@ -8,16 +8,18 @@ describe ERBLint::Linters::PartialInstanceVariable do
   let(:linter) { described_class.new(file_loader, linter_config) }
   let(:processed_source_one) { ERBLint::ProcessedSource.new("_file.html.erb", file) }
   let(:processed_source_two) { ERBLint::ProcessedSource.new("app/views/_a_model/a_view.html.erb", file) }
+  let(:processed_source_three) { ERBLint::ProcessedSource.new("_variant.html+mobile.erb", file) }
   let(:offenses) { linter.offenses }
   before do
     linter.run(processed_source_one)
     linter.run(processed_source_two)
+    linter.run(processed_source_three)
   end
 
   describe "offenses" do
     subject { offenses }
 
-    context "when instance varaible is not present" do
+    context "when instance variable is not present" do
       let(:file) { "<%= user.first_name %>" }
       it { expect(subject).to(eq([])) }
     end
@@ -27,6 +29,7 @@ describe ERBLint::Linters::PartialInstanceVariable do
       it do
         expect(subject).to(eq([
           build_offense(processed_source_one, 7..32, "Instance variable detected in partial."),
+          build_offense(processed_source_three, 7..32, "Instance variable detected in partial."),
         ]))
       end
     end


### PR DESCRIPTION
I noticed there's a bug in the regex used to determine if a template is a partial, which means the partial instance variables linter was missing partials that include a variant in the filename.