### PR TITLE
Update usage text with renamed `erb_lint` executable

### DIFF
--- a/lib/erb_lint/cli.rb
+++ b/lib/erb_lint/cli.rb
@@ -315,7 +315,7 @@ module ERBLint
 
     def option_parser
       OptionParser.new do |opts|
-        opts.banner = "Usage: erblint [options] [file1, file2, ...]"
+        opts.banner = "Usage: erb_lint [options] [file1, file2, ...]"
 
         opts.on("--config FILENAME", "Config file [default: #{DEFAULT_CONFIG_FILENAME}]") do |config|
           if File.exist?(config)


### PR DESCRIPTION
As a new user, I discovered `erblint` as a command that's available because I ran `erb_lint --help` and its usage info displays the previous executable name. This updates the usage info accordingly.