### PR TITLE
Rename erblint to erb_lint.

### DIFF
--- a/spec/erb_lint/linters/no_unused_disable_spec.rb
+++ b/spec/erb_lint/linters/no_unused_disable_spec.rb
@@ -22,16 +22,16 @@ describe ERBLint::Linters::NoUnusedDisable do
   describe "offenses" do
     subject { offenses }
     context "when file has unused disable comment" do
-      let(:file) { "<span></span><%# erblint:disable Fake %>" }
+      let(:file) { "<span></span><%# erb_lint:disable Fake %>" }
       before { linter.run(processed_source, []) }
       it do
         expect(subject.size).to(eq(1))
-        expect(subject.first.message).to(eq("Unused erblint:disable comment for Fake"))
+        expect(subject.first.message).to(eq("Unused erb_lint:disable comment for Fake"))
       end
     end
 
     context "when file has a disable comment and a corresponding offense" do
-      let(:file) { "<span></span><%# erblint:disable Fake %>" }
+      let(:file) { "<span></span><%# erb_lint:disable Fake %>" }
       before do
         offense = ERBLint::Offense.new(
           ERBLint::Linters::Fake.new(file_loader, linter_config),
@@ -49,7 +49,7 @@ describe ERBLint::Linters::NoUnusedDisable do
 
     context "when file has a disable comment in wrong place and a corresponding offense" do
       let(:file) { <<~FILE }
-        <%# erblint:disable Fake %>
+        <%# erb_lint:disable Fake %>
         <span>bad content</span>
       FILE
       before do
@@ -64,12 +64,12 @@ describe ERBLint::Linters::NoUnusedDisable do
 
       it "reports the unused inline comment" do
         expect(subject.size).to(eq(1))
-        expect(subject.first.message).to(eq("Unused erblint:disable comment for Fake"))
+        expect(subject.first.message).to(eq("Unused erb_lint:disable comment for Fake"))
       end
     end
 
     context "when file has disable comment for multiple rules" do
-      let(:file) { "<span></span><%# erblint:disable Fake, Fake2 %>" }
+      let(:file) { "<span></span><%# erb_lint:disable Fake, Fake2 %>" }
       before do
         offense = ERBLint::Offense.new(
           ERBLint::Linters::Fake.new(file_loader, linter_config),
@@ -82,14 +82,14 @@ describe ERBLint::Linters::NoUnusedDisable do
 
       it "reports the unused inline comment" do
         expect(subject.size).to(eq(1))
-        expect(subject.first.message).to(eq("Unused erblint:disable comment for Fake2"))
+        expect(subject.first.message).to(eq("Unused erb_lint:disable comment for Fake2"))
       end
     end
 
     context "when file has multiple disable comments for one offense" do
       let(:file) { <<~ERB }
-        <%# erblint:disable Fake %>
-        <span></span><%# erblint:disable Fake %>
+        <%# erb_lint:disable Fake %>
+        <span></span><%# erb_lint:disable Fake %>
       ERB
       before do
         offense = ERBLint::Offense.new(
@@ -103,7 +103,7 @@ describe ERBLint::Linters::NoUnusedDisable do
 
       it "reports the unused inline comment" do
         expect(subject.size).to(eq(1))
-        expect(subject.first.message).to(eq("Unused erblint:disable comment for Fake"))
+        expect(subject.first.message).to(eq("Unused erb_lint:disable comment for Fake"))
       end
     end
   end


### PR DESCRIPTION
To match the rest of the library.