### PR TITLE
Added a quiet reporter that directs all reporting data to stderr

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -80,18 +80,20 @@ module ERBLint
       runner = ERBLint::Runner.new(file_loader, @config, @options[:disable_inline_configs])
       file_content = nil
 
+      out = (@options[:format] == "quiet") ? method(:warn) : method(:puts)
+
       lint_files.each do |filename|
         runner.clear_offenses
         begin
           file_content = run_on_file(runner, filename)
         rescue => e
           @stats.exceptions += 1
-          puts "Exception occurred when processing: #{relative_filename(filename)}"
-          puts "If this file cannot be processed by erb-lint, " \
+          out.call "Exception occurred when processing: #{relative_filename(filename)}"
+          out.call "If this file cannot be processed by erb-lint, " \
             "you can exclude it in your configuration file."
-          puts e.message
-          puts Rainbow(e.backtrace.join("\n")).red
-          puts
+          out.call e.message
+          out.call Rainbow(e.backtrace.join("\n")).red
+          out.call
         end
       end
 
@@ -101,7 +103,7 @@ module ERBLint
 
       if stdin? && autocorrect?
         # When running from stdin, we only lint a single file
-        puts "================ #{lint_files.first} ==================\n"
+        out.call "================ #{lint_files.first} ==================\n"
         puts file_content
       end
 

--- a/lib/erb_lint/reporters/quiet_reporter.rb
+++ b/lib/erb_lint/reporters/quiet_reporter.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module ERBLint
+  module Reporters
+    class QuietReporter < Reporter
+      def preview
+        warn "#{linting} #{stats.files} files with #{linters}..."
+      end
+
+      def show
+        processed_files.each do |filename, offenses|
+          offenses.each do |offense|
+            warn format_offense(filename, offense)
+          end
+        end
+
+        footer
+        summary
+      end
+
+      private
+
+      def linting
+        "Linting" + (autocorrect ? " and autocorrecting" : "")
+      end
+
+      def linters
+        "#{stats.linters} linters" + (autocorrect ? " (#{stats.autocorrectable_linters} autocorrectable)" : "")
+      end
+
+      def format_offense(filename, offense)
+        [
+          "#{filename}:",
+          "#{offense.line_number}:",
+          "#{offense.column}: ",
+          ("[#{offense.simple_name}] " if show_linter_names),
+          offense.message.to_s
+        ].compact.join
+      end
+
+      def footer
+      end
+
+      def summary
+        if stats.corrected > 0
+          report_corrected_offenses
+        elsif stats.ignored > 0 || stats.found > 0
+          if stats.ignored > 0
+            warn(Rainbow("#{stats.ignored} error(s) were ignored in ERB files").yellow)
+          end
+
+          if stats.found > 0
+            warn(Rainbow("#{stats.found} error(s) were found in ERB files").red)
+          end
+        else
+          warn Rainbow("No errors were found in ERB files").green
+        end
+      end
+
+      def report_corrected_offenses
+        corrected_found_diff = stats.found - stats.corrected
+
+        if corrected_found_diff > 0
+          message = Rainbow(
+            "#{stats.corrected} error(s) corrected and #{corrected_found_diff} error(s) remaining in ERB files"
+          ).red
+
+          warn(message)
+        else
+          warn Rainbow("#{stats.corrected} error(s) corrected in ERB files").green
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Neovim conform and other editors such as Zed work better when able to pipe a file directly to stdin and get the formatted output via stdout.

The current reporters inject report data to the formatted file written to stdout. This PR adds a `quiet` reporter similar to [rubocop's quiet format](https://github.com/rubocop/rubocop/pull/1593) and writes all report output to stderr.

Addresses comments: https://github.com/Shopify/erb-lint/issues/225#issuecomment-2147731814, https://github.com/Shopify/erb-lint/issues/225#issuecomment-2192203785

The report output is still available via stderr but can also now be disabled with the ruby `-W0` flag to suppress the warnings:

```bash
❯ cat index.html.erb | ruby -W0 erblint --format quiet --autocorrect --stdin index.html.erb
```

This can be run now as follows in a `conform.nvim` configuration:

```lua
formatters = {
  erb_lint = {
    env = {
      RUBYOPT = "-W0" -- suppress reporting output
    },
    command = "bundle",
    args = { "exec", "erblint", "--format", "quiet", "--autocorrect", "$FILENAME" },
  },
}
```