### PR TITLE
Prevent opening ERB line from being a rubocop violation

### DIFF
--- a/lib/erb_lint/linters/rubocop.rb
+++ b/lib/erb_lint/linters/rubocop.rb
@@ -79,8 +79,19 @@ module ERBLint
             .to_source_range(rubocop_offense.location)
             .offset(offset)
 
+          next if offense_removes_erb_tag(rubocop_offense, processed_source)
+
           add_offense(rubocop_offense, offense_range, correction, offset, code_node.loc.range)
         end
+      end
+
+      def offense_removes_erb_tag(rubocop_offense, processed_source)
+        range = rubocop_offense.location
+
+        removed_lines = processed_source.to_source_range(range).source
+
+        erb_tag_pattern = /\A<%=?\z/
+        removed_lines.match?(erb_tag_pattern)
       end
 
       def tempfile_from(filename, content)


### PR DESCRIPTION
Addresses #331.

This fixes a problem where erb like:

```erb
<%
  some_ruby_code
%>
```

Would result in the first line being considered a `Layout/TrailingWhitespace` offense.  When used with `--autocorrect`, this would break the erb file by updating it to:

```txt
  some_ruby_code
%>
```

This fix will consider whether the source line is an erb tag only, and if so, not consider that a violation.

I'm not completely sure if this is the right fix or if there is a better fix that could be made at a different point, such as when parsing before trying to identify offenses.  Very open to feedback if there are better approaches.
