### PR TITLE
perf: add fast string pre-checks to skip unnecessary parsing

### DIFF
--- a/lib/erb_lint/linters/allowed_script_type.rb
+++ b/lib/erb_lint/linters/allowed_script_type.rb
@@ -23,9 +23,12 @@ module ERBLint
       def run(processed_source)
         parser = processed_source.parser
         parser.nodes_with_type(:tag).each do |tag_node|
+          # Fast path: check tag name from AST node directly before creating Tag object
+          tag_name_node = tag_node.to_a[1]
+          next unless tag_name_node&.loc&.source == "script"
+
           tag = BetterHtml::Tree::Tag.from_node(tag_node)
           next if tag.closing?
-          next unless tag.name == "script"
 
           if @config.disallow_inline_scripts?
             name_node = tag_node.to_a[1]

--- a/lib/erb_lint/linters/no_javascript_tag_helper.rb
+++ b/lib/erb_lint/linters/no_javascript_tag_helper.rb
@@ -25,6 +25,9 @@ module ERBLint
 
           source = code_node.loc.source
 
+          # Fast path: skip expensive parsing if source can't contain the target method
+          next unless source.include?("javascript_tag")
+
           ruby_node =
             begin
               BetterHtml::TestHelper::RubyNode.parse(source)

--- a/lib/erb_lint/linters/require_input_autocomplete.rb
+++ b/lib/erb_lint/linters/require_input_autocomplete.rb
@@ -52,6 +52,10 @@ module ERBLint
 
       def find_html_input_tags(parser)
         parser.nodes_with_type(:tag).each do |tag_node|
+          # Fast path: check tag name from AST node directly before creating Tag object
+          tag_name_node = tag_node.to_a[1]
+          next unless tag_name_node&.loc&.source == "input"
+
           tag = BetterHtml::Tree::Tag.from_node(tag_node)
 
           autocomplete_attribute = tag.attributes["autocomplete"]
@@ -82,10 +86,16 @@ module ERBLint
         type_present && HTML_INPUT_TYPES_REQUIRING_AUTOCOMPLETE.include?(type_attribute.value)
       end
 
+      FORM_HELPER_NAMES_PATTERN = Regexp.union(FORM_HELPERS_REQUIRING_AUTOCOMPLETE.map(&:to_s)).freeze
+
       def find_rails_helper_input_tags(parser)
         parser.ast.descendants(:erb).each do |erb_node|
           indicator_node, _, code_node, _ = *erb_node
           source = code_node.loc.source
+
+          # Fast path: skip expensive parsing if source can't contain any form helper name
+          next unless source.match?(FORM_HELPER_NAMES_PATTERN)
+
           ruby_node = extract_ruby_node(source)
           send_node = ruby_node&.descendants(:send)&.first
 

--- a/lib/erb_lint/linters/require_script_nonce.rb
+++ b/lib/erb_lint/linters/require_script_nonce.rb
@@ -21,6 +21,10 @@ module ERBLint
 
       def find_html_script_tags(parser)
         parser.nodes_with_type(:tag).each do |tag_node|
+          # Fast path: check tag name from AST node directly before creating Tag object
+          tag_name_node = tag_node.to_a[1]
+          next unless tag_name_node&.loc&.source == "script"
+
           tag = BetterHtml::Tree::Tag.from_node(tag_node)
           nonce_attribute = tag.attributes["nonce"]
 
@@ -52,10 +56,16 @@ module ERBLint
           type_attribute.value_node.to_a[1] != "application/javascript"
       end
 
+      TAG_HELPER_PATTERN = /javascript_tag|javascript_include_tag|javascript_pack_tag/
+
       def find_rails_helper_script_tags(parser)
         parser.ast.descendants(:erb).each do |erb_node|
           indicator_node, _, code_node, _ = *erb_node
           source = code_node.loc.source
+
+          # Fast path: skip expensive parsing if source can't contain any tag helper name
+          next unless source.match?(TAG_HELPER_PATTERN)
+
           ruby_node = extract_ruby_node(source)
           send_node = ruby_node&.descendants(:send)&.first
 


### PR DESCRIPTION
## Summary

Add cheap string checks before expensive `RubyNode.parse` and `Tag.from_node` calls in several linters.

## Problem

Several linters parse every ERB snippet with `BetterHtml::TestHelper::RubyNode.parse` or create `BetterHtml::Tree::Tag` objects for every HTML tag, even when the vast majority could not possibly match. For example, `NoJavascriptTagHelper` parses every ERB snippet looking for `javascript_tag` calls — but in a typical codebase, >99% of snippets don't contain that string.

Similarly, `AllowedScriptType`, `RequireScriptNonce`, and `RequireInputAutocomplete` create full `Tag` objects for every HTML tag even though they only care about `<script>` or `<input>` tags specifically.

## Changes

**4 files changed, +26 −1.** All additive — only adds `next unless` guards before existing logic:

- `NoJavascriptTagHelper`: `next unless source.include?("javascript_tag")`
- `RequireInputAutocomplete`: `next unless source.match?(FORM_HELPER_NAMES_PATTERN)` for ERB helpers; `next unless tag_name == "input"` for HTML tags
- `RequireScriptNonce`: `next unless source.match?(TAG_HELPER_PATTERN)` for ERB helpers; `next unless tag_name == "script"` for HTML tags
- `AllowedScriptType`: `next unless tag_name == "script"` before `Tag.from_node`

The tag name is read directly from the AST node (`tag_node.to_a[1].loc.source`) which avoids creating the full `Tag` object.

## Impact

The improvement scales with the ratio of non-matching to matching tags/snippets. In a typical codebase with thousands of ERB snippets and HTML tags but very few `javascript_tag` calls or `<script>` tags, this avoids the vast majority of parsing work in these linters.

No new tests needed — existing specs cover both "offense found" (guard passes, full logic runs) and "no offense" (guard filters correctly) paths.