### PR TITLE
Fix severity level names support in CLI

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -369,7 +369,7 @@ module ERBLint
         end
 
         opts.on("--fail-level SEVERITY", "Minimum severity for exit with error code") do |level|
-          parsed_severity = SEVERITY_CODE_TABLE[level.upcase.to_sym] || (SEVERITY_NAMES & [level.downcase]).first
+          parsed_severity = SEVERITY_CODE_TABLE[level.upcase.to_sym] || (SEVERITY_NAMES & [level.downcase.to_sym]).first
 
           if parsed_severity.nil?
             failure!("#{level}: not a valid failure level (#{SEVERITY_NAMES.join(", ")})")

--- a/spec/erb_lint/cli_spec.rb
+++ b/spec/erb_lint/cli_spec.rb
@@ -396,7 +396,7 @@ describe ERBLint::CLI do
       end
 
       context "when fail level is lower or equal than found errors" do
-        let(:args) { ["--lint-all", "--fail-level", "I", "--enable-linter", "linter_with_info_errors"] }
+        let(:args) { ["--lint-all", "--fail-level", "info", "--enable-linter", "linter_with_info_errors"] }
 
         context "with the default glob" do
           it "shows all error messages and line numbers" do


### PR DESCRIPTION
Fixes the #400 (--fail-level command line option does not accept severity names, only codes)